### PR TITLE
Add comprehensive C#/.NET/ASP.NET support with optional VB parser

### DIFF
--- a/LANGUAGE_SUPPORT.md
+++ b/LANGUAGE_SUPPORT.md
@@ -11,18 +11,35 @@
 | Rust       | `.rs`         | tree-sitter-rust       | function, type (struct/enum/trait), impl, constant | `#[attr]`     | `///` and `//!` comments   | Macro-generated symbols are not visible to the parser            |
 | Java       | `.java`       | tree-sitter-java       | method, class, type (interface/enum), constant     | `@Annotation` | `/** */` Javadoc           | Deep inner-class nesting may be flattened                        |
 | PHP        | `.php`        | tree-sitter-php        | function, class, method, type (interface/trait/enum), constant | `#[Attribute]` | `/** */` PHPDoc | PHP 8+ attributes supported; language-file `<?php` tag required  |
+| C# / .NET / ASP.NET | `.cs`, `.csx`, `.razor`, `.cshtml` | tree-sitter-c-sharp | class, method, type (interface/enum/record/delegate), constant, property | `[Attribute]` | `///` and `//` comments | Razor supports `@code`/`@functions` C# blocks; ASP.NET code-behind files (`*.aspx.cs`, etc.) are parsed via `.cs` |
+| VB.NET / ASP.NET | `.vb` | tree-sitter-vb-dotnet (optional extra) | class/module, method, type (interface/enum/delegate), property, constant, event | `<Attribute>` blocks | `'` comments | Optional parser dependency; install with `pip install jcodemunch-mcp[dotnet]` |
 
 ---
 
 ## Parser Engine
 
-All language parsing is powered by **tree-sitter** via the `tree-sitter-language-pack` Python package, providing:
+Most language parsing is powered by **tree-sitter** via the `tree-sitter-language-pack` Python package, providing:
 
 * Incremental, error-tolerant parsing
 * Uniform AST representation across languages
 * Pre-compiled grammars for supported languages
 
-**Dependency:** `tree-sitter-language-pack>=0.7.0` (pinned in `pyproject.toml`)
+**Core dependency:** `tree-sitter-language-pack>=0.7.0` (pinned in `pyproject.toml`)
+
+For VB.NET, jCodeMunch uses an optional external grammar package:
+
+* `tree-sitter-vb-dotnet` (installed via `pip install jcodemunch-mcp[dotnet]`)
+* On systems without a prebuilt wheel, C build tools are required.
+
+---
+
+## Language Filter Aliases
+
+`search_symbols.language` accepts canonical languages and aliases:
+
+* C#: `csharp`, `c#`, `cs`
+* VB: `vb`, `vbnet`, `visualbasic`
+* Framework families (map to both C# and VB): `dotnet`, `.net`, `netframework`, `aspnet`, `aspnetframework`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ IDs remain stable across re-indexing when path, qualified name, and kind are unc
 pip install jcodemunch-mcp
 ```
 
+Optional: install VB.NET parser support (C#/.NET support is included by default):
+
+```bash
+pip install "jcodemunch-mcp[dotnet]"
+```
+
+`[dotnet]` installs `tree-sitter-vb-dotnet` from GitHub. If a prebuilt wheel is unavailable for your platform, install C build tools first.
+
 Verify:
 
 ```bash
@@ -264,17 +272,21 @@ Every tool response includes a `_meta` envelope with timing, token savings, and 
 
 ## Supported Languages
 
-| Language   | Extensions    | Symbol Types                            |
-| ---------- | ------------- | --------------------------------------- |
-| Python     | `.py`         | function, class, method, constant, type |
-| JavaScript | `.js`, `.jsx` | function, class, method, constant       |
-| TypeScript | `.ts`, `.tsx` | function, class, method, constant, type |
-| Go         | `.go`         | function, method, type, constant        |
-| Rust       | `.rs`         | function, type, impl, constant          |
-| Java       | `.java`       | method, class, type, constant           |
-| PHP        | `.php`        | function, class, method, type, constant |
+| Language            | Extensions                      | Symbol Types                                            |
+| ------------------- | ------------------------------- | ------------------------------------------------------- |
+| Python              | `.py`                           | function, class, method, constant, type                 |
+| JavaScript          | `.js`, `.jsx`                   | function, class, method, constant                       |
+| TypeScript          | `.ts`, `.tsx`                   | function, class, method, constant, type                 |
+| Go                  | `.go`                           | function, method, type, constant                        |
+| Rust                | `.rs`                           | function, type, impl, constant                          |
+| Java                | `.java`                         | method, class, type, constant                           |
+| PHP                 | `.php`                          | function, class, method, type, constant                 |
+| C# / .NET / ASP.NET | `.cs`, `.csx`, `.razor`, `.cshtml` | class, method, type, constant, property              |
+| VB.NET              | `.vb`                           | class/module, method, type, constant, property, event   |
 
 See LANGUAGE_SUPPORT.md for full semantics.
+
+`search_symbols.language` accepts canonical languages and aliases such as `c#`, `vbnet`, `dotnet`, and `aspnetframework`.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -139,6 +139,10 @@ Returns a list of symbols plus an error list for any IDs not found.
 
 Weighted scoring search across name, signature, summary, keywords, and docstring. All filters are optional.
 
+`language` accepts canonical values (`python`, `javascript`, `typescript`, `go`, `rust`, `java`, `php`, `csharp`, `vb`) and aliases:
+- Direct aliases: `c#`, `cs`, `vbnet`, `visualbasic`
+- Family aliases: `dotnet`, `.net`, `netframework`, `aspnet`, `aspnetframework` (map to both `csharp` and `vb`)
+
 #### `search_text` — Full-text search across file contents
 
 ```json
@@ -166,7 +170,7 @@ class Symbol:
     name: str                # Symbol name
     qualified_name: str      # Dot-separated with parent context
     kind: str                # function | class | method | constant | type
-    language: str            # python | javascript | typescript | go | rust | java | php
+    language: str            # canonical key: python | javascript | typescript | go | rust | java | php | csharp | vb
     signature: str           # Full signature line(s)
     content_hash: str = ""   # SHA-256 of source bytes (drift detection)
     docstring: str = ""
@@ -212,7 +216,7 @@ Recursive directory walk with the full security pipeline.
 
 ### Filtering Pipeline (Both Paths)
 
-1. **Extension filter** — must be in `LANGUAGE_EXTENSIONS` (.py, .js, .jsx, .ts, .tsx, .go, .rs, .java, .php)
+1. **Extension filter** — must be in `LANGUAGE_EXTENSIONS` (.py, .js, .jsx, .ts, .tsx, .go, .rs, .java, .php, .cs, .csx, .razor, .cshtml, .vb)
 2. **Skip patterns** — `node_modules/`, `vendor/`, `.git/`, `build/`, `dist/`, lock files, minified files, etc.
 3. **`.gitignore`** — respected via the `pathspec` library
 4. **Secret detection** — `.env`, `*.pem`, `*.key`, `*.p12`, credentials files excluded

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -6,6 +6,14 @@
 pip install git+https://github.com/jgravelle/jcodemunch-mcp.git
 ```
 
+Optional VB.NET parser support:
+
+```bash
+pip install "jcodemunch-mcp[dotnet]"
+```
+
+The optional extra installs `tree-sitter-vb-dotnet` from GitHub and may require local C build tools if no wheel is available.
+
 Or from source:
 
 ```bash
@@ -192,6 +200,9 @@ index_repo: { "url": "owner/repo" }
 | `get_repo_outline` | High-level overview           | `repo`                                                             |
 | `invalidate_cache` | Delete cached index           | `repo`                                                             |
 
+`search_symbols.language` supports canonical names and aliases.
+Examples: `csharp`, `c#`, `vb`, `vbnet`, `dotnet`, `aspnetframework`.
+
 ---
 
 ## Symbol IDs
@@ -244,7 +255,11 @@ To disable, set `JCODEMUNCH_SHARE_SAVINGS=0` in your MCP server env:
 Check the URL format (`owner/repo` or full GitHub URL). For private repositories, set `GITHUB_TOKEN`.
 
 **"No source files found"**
-The repository may not contain supported language files (`.py`, `.js`, `.ts`, `.go`, `.rs`, `.java`), or files may be excluded by skip patterns.
+The repository may not contain supported language files (`.py`, `.js`, `.ts`, `.go`, `.rs`, `.java`, `.php`, `.cs`, `.csx`, `.razor`, `.cshtml`, `.vb`), or files may be excluded by skip patterns.
+
+**"VB parser unavailable" warning**
+VB files were discovered but optional VB parsing support is not installed. Install:
+`pip install "jcodemunch-mcp[dotnet]"`.
 
 **Rate limiting**
 Set `GITHUB_TOKEN` to increase GitHub API limits (5,000 requests/hour vs 60 unauthenticated).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 anthropic = ["anthropic>=0.40.0"]
 gemini = ["google-generativeai>=0.8.0"]
 all = ["anthropic>=0.40.0", "google-generativeai>=0.8.0"]
+dotnet = ["tree-sitter-vb-dotnet @ git+https://github.com/CodeAnt-AI/tree-sitter-vb-dotnet.git@cfca210ce8fdcb5245bd9cd5c47ce0a21a8488d5", "tree-sitter>=0.24,<0.26"]
 test = ["pytest", "pytest-asyncio", "pytest-cov"]
 
 [project.scripts]
@@ -29,6 +30,9 @@ packages = ["src/jcodemunch_mcp"]
 
 [tool.hatch.build.targets.sdist]
 exclude = [".claude/"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/jcodemunch_mcp/parser/__init__.py
+++ b/src/jcodemunch_mcp/parser/__init__.py
@@ -1,7 +1,19 @@
 """Parser package for extracting symbols from source code."""
 
 from .symbols import Symbol, slugify, make_symbol_id, compute_content_hash
-from .languages import LanguageSpec, LANGUAGE_REGISTRY, LANGUAGE_EXTENSIONS, PYTHON_SPEC
+from .languages import (
+    LanguageSpec,
+    LANGUAGE_REGISTRY,
+    LANGUAGE_EXTENSIONS,
+    PYTHON_SPEC,
+    CANONICAL_LANGUAGES,
+    LANGUAGE_ALIASES,
+    LANGUAGE_FAMILY_ALIASES,
+    normalize_language_name,
+    resolve_language_alias,
+    resolve_language_filter,
+    supported_language_filters,
+)
 from .extractor import parse_file
 from .hierarchy import SymbolNode, build_symbol_tree, flatten_tree
 
@@ -13,6 +25,13 @@ __all__ = [
     "LanguageSpec",
     "LANGUAGE_REGISTRY",
     "LANGUAGE_EXTENSIONS",
+    "CANONICAL_LANGUAGES",
+    "LANGUAGE_ALIASES",
+    "LANGUAGE_FAMILY_ALIASES",
+    "normalize_language_name",
+    "resolve_language_alias",
+    "resolve_language_filter",
+    "supported_language_filters",
     "PYTHON_SPEC",
     "parse_file",
     "SymbolNode",

--- a/src/jcodemunch_mcp/parser/extractor.py
+++ b/src/jcodemunch_mcp/parser/extractor.py
@@ -1,40 +1,353 @@
 """Generic AST symbol extractor using tree-sitter."""
 
-from typing import Optional
-from tree_sitter_language_pack import get_language, get_parser
+from __future__ import annotations
 
-from .symbols import Symbol, make_symbol_id, compute_content_hash
-from .languages import LanguageSpec, LANGUAGE_REGISTRY
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from tree_sitter_language_pack import get_parser
+
+from .symbols import Symbol, compute_content_hash, make_symbol_id
+from .languages import LanguageSpec, LANGUAGE_REGISTRY, resolve_language_alias
+
+RAZOR_EXTENSIONS = {".razor", ".cshtml"}
+RAZOR_BLOCK_PATTERN = re.compile(r"@(code|functions)\b", re.IGNORECASE)
+PARSER_CACHE: dict[str, object] = {}
+
+
+@dataclass
+class RazorCodeBlock:
+    """A C# code block extracted from a Razor file."""
+
+    body: str
+    body_start_byte: int
+    body_start_line: int
 
 
 def parse_file(content: str, filename: str, language: str) -> list[Symbol]:
     """Parse source code and extract symbols using tree-sitter.
-    
+
     Args:
-        content: Raw source code
-        filename: File path (for ID generation)
-        language: Language name (must be in LANGUAGE_REGISTRY)
-    
+        content: Raw source code.
+        filename: File path (for ID generation).
+        language: Language name (must resolve to a registry key).
+
     Returns:
-        List of Symbol objects
+        List of Symbol objects.
     """
-    if language not in LANGUAGE_REGISTRY:
+    canonical_language = resolve_language_alias(language) or language
+    if canonical_language not in LANGUAGE_REGISTRY:
         return []
-    
-    spec = LANGUAGE_REGISTRY[language]
+
+    spec = LANGUAGE_REGISTRY[canonical_language]
+
+    if (
+        canonical_language == "csharp"
+        and _normalized_extension(filename) in RAZOR_EXTENSIONS
+    ):
+        return _parse_razor_file(content, filename, canonical_language, spec)
+
+    parser = _get_parser_for_language(spec.ts_language)
     source_bytes = content.encode("utf-8")
-    
-    # Get parser for this language
-    parser = get_parser(spec.ts_language)
+    symbols = _extract_symbols_from_source(
+        source_bytes=source_bytes,
+        filename=filename,
+        language=canonical_language,
+        spec=spec,
+        parser=parser,
+    )
+    return _disambiguate_overloads(symbols)
+
+
+def _normalized_extension(filename: str) -> str:
+    filename = filename.lower()
+    dot = filename.rfind(".")
+    if dot < 0:
+        return ""
+    return filename[dot:]
+
+
+def _get_parser_for_language(ts_language: str):
+    """Resolve parser source for a given tree-sitter language id."""
+    cached = PARSER_CACHE.get(ts_language)
+    if cached is not None:
+        return cached
+
+    if ts_language == "vb":
+        parser = _build_vb_parser()
+    else:
+        parser = get_parser(ts_language)
+
+    PARSER_CACHE[ts_language] = parser
+    return parser
+
+
+def _build_vb_parser():
+    """Build parser for Visual Basic .NET via optional external grammar."""
+    try:
+        import tree_sitter
+        import tree_sitter_tree_sitter_vb_dotnet
+    except Exception as exc:
+        raise RuntimeError(
+            "VB parser unavailable. Install optional .NET support with "
+            "`pip install jcodemunch-mcp[dotnet]`. "
+            "If no prebuilt wheel is available, install C build tools first."
+        ) from exc
+
+    capsule = tree_sitter_tree_sitter_vb_dotnet.language()
+    try:
+        language_obj = tree_sitter.Language(capsule)
+    except Exception:
+        language_obj = capsule
+
+    try:
+        return tree_sitter.Parser(language_obj)
+    except TypeError:
+        parser = tree_sitter.Parser()
+        if hasattr(parser, "set_language"):
+            parser.set_language(language_obj)
+        else:
+            parser.language = language_obj
+        return parser
+
+
+def _extract_symbols_from_source(
+    source_bytes: bytes,
+    filename: str,
+    language: str,
+    spec: LanguageSpec,
+    parser,
+) -> list[Symbol]:
     tree = parser.parse(source_bytes)
-    
-    symbols = []
-    _walk_tree(tree.root_node, spec, source_bytes, filename, language, symbols, None)
-
-    # Disambiguate overloaded symbols (same ID)
-    symbols = _disambiguate_overloads(symbols)
-
+    symbols: list[Symbol] = []
+    _walk_tree(
+        tree.root_node,
+        spec,
+        source_bytes,
+        filename,
+        language,
+        symbols,
+        None,
+    )
     return symbols
+
+
+def _parse_razor_file(
+    content: str,
+    filename: str,
+    language: str,
+    spec: LanguageSpec,
+) -> list[Symbol]:
+    """Parse `.razor`/`.cshtml` files by extracting @code/@functions blocks."""
+    blocks = _extract_razor_code_blocks(content)
+    if not blocks:
+        return []
+
+    parser = _get_parser_for_language("csharp")
+    source_bytes = content.encode("utf-8")
+    all_symbols: list[Symbol] = []
+
+    for idx, block in enumerate(blocks, start=1):
+        wrapper_name = f"__RazorComponent_{idx}"
+        prefix = f"class {wrapper_name} {{\n"
+        suffix = "\n}"
+        wrapped = f"{prefix}{block.body}{suffix}"
+        wrapped_bytes = wrapped.encode("utf-8")
+
+        symbols = _extract_symbols_from_source(
+            source_bytes=wrapped_bytes,
+            filename=filename,
+            language=language,
+            spec=spec,
+            parser=parser,
+        )
+
+        prefix_bytes = len(prefix.encode("utf-8"))
+        body_bytes = len(block.body.encode("utf-8"))
+        wrapper_prefix = f"{wrapper_name}."
+        wrapper_id_prefix = f"{filename}::{wrapper_name}#"
+
+        for symbol in symbols:
+            # Ignore synthetic wrapper class itself.
+            if symbol.name == wrapper_name and symbol.kind == "class":
+                continue
+
+            # Ignore symbols created outside the wrapped body.
+            if symbol.byte_offset < prefix_bytes:
+                continue
+            if symbol.byte_offset >= prefix_bytes + body_bytes:
+                continue
+
+            if symbol.qualified_name.startswith(wrapper_prefix):
+                symbol.qualified_name = symbol.qualified_name[len(wrapper_prefix):]
+            if symbol.parent and symbol.parent.startswith(wrapper_id_prefix):
+                symbol.parent = None
+
+            symbol.id = make_symbol_id(filename, symbol.qualified_name, symbol.kind)
+
+            relative_byte = symbol.byte_offset - prefix_bytes
+            symbol.byte_offset = block.body_start_byte + relative_byte
+
+            # Wrapped file body starts on line 2.
+            symbol.line = block.body_start_line + (symbol.line - 2)
+            symbol.end_line = block.body_start_line + (symbol.end_line - 2)
+            if symbol.line < 1:
+                symbol.line = 1
+            if symbol.end_line < symbol.line:
+                symbol.end_line = symbol.line
+
+            real_bytes = source_bytes[
+                symbol.byte_offset : symbol.byte_offset + symbol.byte_length
+            ]
+            if real_bytes:
+                symbol.content_hash = compute_content_hash(real_bytes)
+
+            all_symbols.append(symbol)
+
+    return _disambiguate_overloads(all_symbols)
+
+
+def _extract_razor_code_blocks(content: str) -> list[RazorCodeBlock]:
+    """Extract Razor C# blocks and map them to byte/line offsets."""
+    blocks: list[RazorCodeBlock] = []
+    offsets = _build_utf8_offset_table(content)
+    cursor = 0
+
+    while True:
+        match = RAZOR_BLOCK_PATTERN.search(content, cursor)
+        if not match:
+            break
+
+        open_brace_idx = _find_next_open_brace(content, match.end())
+        if open_brace_idx is None:
+            cursor = match.end()
+            continue
+
+        close_brace_idx = _find_matching_brace(content, open_brace_idx)
+        if close_brace_idx is None:
+            cursor = open_brace_idx + 1
+            continue
+
+        body_start_char = open_brace_idx + 1
+        body_end_char = close_brace_idx
+        body_text = content[body_start_char:body_end_char]
+        body_start_byte = offsets[body_start_char]
+        body_start_line = _line_from_char_offset(content, body_start_char)
+
+        blocks.append(
+            RazorCodeBlock(
+                body=body_text,
+                body_start_byte=body_start_byte,
+                body_start_line=body_start_line,
+            )
+        )
+        cursor = close_brace_idx + 1
+
+    return blocks
+
+
+def _build_utf8_offset_table(content: str) -> list[int]:
+    """Build char-index -> byte-offset map for UTF-8 strings."""
+    offsets = [0]
+    total = 0
+    for ch in content:
+        total += len(ch.encode("utf-8"))
+        offsets.append(total)
+    return offsets
+
+
+def _line_from_char_offset(content: str, offset: int) -> int:
+    return content.count("\n", 0, offset) + 1
+
+
+def _find_next_open_brace(content: str, start: int) -> Optional[int]:
+    idx = start
+    while idx < len(content) and content[idx].isspace():
+        idx += 1
+    if idx < len(content) and content[idx] == "{":
+        return idx
+    return None
+
+
+def _find_matching_brace(content: str, open_brace_idx: int) -> Optional[int]:
+    """Find matching closing brace while ignoring comments/strings."""
+    depth = 0
+    idx = open_brace_idx
+
+    in_line_comment = False
+    in_block_comment = False
+    in_single_quote = False
+    in_double_quote = False
+    in_verbatim_string = False
+
+    while idx < len(content):
+        ch = content[idx]
+        nxt = content[idx + 1] if idx + 1 < len(content) else ""
+        nxt2 = content[idx + 2] if idx + 2 < len(content) else ""
+
+        if in_line_comment:
+            if ch == "\n":
+                in_line_comment = False
+        elif in_block_comment:
+            if ch == "*" and nxt == "/":
+                in_block_comment = False
+                idx += 1
+        elif in_single_quote:
+            if ch == "\\" and nxt:
+                idx += 1
+            elif ch == "'":
+                in_single_quote = False
+        elif in_double_quote:
+            if in_verbatim_string:
+                if ch == '"' and nxt == '"':
+                    idx += 1
+                elif ch == '"':
+                    in_double_quote = False
+                    in_verbatim_string = False
+            else:
+                if ch == "\\" and nxt:
+                    idx += 1
+                elif ch == '"':
+                    in_double_quote = False
+        else:
+            if ch == "/" and nxt == "/":
+                in_line_comment = True
+                idx += 1
+            elif ch == "/" and nxt == "*":
+                in_block_comment = True
+                idx += 1
+            elif ch == "$" and nxt == "@" and nxt2 == '"':
+                in_double_quote = True
+                in_verbatim_string = True
+                idx += 2
+            elif ch == "@" and nxt == "$" and nxt2 == '"':
+                in_double_quote = True
+                in_verbatim_string = True
+                idx += 2
+            elif ch == "@" and nxt == '"':
+                in_double_quote = True
+                in_verbatim_string = True
+                idx += 1
+            elif ch == "$" and nxt == '"':
+                in_double_quote = True
+                in_verbatim_string = False
+                idx += 1
+            elif ch == '"':
+                in_double_quote = True
+                in_verbatim_string = False
+            elif ch == "'":
+                in_single_quote = True
+            elif ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    return idx
+
+        idx += 1
+
+    return None
 
 
 def _walk_tree(
@@ -43,26 +356,35 @@ def _walk_tree(
     source_bytes: bytes,
     filename: str,
     language: str,
-    symbols: list,
-    parent_symbol: Optional[Symbol] = None
+    symbols: list[Symbol],
+    parent_symbol: Optional[Symbol] = None,
 ):
     """Recursively walk the AST and extract symbols."""
-    # Check if this node is a symbol
     if node.type in spec.symbol_node_types:
         symbol = _extract_symbol(
-            node, spec, source_bytes, filename, language, parent_symbol
+            node,
+            spec,
+            source_bytes,
+            filename,
+            language,
+            parent_symbol,
         )
         if symbol:
             symbols.append(symbol)
             parent_symbol = symbol
-    
-    # Check for constant patterns (top-level assignments with UPPER_CASE names)
-    if node.type in spec.constant_patterns and parent_symbol is None:
-        const_symbol = _extract_constant(node, spec, source_bytes, filename, language)
+
+    if node.type in spec.constant_patterns:
+        const_symbol = _extract_constant(
+            node=node,
+            spec=spec,
+            source_bytes=source_bytes,
+            filename=filename,
+            language=language,
+            parent_symbol=parent_symbol,
+        )
         if const_symbol:
             symbols.append(const_symbol)
-    
-    # Recurse into children
+
     for child in node.children:
         _walk_tree(child, spec, source_bytes, filename, language, symbols, parent_symbol)
 
@@ -73,42 +395,32 @@ def _extract_symbol(
     source_bytes: bytes,
     filename: str,
     language: str,
-    parent_symbol: Optional[Symbol] = None
+    parent_symbol: Optional[Symbol] = None,
 ) -> Optional[Symbol]:
     """Extract a Symbol from an AST node."""
     kind = spec.symbol_node_types[node.type]
-    
-    # Skip nodes with errors
+
     if node.has_error:
         return None
-    
-    # Extract name
+
     name = _extract_name(node, spec, source_bytes)
     if not name:
         return None
-    
-    # Build qualified name
+
     if parent_symbol:
         qualified_name = f"{parent_symbol.name}.{name}"
         kind = "method" if kind == "function" else kind
     else:
         qualified_name = name
-    
-    # Build signature
-    signature = _build_signature(node, spec, source_bytes)
-    
-    # Extract docstring
+
+    signature = _build_signature(node, source_bytes)
     docstring = _extract_docstring(node, spec, source_bytes)
-    
-    # Extract decorators
     decorators = _extract_decorators(node, spec, source_bytes)
-    
-    # Compute content hash
-    symbol_bytes = source_bytes[node.start_byte:node.end_byte]
+
+    symbol_bytes = source_bytes[node.start_byte : node.end_byte]
     c_hash = compute_content_hash(symbol_bytes)
 
-    # Create symbol
-    symbol = Symbol(
+    return Symbol(
         id=make_symbol_id(filename, qualified_name, kind),
         file=filename,
         name=name,
@@ -125,55 +437,48 @@ def _extract_symbol(
         byte_length=node.end_byte - node.start_byte,
         content_hash=c_hash,
     )
-    
-    return symbol
 
 
 def _extract_name(node, spec: LanguageSpec, source_bytes: bytes) -> Optional[str]:
     """Extract the name from an AST node."""
-    # Handle special cases first
     if node.type == "arrow_function":
-        # Arrow functions get name from parent variable_declarator
         return None
-    
-    # Handle type_declaration in Go - name is in type_spec child
+
     if node.type == "type_declaration":
         for child in node.children:
             if child.type == "type_spec":
                 name_node = child.child_by_field_name("name")
                 if name_node:
-                    return source_bytes[name_node.start_byte:name_node.end_byte].decode("utf-8")
+                    return source_bytes[name_node.start_byte : name_node.end_byte].decode(
+                        "utf-8"
+                    )
         return None
-    
+
     if node.type not in spec.name_fields:
         return None
-    
+
     field_name = spec.name_fields[node.type]
     name_node = node.child_by_field_name(field_name)
-    
     if name_node:
-        return source_bytes[name_node.start_byte:name_node.end_byte].decode("utf-8")
-    
+        return source_bytes[name_node.start_byte : name_node.end_byte].decode("utf-8")
     return None
 
 
-def _build_signature(node, spec: LanguageSpec, source_bytes: bytes) -> str:
+def _build_signature(node, source_bytes: bytes) -> str:
     """Build a clean signature from AST node."""
-    # Find the body child to determine where signature ends
     body = node.child_by_field_name("body")
-    
     if body:
-        # Signature is from start of node to start of body
         end_byte = body.start_byte
     else:
         end_byte = node.end_byte
-    
+
     sig_bytes = source_bytes[node.start_byte:end_byte]
-    sig_text = sig_bytes.decode("utf-8").strip()
-    
-    # Clean up: remove trailing '{', ':', etc.
-    sig_text = sig_text.rstrip("{: \n\t")
-    
+    sig_text = sig_bytes.decode("utf-8").strip().rstrip("{: \n\t")
+
+    # For block constructs without a body field, keep only declaration header line.
+    if "\n" in sig_text and body is None:
+        sig_text = sig_text.splitlines()[0].strip()
+
     return sig_text
 
 
@@ -181,7 +486,7 @@ def _extract_docstring(node, spec: LanguageSpec, source_bytes: bytes) -> str:
     """Extract docstring using language-specific strategy."""
     if spec.docstring_strategy == "next_sibling_string":
         return _extract_python_docstring(node, source_bytes)
-    elif spec.docstring_strategy == "preceding_comment":
+    if spec.docstring_strategy == "preceding_comment":
         return _extract_preceding_comments(node, source_bytes)
     return ""
 
@@ -191,26 +496,22 @@ def _extract_python_docstring(node, source_bytes: bytes) -> str:
     body = node.child_by_field_name("body")
     if not body or body.child_count == 0:
         return ""
-    
-    # Find first expression_statement in body (function docstrings)
+
     for child in body.children:
         if child.type == "expression_statement":
-            # Check if it's a string
             expr = child.child_by_field_name("expression")
             if expr and expr.type == "string":
-                doc = source_bytes[expr.start_byte:expr.end_byte].decode("utf-8")
+                doc = source_bytes[expr.start_byte : expr.end_byte].decode("utf-8")
                 return _strip_quotes(doc)
-            # Handle tree-sitter-python 0.21+ string format
             if child.child_count > 0:
                 first = child.children[0]
                 if first.type in ("string", "concatenated_string"):
-                    doc = source_bytes[first.start_byte:first.end_byte].decode("utf-8")
+                    doc = source_bytes[first.start_byte : first.end_byte].decode("utf-8")
                     return _strip_quotes(doc)
-        # Class docstrings are directly string nodes in the block
         elif child.type == "string":
-            doc = source_bytes[child.start_byte:child.end_byte].decode("utf-8")
+            doc = source_bytes[child.start_byte : child.end_byte].decode("utf-8")
             return _strip_quotes(doc)
-    
+
     return ""
 
 
@@ -231,17 +532,16 @@ def _strip_quotes(text: str) -> str:
 def _extract_preceding_comments(node, source_bytes: bytes) -> str:
     """Extract comments that immediately precede a node."""
     comments = []
-    
-    # Walk backwards through siblings
+
     prev = node.prev_named_sibling
     while prev and prev.type in ("comment", "line_comment", "block_comment"):
-        comment_text = source_bytes[prev.start_byte:prev.end_byte].decode("utf-8")
+        comment_text = source_bytes[prev.start_byte : prev.end_byte].decode("utf-8")
         comments.insert(0, comment_text)
         prev = prev.prev_named_sibling
-    
+
     if not comments:
         return ""
-    
+
     docstring = "\n".join(comments)
     return _clean_comment_markers(docstring)
 
@@ -250,10 +550,9 @@ def _clean_comment_markers(text: str) -> str:
     """Clean comment markers from docstring."""
     lines = text.split("\n")
     cleaned = []
-    
+
     for line in lines:
         line = line.strip()
-        # Remove leading comment markers
         if line.startswith("/**"):
             line = line[3:]
         elif line.startswith("/*"):
@@ -264,15 +563,16 @@ def _clean_comment_markers(text: str) -> str:
             line = line[2:]
         elif line.startswith("//!"):
             line = line[3:]
+        elif line.startswith("'"):
+            line = line[1:]
         elif line.startswith("*"):
             line = line[1:]
-        
-        # Remove trailing */
+
         if line.endswith("*/"):
             line = line[:-2]
-        
+
         cleaned.append(line.strip())
-    
+
     return "\n".join(cleaned).strip()
 
 
@@ -280,69 +580,144 @@ def _extract_decorators(node, spec: LanguageSpec, source_bytes: bytes) -> list[s
     """Extract decorators/attributes from a node."""
     if not spec.decorator_node_type:
         return []
-    
+
     decorators = []
-    
-    # Walk backwards through siblings to find decorators
+
+    for child in node.children:
+        if child.type == spec.decorator_node_type:
+            text = source_bytes[child.start_byte : child.end_byte].decode("utf-8").strip()
+            if text:
+                decorators.append(text)
+
     prev = node.prev_named_sibling
     while prev and prev.type == spec.decorator_node_type:
-        decorator_text = source_bytes[prev.start_byte:prev.end_byte].decode("utf-8")
-        decorators.insert(0, decorator_text.strip())
+        text = source_bytes[prev.start_byte : prev.end_byte].decode("utf-8").strip()
+        if text:
+            decorators.insert(0, text)
         prev = prev.prev_named_sibling
-    
-    return decorators
+
+    # Deduplicate while preserving order.
+    seen: set[str] = set()
+    unique: list[str] = []
+    for item in decorators:
+        if item not in seen:
+            seen.add(item)
+            unique.append(item)
+    return unique
 
 
 def _extract_constant(
-    node, spec: LanguageSpec, source_bytes: bytes, filename: str, language: str
+    node,
+    spec: LanguageSpec,
+    source_bytes: bytes,
+    filename: str,
+    language: str,
+    parent_symbol: Optional[Symbol] = None,
 ) -> Optional[Symbol]:
-    """Extract a constant (UPPER_CASE top-level assignment)."""
-    # Only extract constants at module level for Python
+    """Extract constants for supported declaration styles."""
+    name: Optional[str] = None
+
     if node.type == "assignment":
+        if language != "python" or parent_symbol is not None:
+            return None
         left = node.child_by_field_name("left")
         if left and left.type == "identifier":
-            name = source_bytes[left.start_byte:left.end_byte].decode("utf-8")
-            # Check if UPPER_CASE (constant convention)
-            if name.isupper() or (len(name) > 1 and name[0].isupper() and "_" in name):
-                # Get the full assignment text as signature
-                sig = source_bytes[node.start_byte:node.end_byte].decode("utf-8").strip()
-                const_bytes = source_bytes[node.start_byte:node.end_byte]
-                c_hash = compute_content_hash(const_bytes)
+            candidate = source_bytes[left.start_byte : left.end_byte].decode("utf-8")
+            if candidate.isupper() or (
+                len(candidate) > 1 and candidate[0].isupper() and "_" in candidate
+            ):
+                name = candidate
 
-                return Symbol(
-                    id=make_symbol_id(filename, name, "constant"),
-                    file=filename,
-                    name=name,
-                    qualified_name=name,
-                    kind="constant",
-                    language=language,
-                    signature=sig[:100],  # Truncate long assignments
-                    line=node.start_point[0] + 1,
-                    end_line=node.end_point[0] + 1,
-                    byte_offset=node.start_byte,
-                    byte_length=node.end_byte - node.start_byte,
-                    content_hash=c_hash,
+    elif node.type == "const_declaration":
+        if node.type not in spec.name_fields:
+            return None
+        field_name = spec.name_fields[node.type]
+        name_node = node.child_by_field_name(field_name)
+        if name_node:
+            name = source_bytes[name_node.start_byte : name_node.end_byte].decode("utf-8")
+
+    elif node.type == "field_declaration":
+        if language == "csharp":
+            if not _node_has_modifier(node, "const", source_bytes):
+                return None
+        elif language == "java":
+            if not (
+                _node_has_modifier(node, "static", source_bytes)
+                and _node_has_modifier(node, "final", source_bytes)
+            ):
+                return None
+        else:
+            return None
+
+        name = _extract_first_variable_name(node, source_bytes)
+
+    if not name:
+        return None
+
+    if parent_symbol:
+        qualified_name = f"{parent_symbol.name}.{name}"
+        parent_id = parent_symbol.id
+    else:
+        qualified_name = name
+        parent_id = None
+
+    signature = source_bytes[node.start_byte : node.end_byte].decode("utf-8").strip()
+    const_bytes = source_bytes[node.start_byte : node.end_byte]
+    content_hash = compute_content_hash(const_bytes)
+
+    return Symbol(
+        id=make_symbol_id(filename, qualified_name, "constant"),
+        file=filename,
+        name=name,
+        qualified_name=qualified_name,
+        kind="constant",
+        language=language,
+        signature=signature[:160],
+        parent=parent_id,
+        line=node.start_point[0] + 1,
+        end_line=node.end_point[0] + 1,
+        byte_offset=node.start_byte,
+        byte_length=node.end_byte - node.start_byte,
+        content_hash=content_hash,
+    )
+
+
+def _node_has_modifier(node, modifier: str, source_bytes: bytes) -> bool:
+    lower_modifier = modifier.lower()
+    for child in node.children:
+        if child.type != "modifier":
+            continue
+        text = source_bytes[child.start_byte : child.end_byte].decode("utf-8").strip().lower()
+        if text == lower_modifier:
+            return True
+    return False
+
+
+def _extract_first_variable_name(node, source_bytes: bytes) -> Optional[str]:
+    for child in node.children:
+        if child.type != "variable_declaration":
+            continue
+        for grand in child.children:
+            if grand.type != "variable_declarator":
+                continue
+            name_node = grand.child_by_field_name("name")
+            if name_node:
+                return source_bytes[name_node.start_byte : name_node.end_byte].decode(
+                    "utf-8"
                 )
-
     return None
 
 
 def _disambiguate_overloads(symbols: list[Symbol]) -> list[Symbol]:
-    """Append ordinal suffix to symbols with duplicate IDs.
-
-    E.g., if two symbols have ID "file.py::foo#function", they become
-    "file.py::foo#function~1" and "file.py::foo#function~2".
-    """
+    """Append ordinal suffix to symbols with duplicate IDs."""
     from collections import Counter
 
     id_counts = Counter(s.id for s in symbols)
-    # Only process IDs that appear more than once
     duplicated = {sid for sid, count in id_counts.items() if count > 1}
 
     if not duplicated:
         return symbols
 
-    # Track ordinals per duplicate ID
     ordinals: dict[str, int] = {}
     result = []
     for sym in symbols:

--- a/src/jcodemunch_mcp/parser/languages.py
+++ b/src/jcodemunch_mcp/parser/languages.py
@@ -54,6 +54,11 @@ LANGUAGE_EXTENSIONS = {
     ".rs": "rust",
     ".java": "java",
     ".php": "php",
+    ".cs": "csharp",
+    ".csx": "csharp",
+    ".razor": "csharp",
+    ".cshtml": "csharp",
+    ".vb": "vb",
 }
 
 
@@ -277,6 +282,115 @@ PHP_SPEC = LanguageSpec(
 )
 
 
+# C# specification
+CSHARP_SPEC = LanguageSpec(
+    ts_language="csharp",
+    symbol_node_types={
+        "class_declaration": "class",
+        "struct_declaration": "type",
+        "interface_declaration": "type",
+        "enum_declaration": "type",
+        "record_declaration": "type",
+        "delegate_declaration": "type",
+        "method_declaration": "method",
+        "constructor_declaration": "method",
+        "property_declaration": "method",
+    },
+    name_fields={
+        "class_declaration": "name",
+        "struct_declaration": "name",
+        "interface_declaration": "name",
+        "enum_declaration": "name",
+        "record_declaration": "name",
+        "delegate_declaration": "name",
+        "method_declaration": "name",
+        "constructor_declaration": "name",
+        "property_declaration": "name",
+    },
+    param_fields={
+        "method_declaration": "parameters",
+        "constructor_declaration": "parameters",
+    },
+    return_type_fields={
+        "method_declaration": "returns",
+        "delegate_declaration": "type",
+        "property_declaration": "type",
+    },
+    docstring_strategy="preceding_comment",
+    decorator_node_type="attribute_list",
+    container_node_types=[
+        "class_declaration",
+        "struct_declaration",
+        "interface_declaration",
+        "record_declaration",
+    ],
+    constant_patterns=["field_declaration"],
+    type_patterns=[
+        "struct_declaration",
+        "interface_declaration",
+        "enum_declaration",
+        "record_declaration",
+        "delegate_declaration",
+    ],
+)
+
+
+# Visual Basic .NET specification
+VB_SPEC = LanguageSpec(
+    ts_language="vb",
+    symbol_node_types={
+        "class_block": "class",
+        "module_block": "class",
+        "structure_block": "type",
+        "interface_block": "type",
+        "enum_block": "type",
+        "method_declaration": "method",
+        "constructor_declaration": "method",
+        "property_declaration": "method",
+        "delegate_declaration": "type",
+        "event_declaration": "method",
+    },
+    name_fields={
+        "class_block": "name",
+        "module_block": "name",
+        "structure_block": "name",
+        "interface_block": "name",
+        "enum_block": "name",
+        "method_declaration": "name",
+        "constructor_declaration": "name",
+        "property_declaration": "name",
+        "delegate_declaration": "name",
+        "event_declaration": "name",
+        "const_declaration": "name",
+    },
+    param_fields={
+        "method_declaration": "parameters",
+        "constructor_declaration": "parameters",
+        "property_declaration": "parameters",
+        "delegate_declaration": "parameters",
+    },
+    return_type_fields={
+        "method_declaration": "return_type",
+        "delegate_declaration": "return_type",
+    },
+    docstring_strategy="preceding_comment",
+    decorator_node_type="attribute_block",
+    container_node_types=[
+        "class_block",
+        "module_block",
+        "structure_block",
+        "interface_block",
+    ],
+    constant_patterns=["const_declaration"],
+    type_patterns=[
+        "structure_block",
+        "interface_block",
+        "enum_block",
+        "delegate_declaration",
+    ],
+)
+
+
 # Language registry
 LANGUAGE_REGISTRY = {
     "python": PYTHON_SPEC,
@@ -286,4 +400,75 @@ LANGUAGE_REGISTRY = {
     "rust": RUST_SPEC,
     "java": JAVA_SPEC,
     "php": PHP_SPEC,
+    "csharp": CSHARP_SPEC,
+    "vb": VB_SPEC,
 }
+
+
+CANONICAL_LANGUAGES = tuple(LANGUAGE_REGISTRY.keys())
+
+
+# Aliases that map to one canonical language
+LANGUAGE_ALIASES = {
+    "c#": "csharp",
+    "cs": "csharp",
+    "csharp": "csharp",
+    "vb": "vb",
+    "vbnet": "vb",
+    "visualbasicnet": "vb",
+    "visualbasic": "vb",
+}
+
+
+# Aliases that map to a language family
+LANGUAGE_FAMILY_ALIASES = {
+    "dotnet": {"csharp", "vb"},
+    ".net": {"csharp", "vb"},
+    "netframework": {"csharp", "vb"},
+    ".netframework": {"csharp", "vb"},
+    "aspnet": {"csharp", "vb"},
+    "asp.net": {"csharp", "vb"},
+    "aspnetframework": {"csharp", "vb"},
+    "asp.netframework": {"csharp", "vb"},
+}
+
+
+def normalize_language_name(language: str) -> str:
+    """Normalize a language or alias for lookup."""
+    return language.strip().lower().replace(" ", "").replace("_", "").replace("-", "")
+
+
+def resolve_language_alias(language: str) -> Optional[str]:
+    """Resolve a direct alias to one canonical language."""
+    normalized = normalize_language_name(language)
+
+    if normalized in LANGUAGE_REGISTRY:
+        return normalized
+    if normalized in LANGUAGE_ALIASES:
+        return LANGUAGE_ALIASES[normalized]
+    return None
+
+
+def resolve_language_filter(language: Optional[str]) -> Optional[set[str]]:
+    """Resolve a language filter into canonical languages."""
+    if language is None:
+        return None
+
+    normalized = normalize_language_name(language)
+
+    direct = resolve_language_alias(normalized)
+    if direct:
+        return {direct}
+
+    if normalized in LANGUAGE_FAMILY_ALIASES:
+        return set(LANGUAGE_FAMILY_ALIASES[normalized])
+
+    return None
+
+
+def supported_language_filters() -> list[str]:
+    """Return all accepted language filter values."""
+    values = set(CANONICAL_LANGUAGES)
+    values.update(LANGUAGE_ALIASES.keys())
+    values.update(LANGUAGE_FAMILY_ALIASES.keys())
+    return sorted(values)

--- a/src/jcodemunch_mcp/parser/symbols.py
+++ b/src/jcodemunch_mcp/parser/symbols.py
@@ -13,7 +13,7 @@ class Symbol:
     name: str                       # Symbol name (e.g., "login")
     qualified_name: str             # Fully qualified (e.g., "MyClass.login")
     kind: str                       # "function" | "class" | "method" | "constant" | "type"
-    language: str                   # "python" | "javascript" | "typescript" | "go" | "rust" | "java"
+    language: str                   # Canonical language key (python, javascript, typescript, go, rust, java, php, csharp, vb)
     signature: str                  # Full signature line(s)
     docstring: str = ""             # Extracted docstring (language-specific)
     summary: str = ""               # One-line summary

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -9,6 +9,7 @@ from typing import Any, Optional
 from mcp.server import Server
 from mcp.types import Tool, TextContent
 
+from .parser import supported_language_filters
 from .tools.index_repo import index_repo
 from .tools.index_folder import index_folder
 from .tools.list_repos import list_repos
@@ -28,6 +29,7 @@ server = Server("jcodemunch-mcp")
 @server.list_tools()
 async def list_tools() -> list[Tool]:
     """List all available tools."""
+    language_filter_enum = supported_language_filters()
     return [
         Tool(
             name="index_repo",
@@ -210,7 +212,7 @@ async def list_tools() -> list[Tool]:
                     "language": {
                         "type": "string",
                         "description": "Optional filter by language",
-                        "enum": ["python", "javascript", "typescript", "go", "rust", "java"]
+                        "enum": language_filter_enum,
                     },
                     "max_results": {
                         "type": "integer",

--- a/src/jcodemunch_mcp/storage/index_store.py
+++ b/src/jcodemunch_mcp/storage/index_store.py
@@ -249,7 +249,7 @@ class IndexStore:
             if not file_dest:
                 raise ValueError(f"Unsafe file path in raw_files: {file_path}")
             file_dest.parent.mkdir(parents=True, exist_ok=True)
-            with open(file_dest, "w", encoding="utf-8") as f:
+            with open(file_dest, "w", encoding="utf-8", newline="") as f:
                 f.write(content)
 
         return index
@@ -441,7 +441,7 @@ class IndexStore:
             if not dest:
                 raise ValueError(f"Unsafe file path in raw_files: {fp}")
             dest.parent.mkdir(parents=True, exist_ok=True)
-            with open(dest, "w", encoding="utf-8") as f:
+            with open(dest, "w", encoding="utf-8", newline="") as f:
                 f.write(content)
 
         return updated

--- a/src/jcodemunch_mcp/tools/get_file_tree.py
+++ b/src/jcodemunch_mcp/tools/get_file_tree.py
@@ -103,6 +103,7 @@ def _build_tree(files: list[str], index, path_prefix: str, include_summaries: bo
                 # Get language
                 lang = ""
                 _, ext = os.path.splitext(file_path)
+                ext = ext.lower()
                 from ..parser import LANGUAGE_EXTENSIONS
                 lang = LANGUAGE_EXTENSIONS.get(ext, "")
                 

--- a/src/jcodemunch_mcp/tools/index_folder.py
+++ b/src/jcodemunch_mcp/tools/index_folder.py
@@ -24,6 +24,11 @@ SKIP_PATTERNS = [
     "node_modules/", "vendor/", "venv/", ".venv/", "__pycache__/",
     "dist/", "build/", ".git/", ".tox/", ".mypy_cache/",
     "target/",
+    "bin/",
+    "obj/",
+    ".vs/",
+    "testresults/",
+    "packages/",
     ".gradle/",
     "test_data/", "testdata/", "fixtures/", "snapshots/",
     "migrations/",
@@ -36,7 +41,7 @@ SKIP_PATTERNS = [
 def should_skip_file(path: str) -> bool:
     """Check if file should be skipped based on path patterns."""
     # Normalize path separators for matching
-    normalized = path.replace("\\", "/")
+    normalized = path.replace("\\", "/").lower()
     for pattern in SKIP_PATTERNS:
         if pattern in normalized:
             return True
@@ -130,7 +135,7 @@ def discover_local_files(
             continue
 
         # Extension filter
-        ext = file_path.suffix
+        ext = file_path.suffix.lower()
         if ext not in LANGUAGE_EXTENSIONS:
             continue
 
@@ -235,7 +240,7 @@ def index_folder(
                 rel_path = file_path.relative_to(folder_path).as_posix()
             except ValueError:
                 continue
-            ext = file_path.suffix
+            ext = file_path.suffix.lower()
             if ext not in LANGUAGE_EXTENSIONS:
                 continue
             current_files[rel_path] = content
@@ -261,7 +266,7 @@ def index_folder(
 
             for rel_path in files_to_parse:
                 content = current_files[rel_path]
-                ext = os.path.splitext(rel_path)[1]
+                ext = os.path.splitext(rel_path)[1].lower()
                 language = LANGUAGE_EXTENSIONS.get(ext)
                 if not language:
                     continue
@@ -277,7 +282,7 @@ def index_folder(
 
             # Compute updated language counts from all current files
             for rel_path in current_files:
-                ext = os.path.splitext(rel_path)[1]
+                ext = os.path.splitext(rel_path)[1].lower()
                 lang = LANGUAGE_EXTENSIONS.get(ext)
                 if lang:
                     languages[lang] = languages.get(lang, 0) + 1
@@ -312,7 +317,7 @@ def index_folder(
         parsed_files = []
 
         for rel_path, content in current_files.items():
-            ext = os.path.splitext(rel_path)[1]
+            ext = os.path.splitext(rel_path)[1].lower()
             language = LANGUAGE_EXTENSIONS.get(ext)
             if not language:
                 continue

--- a/src/jcodemunch_mcp/tools/index_repo.py
+++ b/src/jcodemunch_mcp/tools/index_repo.py
@@ -18,6 +18,11 @@ SKIP_PATTERNS = [
     "node_modules/", "vendor/", "venv/", ".venv/", "__pycache__/",
     "dist/", "build/", ".git/", ".tox/", ".mypy_cache/",
     "target/",
+    "bin/",
+    "obj/",
+    ".vs/",
+    "testresults/",
+    "packages/",
     ".gradle/",
     "test_data/", "testdata/", "fixtures/", "snapshots/",
     "migrations/",
@@ -77,8 +82,9 @@ async def fetch_repo_tree(owner: str, repo: str, token: Optional[str] = None) ->
 
 def should_skip_file(path: str) -> bool:
     """Check if file should be skipped based on path patterns."""
+    normalized = path.lower()
     for pattern in SKIP_PATTERNS:
-        if pattern in path:
+        if pattern in normalized:
             return True
     return False
 
@@ -124,6 +130,7 @@ def discover_source_files(
         
         # Extension filter
         _, ext = os.path.splitext(path)
+        ext = ext.lower()
         if ext not in LANGUAGE_EXTENSIONS:
             continue
 
@@ -291,6 +298,7 @@ async def index_repo(
             for path in files_to_parse:
                 content = current_files[path]
                 _, ext = os.path.splitext(path)
+                ext = ext.lower()
                 language = LANGUAGE_EXTENSIONS.get(ext)
                 if not language:
                     continue
@@ -299,14 +307,15 @@ async def index_repo(
                     if symbols:
                         new_symbols.extend(symbols)
                         raw_files_subset[path] = content
-                except Exception:
-                    warnings.append(f"Failed to parse {path}")
+                except Exception as e:
+                    warnings.append(f"Failed to parse {path}: {e}")
 
             new_symbols = summarize_symbols(new_symbols, use_ai=use_ai_summaries)
 
             # Compute language counts from all current files
             for path in current_files:
                 _, ext = os.path.splitext(path)
+                ext = ext.lower()
                 lang = LANGUAGE_EXTENSIONS.get(ext)
                 if lang:
                     languages[lang] = languages.get(lang, 0) + 1
@@ -338,6 +347,7 @@ async def index_repo(
 
         for path, content in current_files.items():
             _, ext = os.path.splitext(path)
+            ext = ext.lower()
             language = LANGUAGE_EXTENSIONS.get(ext)
             if not language:
                 continue
@@ -348,8 +358,8 @@ async def index_repo(
                     languages[language] = languages.get(language, 0) + 1
                     raw_files[path] = content
                     parsed_files.append(path)
-            except Exception:
-                warnings.append(f"Failed to parse {path}")
+            except Exception as e:
+                warnings.append(f"Failed to parse {path}: {e}")
                 continue
 
         if not all_symbols:

--- a/src/jcodemunch_mcp/tools/search_symbols.py
+++ b/src/jcodemunch_mcp/tools/search_symbols.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from ..storage import IndexStore, CodeIndex, record_savings, estimate_savings, cost_avoided
 from ._utils import resolve_repo
+from ..parser import resolve_language_filter
 
 
 def search_symbols(
@@ -51,7 +52,10 @@ def search_symbols(
 
     # Apply language filter (post-search since CodeIndex.search doesn't support it)
     if language:
-        results = [s for s in results if s.get("language") == language]
+        resolved_languages = resolve_language_filter(language)
+        if not resolved_languages:
+            return {"error": f"Unknown language filter: {language}"}
+        results = [s for s in results if s.get("language") in resolved_languages]
 
     # Score and sort (search already does this, but we need to add score to output)
     query_lower = query.lower()

--- a/tests/fixtures/csharp/sample.cs
+++ b/tests/fixtures/csharp/sample.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace SampleApp;
+
+/// <summary>
+/// User service.
+/// </summary>
+public class UserService
+{
+    public const int MAX_RETRIES = 3;
+
+    public string Name { get; set; } = "";
+
+    public UserService()
+    {
+    }
+
+    public string GetUser(int userId)
+    {
+        return userId.ToString();
+    }
+}
+
+public interface IAuthenticator
+{
+    bool Authenticate(string token);
+}
+
+public record UserRecord(int Id, string Name);

--- a/tests/fixtures/csharp/sample.razor
+++ b/tests/fixtures/csharp/sample.razor
@@ -1,0 +1,19 @@
+@page "/users"
+
+<h3>Users</h3>
+
+@code {
+    private int _count = 0;
+
+    public void Increment()
+    {
+        _count++;
+    }
+}
+
+@functions {
+    public string FormatUser(int id)
+    {
+        return $"user-{id}";
+    }
+}

--- a/tests/fixtures/vb/sample.vb
+++ b/tests/fixtures/vb/sample.vb
@@ -1,0 +1,23 @@
+Namespace SampleApp
+
+''' <summary>User service.</summary>
+Public Class UserService
+    Public Const MAX_RETRIES As Integer = 3
+
+    Public Property Name As String
+
+    Public Sub New()
+    End Sub
+
+    Public Function GetUser(userId As Integer) As String
+        Return userId.ToString()
+    End Function
+End Class
+
+Public Interface IAuthenticator
+    Function Authenticate(token As String) As Boolean
+End Interface
+
+Public Delegate Function TokenValidator(token As String) As Boolean
+
+End Namespace

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -44,6 +44,16 @@ def _by_name(symbols: list[Symbol], name: str) -> Symbol:
     raise AssertionError(f"No symbol named '{name}' found. Available: {_names(symbols)}")
 
 
+def _vb_parser_available() -> bool:
+    try:
+        parse_file("Public Class Probe\nEnd Class\n", "probe.vb", "vb")
+        return True
+    except RuntimeError as exc:
+        if "VB parser unavailable" in str(exc):
+            return False
+        raise
+
+
 # ===========================================================================
 # 1. Per-Language Extraction
 # ===========================================================================
@@ -240,6 +250,58 @@ class TestPerLanguageExtraction:
         get_user = _by_name(symbols, "getUser")
         assert "Sample" in get_user.qualified_name
 
+    # -- C# --------------------------------------------------------------
+
+    def test_csharp_class(self):
+        content, fname = _fixture("csharp", "sample.cs")
+        symbols = parse_file(content, fname, "csharp")
+        cls = _by_name(symbols, "UserService")
+        assert cls.kind == "class"
+        assert cls.language == "csharp"
+
+    def test_csharp_methods(self):
+        content, fname = _fixture("csharp", "sample.cs")
+        symbols = parse_file(content, fname, "csharp")
+        grouped = _kinds(symbols)
+        methods = grouped.get("method", [])
+        method_names = {m.name for m in methods}
+        assert "GetUser" in method_names
+        assert "UserService" in {m.qualified_name.split(".")[0] for m in methods if "." in m.qualified_name}
+
+    def test_csharp_constant(self):
+        content, fname = _fixture("csharp", "sample.cs")
+        symbols = parse_file(content, fname, "csharp")
+        const = _by_name(symbols, "MAX_RETRIES")
+        assert const.kind == "constant"
+
+    def test_razor_methods(self):
+        content, fname = _fixture("csharp", "sample.razor")
+        symbols = parse_file(content, fname, "csharp")
+        inc = _by_name(symbols, "Increment")
+        fmt = _by_name(symbols, "FormatUser")
+        assert inc.kind == "method"
+        assert fmt.kind == "method"
+        assert fmt.byte_offset > inc.byte_offset
+
+
+@pytest.mark.skipif(not _vb_parser_available(), reason="Optional VB parser is not installed")
+class TestVBPerLanguageExtraction:
+    """VB-specific extraction checks, enabled only with optional parser."""
+
+    def test_vb_class_and_method(self):
+        content, fname = _fixture("vb", "sample.vb")
+        symbols = parse_file(content, fname, "vb")
+        cls = _by_name(symbols, "UserService")
+        method = _by_name(symbols, "GetUser")
+        assert cls.kind == "class"
+        assert method.kind == "method"
+
+    def test_vb_constant(self):
+        content, fname = _fixture("vb", "sample.vb")
+        symbols = parse_file(content, fname, "vb")
+        const = _by_name(symbols, "MAX_RETRIES")
+        assert const.kind == "constant"
+
 
 # ===========================================================================
 # 2. Overload Disambiguation
@@ -322,6 +384,7 @@ class TestDeterminism:
         ("go", "sample.go"),
         ("rust", "sample.rs"),
         ("java", "Sample.java"),
+        ("csharp", "sample.cs"),
     ])
     def test_deterministic_ids_and_hashes(self, language, filename):
         content, fname = _fixture(language, filename)
@@ -337,6 +400,18 @@ class TestDeterminism:
             )
             assert s1.kind == s2.kind
             assert s1.qualified_name == s2.qualified_name
+
+
+@pytest.mark.skipif(not _vb_parser_available(), reason="Optional VB parser is not installed")
+class TestVBDeterminism:
+    def test_vb_deterministic_ids_and_hashes(self):
+        content, fname = _fixture("vb", "sample.vb")
+        run1 = parse_file(content, fname, "vb")
+        run2 = parse_file(content, fname, "vb")
+        assert len(run1) == len(run2)
+        for s1, s2 in zip(run1, run2):
+            assert s1.id == s2.id
+            assert s1.content_hash == s2.content_hash
 
 
 # ===========================================================================
@@ -636,3 +711,137 @@ class TestNewTools:
             storage_path=storage,
         )
         assert result["success"] is False
+
+
+class TestLanguageFilterAliases:
+    """Validate canonical and framework aliases in search_symbols.language."""
+
+    def _seed_index(self, tmp_path: Path) -> str:
+        storage = str(tmp_path / "store")
+        store = IndexStore(base_path=storage)
+
+        cs = Symbol(
+            id="a.cs::AuthService.Login#method",
+            file="a.cs",
+            name="Login",
+            qualified_name="AuthService.Login",
+            kind="method",
+            language="csharp",
+            signature="public string Login(string token)",
+            line=1,
+            end_line=1,
+            byte_offset=0,
+            byte_length=10,
+        )
+        vb = Symbol(
+            id="b.vb::AuthService.Login#method",
+            file="b.vb",
+            name="Login",
+            qualified_name="AuthService.Login",
+            kind="method",
+            language="vb",
+            signature="Public Function Login(token As String) As String",
+            line=1,
+            end_line=1,
+            byte_offset=0,
+            byte_length=10,
+        )
+
+        store.save_index(
+            owner="alias",
+            name="demo",
+            source_files=["a.cs", "b.vb"],
+            symbols=[cs, vb],
+            raw_files={"a.cs": "class AuthService {}", "b.vb": "Class AuthService\nEnd Class\n"},
+            languages={"csharp": 1, "vb": 1},
+        )
+        return storage
+
+    def test_dotnet_alias_returns_csharp_and_vb(self, tmp_path):
+        from jcodemunch_mcp.tools.search_symbols import search_symbols
+
+        storage = self._seed_index(tmp_path)
+        result = search_symbols(
+            repo="alias/demo",
+            query="Login",
+            language="dotnet",
+            storage_path=storage,
+        )
+        assert "error" not in result
+        files = {r["file"] for r in result["results"]}
+        assert "a.cs" in files
+        assert "b.vb" in files
+
+    def test_aspnetframework_alias_returns_csharp_and_vb(self, tmp_path):
+        from jcodemunch_mcp.tools.search_symbols import search_symbols
+
+        storage = self._seed_index(tmp_path)
+        result = search_symbols(
+            repo="alias/demo",
+            query="Login",
+            language="aspnetframework",
+            storage_path=storage,
+        )
+        assert "error" not in result
+        assert result["result_count"] == 2
+
+    def test_csharp_alias_is_single_language(self, tmp_path):
+        from jcodemunch_mcp.tools.search_symbols import search_symbols
+
+        storage = self._seed_index(tmp_path)
+        result = search_symbols(
+            repo="alias/demo",
+            query="Login",
+            language="c#",
+            storage_path=storage,
+        )
+        assert "error" not in result
+        assert result["result_count"] == 1
+        assert result["results"][0]["file"] == "a.cs"
+
+
+class TestRazorOffsets:
+    """Validate Razor symbol byte offsets with persisted storage retrieval."""
+
+    def test_get_symbol_content_for_razor_symbol(self, tmp_path):
+        content, fname = _fixture("csharp", "sample.razor")
+        symbols = parse_file(content, fname, "csharp")
+        format_user = _by_name(symbols, "FormatUser")
+
+        store = IndexStore(base_path=str(tmp_path / "store"))
+        store.save_index(
+            owner="razor",
+            name="demo",
+            source_files=[fname],
+            symbols=symbols,
+            raw_files={fname: content},
+            languages={"csharp": 1},
+        )
+
+        symbol_content = store.get_symbol_content("razor", "demo", format_user.id)
+        assert symbol_content is not None
+        assert "FormatUser" in symbol_content
+        assert "return $\"user-{id}\";" in symbol_content
+
+
+@pytest.mark.skipif(_vb_parser_available(), reason="Optional VB parser is installed")
+class TestVBMissingParserWarning:
+    """VB files should produce explicit warnings when parser is unavailable."""
+
+    def test_index_folder_warns_when_vb_parser_missing(self, tmp_path):
+        from jcodemunch_mcp.tools.index_folder import index_folder
+
+        (tmp_path / "main.py").write_text("def ok():\n    return 1\n", encoding="utf-8")
+        (tmp_path / "legacy.vb").write_text(
+            "Public Class Legacy\nEnd Class\n",
+            encoding="utf-8",
+        )
+
+        result = index_folder(
+            path=str(tmp_path),
+            use_ai_summaries=False,
+            storage_path=str(tmp_path / "store"),
+        )
+        assert result["success"] is True
+        warnings = result.get("warnings", [])
+        assert any("VB parser unavailable" in warning for warning in warnings)

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -4,6 +4,20 @@ import pytest
 from jcodemunch_mcp.parser import parse_file
 
 
+def _vb_parser_available() -> bool:
+    try:
+        parse_file(
+            "Public Class Probe\nEnd Class\n",
+            "probe.vb",
+            "vb",
+        )
+        return True
+    except RuntimeError as exc:
+        if "VB parser unavailable" in str(exc):
+            return False
+        raise
+
+
 JAVASCRIPT_SOURCE = '''
 /** Greet a user. */
 function greet(name) {
@@ -258,4 +272,134 @@ def test_parse_php():
     enum = next((s for s in symbols if s.name == "Status"), None)
     assert enum is not None
     assert enum.kind == "type"
+
+
+CSHARP_SOURCE = '''
+namespace SampleApp;
+
+/// User service.
+public class UserService
+{
+    public const int MAX_RETRIES = 3;
+
+    public string Name { get; set; } = "";
+
+    public UserService()
+    {
+    }
+
+    public string GetUser(int userId)
+    {
+        return userId.ToString();
+    }
+}
+
+public interface IAuthenticator
+{
+    bool Authenticate(string token);
+}
+
+public record UserRecord(int Id, string Name);
+'''
+
+
+def test_parse_csharp():
+    """Test C# parsing."""
+    symbols = parse_file(CSHARP_SOURCE, "service.cs", "csharp")
+
+    cls = next((s for s in symbols if s.name == "UserService"), None)
+    assert cls is not None
+    assert cls.kind == "class"
+    assert "User service" in cls.docstring
+
+    method = next((s for s in symbols if s.name == "GetUser"), None)
+    assert method is not None
+    assert method.kind == "method"
+    assert method.parent is not None
+
+    const = next((s for s in symbols if s.name == "MAX_RETRIES"), None)
+    assert const is not None
+    assert const.kind == "constant"
+
+    iface = next((s for s in symbols if s.name == "IAuthenticator"), None)
+    assert iface is not None
+    assert iface.kind == "type"
+
+    record = next((s for s in symbols if s.name == "UserRecord"), None)
+    assert record is not None
+    assert record.kind == "type"
+
+
+RAZOR_SOURCE = '''
+@page "/users"
+
+@code {
+    public void Increment()
+    {
+    }
+}
+
+@functions {
+    public string FormatUser(int id)
+    {
+        return $"user-{id}";
+    }
+}
+'''
+
+
+def test_parse_razor():
+    """Test Razor parsing using @code and @functions blocks."""
+    symbols = parse_file(RAZOR_SOURCE, "component.razor", "csharp")
+
+    inc = next((s for s in symbols if s.name == "Increment"), None)
+    assert inc is not None
+    assert inc.kind == "method"
+    assert inc.line > 0
+    assert inc.byte_offset >= 0
+
+    fmt = next((s for s in symbols if s.name == "FormatUser"), None)
+    assert fmt is not None
+    assert fmt.kind == "method"
+    assert fmt.line > inc.line
+    assert fmt.byte_offset > inc.byte_offset
+
+
+VB_SOURCE = '''
+Namespace SampleApp
+
+Public Class UserService
+    Public Const MAX_RETRIES As Integer = 3
+
+    Public Property Name As String
+
+    Public Function GetUser(userId As Integer) As String
+        Return userId.ToString()
+    End Function
+End Class
+
+Public Interface IAuthenticator
+    Function Authenticate(token As String) As Boolean
+End Interface
+
+End Namespace
+'''
+
+
+@pytest.mark.skipif(not _vb_parser_available(), reason="Optional VB parser is not installed")
+def test_parse_vb():
+    """Test VB.NET parsing when optional parser is available."""
+    symbols = parse_file(VB_SOURCE, "service.vb", "vb")
+
+    cls = next((s for s in symbols if s.name == "UserService"), None)
+    assert cls is not None
+    assert cls.kind == "class"
+
+    method = next((s for s in symbols if s.name == "GetUser"), None)
+    assert method is not None
+    assert method.kind == "method"
+
+    const = next((s for s in symbols if s.name == "MAX_RETRIES"), None)
+    assert const is not None
+    assert const.kind == "constant"
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -128,7 +128,7 @@ class TestBinaryDetection:
         assert is_binary_extension(f"file{ext}") is True
 
     @pytest.mark.parametrize("ext", [
-        ".py", ".js", ".ts", ".go", ".rs", ".java", ".md", ".txt",
+        ".py", ".js", ".ts", ".go", ".rs", ".java", ".cs", ".vb", ".razor", ".cshtml", ".md", ".txt",
     ])
     def test_source_extensions_not_binary(self, ext):
         assert is_binary_extension(f"file{ext}") is False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -51,3 +51,12 @@ async def test_search_symbols_tool_schema():
     # kind should have enum
     assert "enum" in props["kind"]
     assert set(props["kind"]["enum"]) == {"function", "class", "method", "constant", "type"}
+
+    assert "enum" in props["language"]
+    language_enum = set(props["language"]["enum"])
+    # Canonical
+    assert {"python", "javascript", "typescript", "go", "rust", "java", "php", "csharp", "vb"} <= language_enum
+    # Direct aliases
+    assert {"c#", "cs", "vbnet", "visualbasic"} <= language_enum
+    # Family aliases
+    assert {"dotnet", ".net", "aspnet", "aspnetframework", "netframework"} <= language_enum

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -27,6 +27,8 @@ def test_should_skip_file():
     """Test skip patterns."""
     assert should_skip_file("node_modules/foo.js") is True
     assert should_skip_file("vendor/github.com/foo.go") is True
+    assert should_skip_file("TestResults/report.trx") is True
+    assert should_skip_file(".vs/config.json") is True
     assert should_skip_file("src/main.py") is False
 
 
@@ -45,6 +47,26 @@ def test_discover_source_files():
     assert "src/utils.py" in files
     assert "node_modules/foo.js" not in files
     assert "README.md" not in files  # Not a source file
+
+
+def test_discover_source_files_dotnet_extensions_and_case():
+    """Test .NET extension discovery including uppercase variants."""
+    tree_entries = [
+        {"path": "src/Service.CS", "type": "blob", "size": 1000},
+        {"path": "src/Page.aspx.cs", "type": "blob", "size": 1000},
+        {"path": "src/Legacy.VB", "type": "blob", "size": 1000},
+        {"path": "src/Component.razor", "type": "blob", "size": 1000},
+        {"path": "src/View.CSHTML", "type": "blob", "size": 1000},
+        {"path": "src/View.vbhtml", "type": "blob", "size": 1000},
+    ]
+
+    files = discover_source_files(tree_entries)
+    assert "src/Service.CS" in files
+    assert "src/Page.aspx.cs" in files
+    assert "src/Legacy.VB" in files
+    assert "src/Component.razor" in files
+    assert "src/View.CSHTML" in files
+    assert "src/View.vbhtml" not in files
 
 
 def test_discover_source_files_respects_max():


### PR DESCRIPTION
## Summary
This PR proposes comprehensive .NET language indexing improvements for jCodeMunch MCP:

- Add first-class C# support (`.cs`, `.csx`) and ASP.NET-oriented C# sources (`.razor`, `.cshtml`).
- Add optional VB.NET support (`.vb`) via native tree-sitter parser integration.
- Add language aliases for search filters (for example `c#`, `cs`, `vbnet`, `dotnet`, `aspnetframework`, `.net`).
- Improve .NET file discovery robustness and extension normalization.

## What changed

### Parser and language registry
- Added `csharp` and `vb` specs to `LANGUAGE_REGISTRY`.
- Extended `LANGUAGE_EXTENSIONS` with:
  - `.cs`, `.csx`, `.razor`, `.cshtml`, `.vb`
- Added alias resolution helpers:
  - direct aliases (`c#`, `cs`, `vbnet`, `visualbasic`)
  - family aliases (`dotnet`, `.net`, `netframework`, `aspnet`, `aspnetframework`) -> `{csharp, vb}`

### Multi-backend parser resolution
- Refactored parser resolution in `extractor.py`:
  - Existing languages continue using `tree-sitter-language-pack`.
  - VB uses optional native grammar loading through `tree_sitter` + `tree_sitter_tree_sitter_vb_dotnet`.
- Added actionable runtime error when VB parser is not installed:
  - suggests `pip install jcodemunch-mcp[dotnet]`.

### Razor support
- Implemented dedicated parsing flow for `.razor` and `.cshtml`:
  - extracts `@code { ... }` and `@functions { ... }` blocks
  - parses blocks as synthetic C# class context
  - remaps symbol lines/byte offsets/IDs/qualified names back to original file

### Search and API schema
- `search_symbols` now resolves canonical + alias language filters (single language or family set).
- MCP `search_symbols.language` enum is now generated dynamically from supported canonical values + aliases.
- Includes `php` in schema enum as expected.

### Indexing hardening for .NET repos
- Added skip patterns for common .NET build artifacts:
  - `bin/`, `obj/`, `.vs/`, `TestResults/`, `packages/`
- Normalized extension lookups to lowercase across discovery/indexing/file tree paths.

### Storage correctness on Windows
- Preserved raw file byte offsets by writing cached source files with `newline=""`.
- This avoids CRLF translation drift for byte-offset-based symbol retrieval.

### Packaging
- Added optional dependency group `dotnet`:
  - `tree-sitter-vb-dotnet` (git reference pinned)
  - `tree-sitter>=0.24,<0.26`
- Enabled hatch direct references:
  - `[tool.hatch.metadata] allow-direct-references = true`

### Docs
Updated:
- `README.md`
- `LANGUAGE_SUPPORT.md`
- `SPEC.md`
- `USER_GUIDE.md`

Includes new language matrix, optional VB installation path, alias behavior, and troubleshooting notes.

## Tests
- Added fixtures:
  - `tests/fixtures/csharp/sample.cs`
  - `tests/fixtures/csharp/sample.razor`
  - `tests/fixtures/vb/sample.vb`
- Expanded tests in:
  - `tests/test_languages.py`
  - `tests/test_hardening.py`
  - `tests/test_tools.py`
  - `tests/test_server.py`
  - `tests/test_security.py`
- Added explicit checks for:
  - Razor symbol extraction and byte-offset retrieval
  - alias/family language filters (`dotnet`, `aspnetframework`, `c#`)
  - VB optional-parser warning behavior

## Validation run
Executed locally:

- `python -m pytest -q`
- Result: `199 passed, 8 skipped`

(skips are expected for optional VB-parser-dependent scenarios when VB parser is not installed)

## Notes
- Canonical language values stored in index remain `csharp` and `vb`.
- Alias handling is query-time only.
- WebForms markup parsing (`.aspx/.ascx/.master`) is intentionally out of scope in this PR.
