### PR TITLE
Add Swift language support

### DIFF
--- a/src/jcodemunch_mcp/parser/extractor.py
+++ b/src/jcodemunch_mcp/parser/extractor.py
@@ -402,6 +402,52 @@ def _extract_constant(
                     content_hash=c_hash,
                 )
 
+    # Swift: let MAX_SPEED = 100  (property_declaration with let binding)
+    if node.type == "property_declaration":
+        # Only extract immutable `let` bindings (not `var`)
+        binding = None
+        for child in node.children:
+            if child.type == "value_binding_pattern":
+                binding = child
+                break
+        if not binding:
+            return None
+        mutability = binding.child_by_field_name("mutability")
+        if not mutability or mutability.text != b"let":
+            return None
+        pattern = node.child_by_field_name("name")
+        if not pattern:
+            return None
+        name_node = pattern.child_by_field_name("bound_identifier")
+        if not name_node:
+            # fallback: first simple_identifier in pattern
+            for child in pattern.children:
+                if child.type == "simple_identifier":
+                    name_node = child
+                    break
+        if not name_node:
+            return None
+        name = source_bytes[name_node.start_byte:name_node.end_byte].decode("utf-8")
+        if not (name.isupper() or (len(name) > 1 and name[0].isupper() and "_" in name)):
+            return None
+        sig = source_bytes[node.start_byte:node.end_byte].decode("utf-8").strip()
+        const_bytes = source_bytes[node.start_byte:node.end_byte]
+        c_hash = compute_content_hash(const_bytes)
+        return Symbol(
+            id=make_symbol_id(filename, name, "constant"),
+            file=filename,
+            name=name,
+            qualified_name=name,
+            kind="constant",
+            language=language,
+            signature=sig[:100],
+            line=node.start_point[0] + 1,
+            end_line=node.end_point[0] + 1,
+            byte_offset=node.start_byte,
+            byte_length=node.end_byte - node.start_byte,
+            content_hash=c_hash,
+        )
+
     return None
 
 

--- a/src/jcodemunch_mcp/parser/languages.py
+++ b/src/jcodemunch_mcp/parser/languages.py
@@ -62,6 +62,7 @@ LANGUAGE_EXTENSIONS = {
     ".cs": "csharp",
     ".c": "c",
     ".h": "c",
+    ".swift": "swift",
 }
 
 
@@ -387,6 +388,36 @@ C_SPEC = LanguageSpec(
 )
 
 
+# Swift specification
+# Note: tree-sitter-swift uses class_declaration for class/struct/enum/extension;
+# the declaration_kind child field ("class"/"struct"/"enum"/"extension") disambiguates
+# at the source level but all map to "class" here for uniform treatment.
+# Attributes (@discardableResult etc.) live inside a modifiers child node rather
+# than as preceding siblings, so decorator extraction is not supported in this spec.
+SWIFT_SPEC = LanguageSpec(
+    ts_language="swift",
+    symbol_node_types={
+        "function_declaration": "function",
+        "class_declaration": "class",    # covers class, struct, enum, extension
+        "protocol_declaration": "type",
+        "init_declaration": "method",
+    },
+    name_fields={
+        "function_declaration": "name",  # simple_identifier child
+        "class_declaration": "name",     # type_identifier child
+        "protocol_declaration": "name",  # type_identifier child
+        "init_declaration": "name",      # "init" keyword token
+    },
+    param_fields={},  # Swift params are unnamed children; signature captured via source range
+    return_type_fields={},  # return type shares field "name" with function identifier
+    docstring_strategy="preceding_comment",  # /// and /* */ doc comments
+    decorator_node_type=None,
+    container_node_types=["class_declaration", "protocol_declaration"],
+    constant_patterns=["property_declaration"],  # let/var at file scope
+    type_patterns=["protocol_declaration"],
+)
+
+
 # Language registry
 LANGUAGE_REGISTRY = {
     "python": PYTHON_SPEC,
@@ -399,4 +430,5 @@ LANGUAGE_REGISTRY = {
     "dart": DART_SPEC,
     "csharp": CSHARP_SPEC,
     "c": C_SPEC,
+    "swift": SWIFT_SPEC,
 }

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -212,7 +212,7 @@ async def list_tools() -> list[Tool]:
                     "language": {
                         "type": "string",
                         "description": "Optional filter by language",
-                        "enum": ["python", "javascript", "typescript", "go", "rust", "java", "php", "dart", "csharp", "c"]
+                        "enum": ["python", "javascript", "typescript", "go", "rust", "java", "php", "dart", "csharp", "c", "swift"]
                     },
                     "max_results": {
                         "type": "integer",

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -489,6 +489,88 @@ def test_parse_csharp():
     assert record.kind == "class"
 
 
+SWIFT_SOURCE = '''
+/// Greet a user by name.
+func greet(name: String) -> String {
+    return "Hello, \\(name)!"
+}
+
+/// A simple animal.
+class Animal {
+    /// Initialize with a name.
+    init(name: String) {}
+
+    /// Make the animal speak.
+    func speak() {}
+}
+
+/// A 2D point.
+struct Point {
+    var x: Double
+    var y: Double
+}
+
+/// Drawable objects.
+protocol Drawable {
+    func draw()
+}
+
+/// Cardinal directions.
+enum Direction {
+    case north, south, east, west
+}
+
+let MAX_SPEED = 100
+'''
+
+
+def test_parse_swift():
+    """Test Swift parsing."""
+    symbols = parse_file(SWIFT_SOURCE, "app.swift", "swift")
+
+    # Top-level function
+    func = next((s for s in symbols if s.name == "greet"), None)
+    assert func is not None
+    assert func.kind == "function"
+    assert "Greet a user by name" in func.docstring
+
+    # Class
+    cls = next((s for s in symbols if s.name == "Animal"), None)
+    assert cls is not None
+    assert cls.kind == "class"
+    assert "simple animal" in cls.docstring
+
+    # init inside class
+    init = next((s for s in symbols if s.name == "init"), None)
+    assert init is not None
+    assert init.kind == "method"
+
+    # Method inside class
+    speak = next((s for s in symbols if s.name == "speak"), None)
+    assert speak is not None
+    assert speak.kind in ("function", "method")
+
+    # Struct (maps to class)
+    point = next((s for s in symbols if s.name == "Point"), None)
+    assert point is not None
+    assert point.kind == "class"
+
+    # Protocol (maps to type)
+    drawable = next((s for s in symbols if s.name == "Drawable"), None)
+    assert drawable is not None
+    assert drawable.kind == "type"
+
+    # Enum (maps to class via class_declaration)
+    direction = next((s for s in symbols if s.name == "Direction"), None)
+    assert direction is not None
+    assert direction.kind == "class"
+
+    # Constant
+    speed = next((s for s in symbols if s.name == "MAX_SPEED"), None)
+    assert speed is not None
+    assert speed.kind == "constant"
+
+
 def test_parse_c():
     """Test C parsing."""
     symbols = parse_file(C_SOURCE, "sample.c", "c")


### PR DESCRIPTION
## Summary

- Adds Swift to the language registry via `SWIFT_SPEC` in `languages.py` — no new dependencies, `tree-sitter-language-pack` already bundles the Swift grammar
- Handles Swift's unified `class_declaration` node (used for class, struct, enum, and extension) mapping all to `"class"` kind
- Extracts `protocol_declaration` as `"type"`, `init_declaration` as `"method"`, and top-level functions/class methods via `function_declaration`
- Adds `property_declaration` constant extraction in `extractor.py` for `let UPPER_CASE = ...` bindings
- Adds `"swift"` to the `search_symbols` language enum in `server.py`
- `.swift` extension registered in `LANGUAGE_EXTENSIONS`

## Known limitations

- Decorators (`@discardableResult`, `@available`, etc.) are not extracted — Swift places them inside a `modifiers` child node rather than as preceding siblings, which doesn't fit the current decorator model without extractor changes
- `param_fields` is empty — Swift parameters are unnamed children in the AST, but signatures are still captured correctly via source range
- Return types are not structured — the return type in `function_declaration` shares the `"name"` field with the function identifier

## Test plan

- [x] `test_parse_swift` covers: top-level function, class, struct, protocol, enum, init, method, and `let` constant
- [x] All 201 existing tests still pass (`4 skipped`, unchanged)
- [x] Verified `tree_sitter_language_pack.get_language('swift')` returns successfully before writing any code

🤖 Generated with [Claude Code](https://claude.com/claude-code)