### PR TITLE
feat: add arrow function variable support for JS/TS

### DIFF
--- a/src/jcodemunch_mcp/parser/extractor.py
+++ b/src/jcodemunch_mcp/parser/extractor.py
@@ -161,6 +161,14 @@ def _walk_tree(
                 else:
                     next_parent = symbol
 
+    # Check for arrow/function-expression variable assignments in JS/TS
+    if node.type == "variable_declarator" and language in ("javascript", "typescript"):
+        var_func = _extract_variable_function(
+            node, spec, source_bytes, filename, language, parent_symbol
+        )
+        if var_func:
+            symbols.append(var_func)
+
     # Check for constant patterns (top-level assignments with UPPER_CASE names)
     if node.type in spec.constant_patterns and parent_symbol is None:
         const_symbol = _extract_constant(node, spec, source_bytes, filename, language)
@@ -274,11 +282,6 @@ def _extract_symbol(
 
 def _extract_name(node, spec: LanguageSpec, source_bytes: bytes) -> Optional[str]:
     """Extract the name from an AST node."""
-    # Handle special cases first
-    if node.type == "arrow_function":
-        # Arrow functions get name from parent variable_declarator
-        return None
-    
     # Handle type_declaration in Go - name is in type_spec child
     if node.type == "type_declaration":
         for child in node.children:
@@ -631,6 +634,79 @@ def _extract_decorators(node, spec: LanguageSpec, source_bytes: bytes) -> list[s
             prev = prev.prev_named_sibling
 
     return decorators
+
+
+_VARIABLE_FUNCTION_TYPES = frozenset({
+    "arrow_function",
+    "function_expression",
+    "generator_function",
+})
+
+
+def _extract_variable_function(
+    node,
+    spec: LanguageSpec,
+    source_bytes: bytes,
+    filename: str,
+    language: str,
+    parent_symbol: Optional[Symbol] = None,
+) -> Optional[Symbol]:
+    """Extract a function from `const name = () => {}` or `const name = function() {}`."""
+    # node is a variable_declarator
+    name_node = node.child_by_field_name("name")
+    if not name_node or name_node.type != "identifier":
+        return None  # destructuring or other non-simple binding
+
+    value_node = node.child_by_field_name("value")
+    if not value_node or value_node.type not in _VARIABLE_FUNCTION_TYPES:
+        return None  # not a function assignment
+
+    name = source_bytes[name_node.start_byte:name_node.end_byte].decode("utf-8")
+
+    kind = "function"
+    if parent_symbol:
+        qualified_name = f"{parent_symbol.name}.{name}"
+        kind = "method"
+    else:
+        qualified_name = name
+
+    # Signature: use the full declaration statement (lexical_declaration parent)
+    # to capture export/const keywords
+    sig_node = node.parent if node.parent and node.parent.type in (
+        "lexical_declaration", "export_statement", "variable_declaration",
+    ) else node
+    # Walk up through export_statement wrapper if present
+    if sig_node.parent and sig_node.parent.type == "export_statement":
+        sig_node = sig_node.parent
+
+    signature = _build_signature(sig_node, spec, source_bytes)
+
+    # Docstring: look for preceding comment on the declaration statement
+    doc_node = sig_node
+    docstring = _extract_docstring(doc_node, spec, source_bytes)
+
+    # Content hash covers the full declaration
+    start_byte = sig_node.start_byte
+    end_byte = sig_node.end_byte
+    symbol_bytes = source_bytes[start_byte:end_byte]
+    c_hash = compute_content_hash(symbol_bytes)
+
+    return Symbol(
+        id=make_symbol_id(filename, qualified_name, kind),
+        file=filename,
+        name=name,
+        qualified_name=qualified_name,
+        kind=kind,
+        language=language,
+        signature=signature,
+        docstring=docstring,
+        parent=parent_symbol.id if parent_symbol else None,
+        line=sig_node.start_point[0] + 1,
+        end_line=sig_node.end_point[0] + 1,
+        byte_offset=start_byte,
+        byte_length=end_byte - start_byte,
+        content_hash=c_hash,
+    )
 
 
 def _extract_constant(

--- a/src/jcodemunch_mcp/parser/languages.py
+++ b/src/jcodemunch_mcp/parser/languages.py
@@ -104,7 +104,6 @@ JAVASCRIPT_SPEC = LanguageSpec(
         "function_declaration": "function",
         "class_declaration": "class",
         "method_definition": "method",
-        "arrow_function": "function",
         "generator_function_declaration": "function",
     },
     name_fields={
@@ -133,7 +132,6 @@ TYPESCRIPT_SPEC = LanguageSpec(
         "function_declaration": "function",
         "class_declaration": "class",
         "method_definition": "method",
-        "arrow_function": "function",
         "interface_declaration": "type",
         "type_alias_declaration": "type",
         "enum_declaration": "type",

--- a/tests/test_arrow_functions.py
+++ b/tests/test_arrow_functions.py
@@ -1,0 +1,178 @@
+"""Tests for arrow function variable support in JS/TS."""
+
+import pytest
+from jcodemunch_mcp.parser import parse_file
+
+
+# --- Arrow function assigned to const ---
+
+JS_ARROW_BASIC = '''\
+const add = (a, b) => a + b;
+'''
+
+def test_js_arrow_function_indexed():
+    """const add = (a, b) => ... should be indexed as a function."""
+    symbols = parse_file(JS_ARROW_BASIC, "utils.js", "javascript")
+    func = next((s for s in symbols if s.name == "add"), None)
+    assert func is not None
+    assert func.kind == "function"
+    assert func.id == "utils.js::add#function"
+
+
+# --- Function expression assigned to const ---
+
+JS_FUNCTION_EXPRESSION = '''\
+const multiply = function(a, b) {
+    return a * b;
+};
+'''
+
+def test_js_function_expression_indexed():
+    """const multiply = function() {} should be indexed as a function."""
+    symbols = parse_file(JS_FUNCTION_EXPRESSION, "math.js", "javascript")
+    func = next((s for s in symbols if s.name == "multiply"), None)
+    assert func is not None
+    assert func.kind == "function"
+
+
+# --- Generator function expression ---
+
+JS_GENERATOR_EXPRESSION = '''\
+const generate = function*(items) {
+    for (const item of items) yield item;
+};
+'''
+
+def test_js_generator_expression_indexed():
+    """const generate = function*() {} should be indexed as a function."""
+    symbols = parse_file(JS_GENERATOR_EXPRESSION, "gen.js", "javascript")
+    func = next((s for s in symbols if s.name == "generate"), None)
+    assert func is not None
+    assert func.kind == "function"
+
+
+# --- Exported arrow function ---
+
+JS_EXPORTED_ARROW = '''\
+export const validate = (input) => {
+    return input.length > 0;
+};
+'''
+
+def test_js_exported_arrow_includes_export_in_signature():
+    """Exported arrow functions should have 'export' in signature."""
+    symbols = parse_file(JS_EXPORTED_ARROW, "validate.js", "javascript")
+    func = next((s for s in symbols if s.name == "validate"), None)
+    assert func is not None
+    assert func.kind == "function"
+    assert "export" in func.signature
+
+
+# --- TypeScript arrow with type annotation ---
+
+TS_ARROW_TYPED = '''\
+export const validate = (input: string): boolean => {
+    return input.length > 0;
+};
+'''
+
+def test_ts_arrow_typed():
+    """TypeScript arrow with type annotations should be indexed."""
+    symbols = parse_file(TS_ARROW_TYPED, "validate.ts", "typescript")
+    func = next((s for s in symbols if s.name == "validate"), None)
+    assert func is not None
+    assert func.kind == "function"
+    assert "export" in func.signature
+
+
+# --- Non-function assignments should NOT be indexed ---
+
+JS_NON_FUNCTION_ASSIGNMENTS = '''\
+const x = 5;
+const arr = [1, 2, 3];
+const obj = { key: "value" };
+const str = "hello";
+'''
+
+def test_non_function_assignments_not_indexed():
+    """Plain value assignments should not create function symbols."""
+    symbols = parse_file(JS_NON_FUNCTION_ASSIGNMENTS, "vals.js", "javascript")
+    func_symbols = [s for s in symbols if s.kind == "function"]
+    assert len(func_symbols) == 0
+
+
+# --- Inline arrow callbacks should NOT be indexed ---
+
+JS_INLINE_ARROW = '''\
+[1, 2, 3].map(x => x + 1);
+const result = items.filter(item => item.active);
+'''
+
+def test_inline_arrow_not_indexed():
+    """Arrow functions not assigned via variable_declarator should not be indexed."""
+    symbols = parse_file(JS_INLINE_ARROW, "inline.js", "javascript")
+    func_symbols = [s for s in symbols if s.kind == "function"]
+    assert len(func_symbols) == 0
+
+
+# --- Destructuring should NOT be indexed ---
+
+JS_DESTRUCTURING = '''\
+const { foo, bar } = require("something");
+const [a, b] = [1, 2];
+'''
+
+def test_destructuring_not_indexed():
+    """Destructuring assignments should not create function symbols."""
+    symbols = parse_file(JS_DESTRUCTURING, "destructure.js", "javascript")
+    func_symbols = [s for s in symbols if s.kind == "function"]
+    assert len(func_symbols) == 0
+
+
+# --- Docstring extraction from preceding comment ---
+
+JS_ARROW_WITH_DOCSTRING = '''\
+/** Adds two numbers together. */
+const add = (a, b) => a + b;
+'''
+
+def test_arrow_docstring_extraction():
+    """Arrow function should pick up preceding JSDoc comment."""
+    symbols = parse_file(JS_ARROW_WITH_DOCSTRING, "doc.js", "javascript")
+    func = next((s for s in symbols if s.name == "add"), None)
+    assert func is not None
+    assert "Adds two numbers" in func.docstring
+
+
+# --- Signature includes params ---
+
+JS_ARROW_MULTILINE = '''\
+const processData = (data, options) => {
+    return data;
+};
+'''
+
+def test_arrow_signature_includes_params():
+    """Arrow function signature should include parameter list."""
+    symbols = parse_file(JS_ARROW_MULTILINE, "process.js", "javascript")
+    func = next((s for s in symbols if s.name == "processData"), None)
+    assert func is not None
+    assert "data" in func.signature
+    assert "options" in func.signature
+
+
+# --- Multiple arrow functions in one file ---
+
+JS_MULTIPLE_ARROWS = '''\
+const foo = () => {};
+function bar() {}
+const baz = (x) => x * 2;
+'''
+
+def test_multiple_arrows_with_regular_functions():
+    """Both arrow and regular functions should be indexed."""
+    symbols = parse_file(JS_MULTIPLE_ARROWS, "multi.js", "javascript")
+    names = {s.name for s in symbols if s.kind == "function"}
+    assert "foo" in names
+    assert "bar" in names
+    assert "baz" in names


### PR DESCRIPTION
## Summary

- Index `const foo = () => {}`, `const bar = function() {}`, and `const gen = function*() {}` patterns as function symbols in JS/TS
- New `_extract_variable_function()` extracts name from the parent `variable_declarator` node, resolving the long-standing TODO at `extractor.py:136`
- Remove `arrow_function` from JS/TS `symbol_node_types` — these caused wasted `_extract_symbol` calls on every inline callback (`.map(x => x + 1)`) that always returned `None`

## What gets indexed

| Pattern | Indexed? |
|---|---|
| `const foo = () => {}` | Yes |
| `const foo = function() {}` | Yes |
| `const foo = function*() {}` | Yes |
| `export const validate = (input: string): boolean => ...` | Yes (signature includes `export`) |
| `const x = 5` / `const arr = [1,2,3]` | No |
| `[1,2,3].map(x => x + 1)` | No |
| `const { a, b } = foo()` | No |

## Test plan

- [x] 11 new tests in `tests/test_arrow_functions.py`
- [x] Positive: arrow function, function expression, generator, exported, TypeScript typed
- [x] Negative: non-function values, inline callbacks, destructuring
- [x] Docstring extraction from preceding `/** */` comment
- [x] Signature includes parameters
- [x] Full test suite: 233 passed, 0 regressions (3 pre-existing async failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)