### PR TITLE
fix: improve get_file_outline description and error handling

### DIFF
--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -123,7 +123,7 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="get_file_outline",
-            description="Get all symbols (functions, classes, methods) in a file with signatures and summaries.",
+            description="Get all symbols (functions, classes, methods) in a file with signatures and summaries. Pass repo and file_path (e.g. 'src/main.py').",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -365,6 +365,8 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         
         return [TextContent(type="text", text=json.dumps(result, indent=2))]
     
+    except KeyError as e:
+        return [TextContent(type="text", text=json.dumps({"error": f"Missing required argument: {e}. Check the tool schema for correct parameter names."}, indent=2))]
     except Exception as e:
         return [TextContent(type="text", text=json.dumps({"error": str(e)}, indent=2))]
 


### PR DESCRIPTION
## Problem

Models were calling `get_file_outline` with `file=...` instead of `file_path=...`. The tool description didn't mention the argument name, so models guessed — and guessed wrong.

When this happened, the `KeyError` was caught by the generic `except Exception` handler, which returned `str(e)` — just `"'file_path'"` with no context, giving the caller no indication of what went wrong or how to fix it.

## Changes

- **Tool description**: Added `file_path` arg name explicitly — `"Pass repo and file_path (e.g. 'src/main.py')"`.
- **Error handling**: Added a dedicated `KeyError` handler before the generic one, returning a clear message: `"Missing required argument: 'file_path'. Check the tool schema for correct parameter names."` — applies to all tools in the server.