### PR TITLE
feat(dotnet): add GetRepoOutlineTool MCP tool

### DIFF
--- a/dotnet/src/JCodeMunch.Mcp/Tools/GetRepoOutlineTool.cs
+++ b/dotnet/src/JCodeMunch.Mcp/Tools/GetRepoOutlineTool.cs
@@ -1,0 +1,119 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text.Json;
+using JCodeMunch.Mcp.Storage;
+using ModelContextProtocol.Server;
+
+namespace JCodeMunch.Mcp.Tools;
+
+/// <summary>
+/// MCP tool: get_repo_outline
+/// Returns a high-level overview of an indexed repository.
+/// Port of Python tools/get_repo_outline.py.
+/// </summary>
+[McpServerToolType]
+public static class GetRepoOutlineTool
+{
+    [McpServerTool(Name = "get_repo_outline"), Description("Get a high-level overview of an indexed repository.")]
+    public static string GetRepoOutline(
+        IndexStore store,
+        TokenTracker tracker,
+        [Description("Repository identifier (owner/repo or repo name)")] string repo)
+    {
+        var sw = Stopwatch.StartNew();
+
+        string owner, name;
+        try
+        {
+            (owner, name) = ToolUtils.ResolveRepo(repo, store);
+        }
+        catch (ArgumentException ex)
+        {
+            return JsonSerializer.Serialize(new { error = ex.Message });
+        }
+
+        var index = store.LoadIndex(owner, name);
+        if (index is null)
+            return JsonSerializer.Serialize(new { error = $"Repository not indexed: {owner}/{name}" });
+
+        // Directory-level file counts
+        var dirCounts = new Dictionary<string, int>();
+        foreach (var file in index.SourceFiles)
+        {
+            var parts = file.Split('/');
+            var dir = parts.Length > 1 ? parts[0] + "/" : "(root)";
+            dirCounts[dir] = dirCounts.GetValueOrDefault(dir) + 1;
+        }
+
+        var sortedDirs = dirCounts
+            .OrderByDescending(kv => kv.Value)
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        // Symbol kind breakdown
+        var kindCounts = new Dictionary<string, int>();
+        foreach (var sym in index.Symbols)
+        {
+            var kind = sym.TryGetValue("kind", out var k) && k.ValueKind == JsonValueKind.String
+                ? k.GetString() ?? "unknown"
+                : "unknown";
+            kindCounts[kind] = kindCounts.GetValueOrDefault(kind) + 1;
+        }
+
+        var sortedKinds = kindCounts
+            .OrderByDescending(kv => kv.Value)
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        // Token savings: sum of all raw file sizes
+        var storagePath = Environment.GetEnvironmentVariable("CODE_INDEX_PATH");
+        var contentDir = ToolUtils.GetContentDir(storagePath, owner, name);
+
+        var rawBytes = 0L;
+        var contentDirFull = Path.GetFullPath(contentDir);
+        foreach (var file in index.SourceFiles)
+        {
+            try
+            {
+                var fullPath = Path.GetFullPath(Path.Combine(contentDir, file));
+                if (fullPath.StartsWith(contentDirFull, StringComparison.Ordinal)
+                    && File.Exists(fullPath))
+                {
+                    rawBytes += new FileInfo(fullPath).Length;
+                }
+            }
+            catch
+            {
+                // Skip inaccessible files
+            }
+        }
+
+        var tokensSaved = TokenTracker.EstimateSavings((int)Math.Min(rawBytes, int.MaxValue), 0);
+        var totalSaved = tracker.RecordSaving(tokensSaved);
+
+        var elapsedMs = Math.Round(sw.Elapsed.TotalMilliseconds, 1);
+
+        var costAvoided = TokenTracker.CostAvoided(tokensSaved, totalSaved);
+
+        var meta = new Dictionary<string, object>
+        {
+            ["timing_ms"] = elapsedMs,
+            ["tokens_saved"] = tokensSaved,
+            ["total_tokens_saved"] = totalSaved,
+        };
+        foreach (var (key, value) in costAvoided)
+            meta[key] = value;
+
+        var result = new Dictionary<string, object>
+        {
+            ["repo"] = $"{owner}/{name}",
+            ["indexed_at"] = index.IndexedAt,
+            ["file_count"] = index.SourceFiles.Count,
+            ["symbol_count"] = index.Symbols.Count,
+            ["languages"] = index.Languages,
+            ["directories"] = sortedDirs,
+            ["symbol_kinds"] = sortedKinds,
+            ["_meta"] = meta,
+        };
+
+        return JsonSerializer.Serialize(result);
+    }
+}

--- a/dotnet/src/JCodeMunch.Mcp/Tools/ToolUtils.cs
+++ b/dotnet/src/JCodeMunch.Mcp/Tools/ToolUtils.cs
@@ -1,0 +1,51 @@
+using JCodeMunch.Mcp.Storage;
+
+namespace JCodeMunch.Mcp.Tools;
+
+/// <summary>
+/// Shared helpers for tool modules.
+/// Port of Python tools/_utils.py.
+/// </summary>
+internal static class ToolUtils
+{
+    /// <summary>
+    /// Parse "owner/repo" or look up a single repo name.
+    /// Returns (Owner, Name).
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when the repository is not found.</exception>
+    public static (string Owner, string Name) ResolveRepo(string repo, IndexStore store)
+    {
+        if (repo.Contains('/'))
+        {
+            var parts = repo.Split('/', 2);
+            return (parts[0], parts[1]);
+        }
+
+        var repos = store.ListRepos();
+        var matching = repos
+            .Where(r => r.TryGetValue("repo", out var repoVal)
+                        && repoVal is string repoStr
+                        && repoStr.EndsWith($"/{repo}", StringComparison.Ordinal))
+            .ToList();
+
+        if (matching.Count == 0)
+            throw new ArgumentException($"Repository not found: {repo}");
+
+        var fullRepo = (string)matching[0]["repo"];
+        var repoParts = fullRepo.Split('/', 2);
+        return (repoParts[0], repoParts[1]);
+    }
+
+    /// <summary>
+    /// Compute the content directory path for a repository.
+    /// Mirrors IndexStore.ContentDir: basePath/{owner}-{name}
+    /// </summary>
+    public static string GetContentDir(string? storagePath, string owner, string name)
+    {
+        var basePath = storagePath ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".code-index");
+
+        return Path.Combine(basePath, $"{owner}-{name}");
+    }
+}


### PR DESCRIPTION
## Summary
- Port the Python `get_repo_outline` tool to a .NET 10 MCP tool class (`GetRepoOutlineTool.cs`)
- Add shared `ToolUtils.cs` with `ResolveRepo` and `GetContentDir` helpers used across tool implementations
- Returns directory-level file counts, symbol kind breakdown, languages, and token savings metadata

## Test plan
- [x] `dotnet build` succeeds (no new errors introduced)
- [x] `dotnet test` passes (1/1)
- [ ] Manual verification with an indexed repository