### PR TITLE
feat(parser): add Laravel Blade template support

### DIFF
--- a/LANGUAGE_SUPPORT.md
+++ b/LANGUAGE_SUPPORT.md
@@ -17,6 +17,7 @@
 | C++        | `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hh`, `.hxx`, `.h`* | tree-sitter-cpp | function, class, method, type (struct/enum/union/alias), constant | — | `/* */` and `//` comments | Namespace symbols are used for qualification but not emitted as standalone symbols |
 | Elixir     | `.ex`, `.exs` | tree-sitter-elixir | class (defmodule/defimpl), type (defprotocol/@type/@callback), method (def/defp/defmacro/defguard inside module), function (top-level def) | — | `@doc`/`@moduledoc` strings | Homoiconic grammar; custom walker required. `defstruct`, `use`, `import`, `alias` not indexed |
 | Ruby       | `.rb`, `.rake` | tree-sitter-ruby  | class, type (module), method (instance + `self.` singleton), function (top-level def) | — | `#` preceding comments | `attr_accessor`, constants, and `include`/`extend` not indexed |
+| Blade      | `.blade.php`  | regex (no tree-sitter grammar) | type (@extends), method (@section/@slot/@yield), class (@component/@livewire), function (@include*), constant (@push/@stack) | — | — | Regex-based; PHP code blocks inside templates are not indexed |
 
 \* `.h` uses C++ parsing first, then falls back to C when no C++ symbols are extracted.
 
@@ -125,6 +126,6 @@ JCODEMUNCH_EXTRA_EXTENSIONS=".cgi:perl,.psgi:perl,.mjs:javascript"
 - Comma-separated `.ext:lang` pairs
 - Overrides built-in mappings on collision
 - Unknown languages and malformed entries are skipped with a warning
-- Valid language names: `python`, `javascript`, `typescript`, `go`, `rust`, `java`, `php`, `dart`, `csharp`, `c`, `cpp`, `swift`, `elixir`, `ruby`, `perl`
+- Valid language names: `python`, `javascript`, `typescript`, `go`, `rust`, `java`, `php`, `dart`, `csharp`, `c`, `cpp`, `swift`, `elixir`, `ruby`, `perl`, `blade`
 
 Set via `.mcp.json` `env` block or any environment mechanism supported by your MCP client.

--- a/src/jcodemunch_mcp/parser/__init__.py
+++ b/src/jcodemunch_mcp/parser/__init__.py
@@ -1,7 +1,7 @@
 """Parser package for extracting symbols from source code."""
 
 from .symbols import Symbol, slugify, make_symbol_id, compute_content_hash
-from .languages import LanguageSpec, LANGUAGE_REGISTRY, LANGUAGE_EXTENSIONS, PYTHON_SPEC
+from .languages import LanguageSpec, LANGUAGE_REGISTRY, LANGUAGE_EXTENSIONS, PYTHON_SPEC, get_language_for_path
 from .extractor import parse_file
 from .hierarchy import SymbolNode, build_symbol_tree, flatten_tree
 
@@ -14,6 +14,7 @@ __all__ = [
     "LANGUAGE_REGISTRY",
     "LANGUAGE_EXTENSIONS",
     "PYTHON_SPEC",
+    "get_language_for_path",
     "parse_file",
     "SymbolNode",
     "build_symbol_tree",

--- a/src/jcodemunch_mcp/parser/extractor.py
+++ b/src/jcodemunch_mcp/parser/extractor.py
@@ -1,5 +1,6 @@
 """Generic AST symbol extractor using tree-sitter."""
 
+import re
 from typing import Optional
 from tree_sitter_language_pack import get_parser
 
@@ -27,6 +28,8 @@ def parse_file(content: str, filename: str, language: str) -> list[Symbol]:
         symbols = _parse_cpp_symbols(source_bytes, filename)
     elif language == "elixir":
         symbols = _parse_elixir_symbols(source_bytes, filename)
+    elif language == "blade":
+        symbols = _parse_blade_symbols(source_bytes, filename)
     else:
         spec = LANGUAGE_REGISTRY[language]
         symbols = _parse_with_spec(source_bytes, filename, language, spec)
@@ -1239,3 +1242,102 @@ def _disambiguate_overloads(symbols: list[Symbol]) -> list[Symbol]:
             sym.id = f"{sym.id}~{ordinals[sym.id]}"
         result.append(sym)
     return result
+
+
+# ---------------------------------------------------------------------------
+# Blade template parser (regex-based; no tree-sitter grammar available)
+# ---------------------------------------------------------------------------
+
+# Directives that define named "symbols" in a Blade template
+_BLADE_SYMBOL_PATTERNS: list[tuple[str, str, str]] = [
+    # (kind, directive_regex, capture_group_name)
+    # @extends('layouts.app')  → type  "layouts.app"
+    ("type",     r"@extends\s*\(\s*['\"](?P<name>[^'\"]+)['\"]", "name"),
+    # @section('content')      → method "content"
+    ("method",   r"@section\s*\(\s*['\"](?P<name>[^'\"]+)['\"]", "name"),
+    # @component('alert')      → class  "alert"
+    ("class",    r"@component\s*\(\s*['\"](?P<name>[^'\"]+)['\"]", "name"),
+    # @include('partials.nav') → function "partials.nav"
+    ("function", r"@include(?:If|When|Unless|First)?\s*\(\s*['\"](?P<name>[^'\"]+)['\"]", "name"),
+    # @push('scripts')         → constant "scripts"
+    ("constant", r"@push\s*\(\s*['\"](?P<name>[^'\"]+)['\"]", "name"),
+    # @stack('scripts')        → constant "scripts" (declaration side)
+    ("constant", r"@stack\s*\(\s*['\"](?P<name>[^'\"]+)['\"]", "name"),
+    # @slot('title')           → method "title"
+    ("method",   r"@slot\s*\(\s*['\"](?P<name>[^'\"]+)['\"]", "name"),
+    # @yield('content')        → method "content"
+    ("method",   r"@yield\s*\(\s*['\"](?P<name>[^'\"]+)['\"]", "name"),
+    # @livewire('counter')     → class "counter"
+    ("class",    r"@livewire\s*\(\s*['\"](?P<name>[^'\"]+)['\"]", "name"),
+]
+
+# Compiled once at module load
+_BLADE_COMPILED: list[tuple[str, re.Pattern, str]] = [
+    (kind, re.compile(pattern, re.IGNORECASE), group)
+    for kind, pattern, group in _BLADE_SYMBOL_PATTERNS
+]
+
+
+def _parse_blade_symbols(source_bytes: bytes, filename: str) -> list[Symbol]:
+    """Extract Blade template symbols using regex.
+
+    Since tree-sitter has no Blade grammar, we scan for directives that
+    define meaningful structural elements: @extends, @section, @component,
+    @include*, @push, @stack, @slot, @yield, @livewire.
+    """
+    content = source_bytes.decode("utf-8", errors="replace")
+    lines = content.splitlines()
+
+    # Build a byte-offset → line-number lookup (1-indexed)
+    line_start_offsets: list[int] = []
+    offset = 0
+    for line in lines:
+        line_start_offsets.append(offset)
+        offset += len(line.encode("utf-8")) + 1  # +1 for \n
+
+    def byte_to_line(byte_pos: int) -> int:
+        lo, hi = 0, len(line_start_offsets) - 1
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if line_start_offsets[mid] <= byte_pos:
+                lo = mid
+            else:
+                hi = mid - 1
+        return lo + 1  # 1-indexed
+
+    symbols: list[Symbol] = []
+    seen: set[tuple[str, str]] = set()  # (kind, name) dedup per file
+
+    for kind, pattern, group in _BLADE_COMPILED:
+        for m in pattern.finditer(content):
+            name = m.group(group)
+            key = (kind, name)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            line_no = byte_to_line(m.start())
+            directive_text = m.group(0)
+            qualified_name = name
+
+            sym_bytes = directive_text.encode("utf-8")
+            symbols.append(Symbol(
+                id=make_symbol_id(filename, qualified_name, kind),
+                file=filename,
+                name=name,
+                qualified_name=qualified_name,
+                kind=kind,
+                language="blade",
+                signature=directive_text,
+                docstring="",
+                parent=None,
+                line=line_no,
+                end_line=line_no,
+                byte_offset=m.start(),
+                byte_length=len(sym_bytes),
+                content_hash=compute_content_hash(sym_bytes),
+            ))
+
+    # Sort by line number for stable output
+    symbols.sort(key=lambda s: s.line)
+    return symbols

--- a/src/jcodemunch_mcp/parser/languages.py
+++ b/src/jcodemunch_mcp/parser/languages.py
@@ -78,6 +78,7 @@ LANGUAGE_EXTENSIONS = {
     ".pl": "perl",
     ".pm": "perl",
     ".t": "perl",
+    ".blade.php": "blade",
 }
 
 
@@ -542,6 +543,25 @@ RUBY_SPEC = LanguageSpec(
 )
 
 
+# Blade (Laravel) specification
+# NOTE: No tree-sitter grammar is available for Blade templates.
+# Symbol extraction is performed by _parse_blade_symbols() in extractor.py
+# via regex scanning for Blade directives (@section, @component, @extends, etc.).
+# The fields below are intentionally empty.
+BLADE_SPEC = LanguageSpec(
+    ts_language="blade",
+    symbol_node_types={},
+    name_fields={},
+    param_fields={},
+    return_type_fields={},
+    docstring_strategy="preceding_comment",
+    decorator_node_type=None,
+    container_node_types=[],
+    constant_patterns=[],
+    type_patterns=[],
+)
+
+
 # Language registry
 LANGUAGE_REGISTRY = {
     "python": PYTHON_SPEC,
@@ -559,6 +579,7 @@ LANGUAGE_REGISTRY = {
     "elixir": ELIXIR_SPEC,
     "ruby": RUBY_SPEC,
     "perl": PERL_SPEC,
+    "blade": BLADE_SPEC,
 }
 
 logger = logging.getLogger(__name__)
@@ -589,3 +610,28 @@ def _apply_extra_extensions() -> None:
 
 
 _apply_extra_extensions()
+
+
+def get_language_for_path(path: str) -> "Optional[str]":
+    """Return the language name for a file path, handling compound extensions.
+
+    Checks compound suffixes (e.g. ``.blade.php``) before falling back to the
+    last extension (e.g. ``.php``).  This ensures Blade templates are not
+    mis-classified as plain PHP.
+
+    Args:
+        path: File path or name (e.g. ``resources/views/home.blade.php``).
+
+    Returns:
+        Language name string, or ``None`` if the extension is not recognised.
+    """
+    import os as _os
+    lower = path.lower()
+    base = _os.path.basename(lower)
+    first_dot = base.find(".")
+    if first_dot != -1:
+        compound = base[first_dot:]  # e.g. ".blade.php"
+        if compound in LANGUAGE_EXTENSIONS:
+            return LANGUAGE_EXTENSIONS[compound]
+    _, ext = _os.path.splitext(lower)
+    return LANGUAGE_EXTENSIONS.get(ext)

--- a/src/jcodemunch_mcp/tools/get_file_tree.py
+++ b/src/jcodemunch_mcp/tools/get_file_tree.py
@@ -110,8 +110,8 @@ def _build_tree(files: list[str], index, path_prefix: str, include_summaries: bo
                 lang = file_languages.get(file_path, "")
                 if not lang:
                     _, ext = os.path.splitext(file_path)
-                    from ..parser import LANGUAGE_EXTENSIONS
-                    lang = LANGUAGE_EXTENSIONS.get(ext, "")
+                    from ..parser import LANGUAGE_EXTENSIONS, get_language_for_path
+                    lang = get_language_for_path(file_path) or ""
                 
                 node = {
                     "path": file_path,

--- a/src/jcodemunch_mcp/tools/index_folder.py
+++ b/src/jcodemunch_mcp/tools/index_folder.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 
 logger = logging.getLogger(__name__)
 
-from ..parser import parse_file, LANGUAGE_EXTENSIONS
+from ..parser import parse_file, LANGUAGE_EXTENSIONS, get_language_for_path
 from ..summarizer import generate_file_summaries
 from ..security import (
     validate_path,
@@ -173,7 +173,7 @@ def discover_local_files(
 
         # Extension filter
         ext = file_path.suffix
-        if ext not in LANGUAGE_EXTENSIONS:
+        if ext not in LANGUAGE_EXTENSIONS and get_language_for_path(str(file_path)) is None:
             skip_counts["wrong_extension"] += 1
             logger.debug("SKIP wrong_extension: %s", rel_path)
             continue
@@ -296,7 +296,7 @@ def index_folder(
             except ValueError:
                 continue
             ext = file_path.suffix
-            if ext not in LANGUAGE_EXTENSIONS:
+            if ext not in LANGUAGE_EXTENSIONS and get_language_for_path(str(file_path)) is None:
                 continue
             current_files[rel_path] = content
 
@@ -324,7 +324,7 @@ def index_folder(
                 # Track file hashes for changed/new files even when symbol extraction yields none.
                 raw_files_subset[rel_path] = content
                 ext = os.path.splitext(rel_path)[1]
-                language = LANGUAGE_EXTENSIONS.get(ext)
+                language = get_language_for_path(rel_path)
                 if not language:
                     continue
                 try:
@@ -388,7 +388,7 @@ def index_folder(
         no_symbols_files: list[str] = []
         for rel_path, content in current_files.items():
             ext = os.path.splitext(rel_path)[1]
-            language = LANGUAGE_EXTENSIONS.get(ext)
+            language = get_language_for_path(rel_path)
             if not language:
                 continue
             try:

--- a/src/jcodemunch_mcp/tools/index_repo.py
+++ b/src/jcodemunch_mcp/tools/index_repo.py
@@ -10,7 +10,7 @@ import httpx
 
 from collections import defaultdict
 
-from ..parser import parse_file, LANGUAGE_EXTENSIONS
+from ..parser import parse_file, LANGUAGE_EXTENSIONS, get_language_for_path
 from ..security import is_secret_file, is_binary_extension, get_max_index_files
 from ..storage import IndexStore
 from ..summarizer import summarize_symbols, generate_file_summaries
@@ -136,7 +136,7 @@ def discover_source_files(
         
         # Extension filter
         _, ext = os.path.splitext(path)
-        if ext not in LANGUAGE_EXTENSIONS:
+        if get_language_for_path(path) is None:
             continue
 
         # Skip list
@@ -311,7 +311,7 @@ async def index_repo(
                 # Track file hashes for changed/new files even when symbol extraction yields none.
                 raw_files_subset[path] = content
                 _, ext = os.path.splitext(path)
-                language = LANGUAGE_EXTENSIONS.get(ext)
+                language = get_language_for_path(path)
                 if not language:
                     continue
                 try:
@@ -357,7 +357,7 @@ async def index_repo(
 
         for path, content in current_files.items():
             _, ext = os.path.splitext(path)
-            language = LANGUAGE_EXTENSIONS.get(ext)
+            language = get_language_for_path(path)
             if not language:
                 continue
             try:

--- a/tests/fixtures/blade/sample.blade.php
+++ b/tests/fixtures/blade/sample.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.app')
+
+@section('title', 'User Profile')
+
+@section('content')
+    <div class="container">
+        <h1>{{ $user->name }}</h1>
+
+        @include('partials.avatar', ['user' => $user])
+
+        @component('alert', ['type' => 'success'])
+            @slot('title')
+                Welcome back!
+            @endslot
+            Your profile has been updated.
+        @endcomponent
+
+        @push('scripts')
+            <script>console.log('profile loaded');</script>
+        @endpush
+    </div>
+@endsection
+
+@section('sidebar')
+    @include('partials.nav')
+    @livewire('user-stats', ['userId' => $user->id])
+@endsection
+
+@stack('scripts')
+
+@yield('extra')

--- a/tests/test_blade.py
+++ b/tests/test_blade.py
@@ -1,0 +1,110 @@
+"""Tests for Blade template symbol extraction."""
+
+import pytest
+from pathlib import Path
+
+from src.jcodemunch_mcp.parser.extractor import parse_file
+from src.jcodemunch_mcp.parser.languages import get_language_for_path, LANGUAGE_EXTENSIONS
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "blade" / "sample.blade.php"
+
+
+def _load():
+    return FIXTURE.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Extension / language detection
+# ---------------------------------------------------------------------------
+
+def test_blade_extension_detected():
+    assert get_language_for_path("resources/views/home.blade.php") == "blade"
+
+
+def test_blade_not_confused_with_php():
+    # Plain .php files must still resolve to php, not blade
+    assert get_language_for_path("app/Http/Controllers/HomeController.php") == "php"
+
+
+def test_blade_extension_in_registry():
+    assert ".blade.php" in LANGUAGE_EXTENSIONS
+    assert LANGUAGE_EXTENSIONS[".blade.php"] == "blade"
+
+
+# ---------------------------------------------------------------------------
+# Symbol extraction
+# ---------------------------------------------------------------------------
+
+def _symbols():
+    return parse_file(_load(), "resources/views/profile.blade.php", "blade")
+
+
+def test_blade_returns_symbols():
+    syms = _symbols()
+    assert len(syms) >= 5
+
+
+def test_blade_extends_extracted():
+    syms = _symbols()
+    kinds = {s.kind for s in syms}
+    names = {s.name for s in syms}
+    assert "type" in kinds
+    assert "layouts.app" in names
+
+
+def test_blade_sections_extracted():
+    syms = _symbols()
+    section_names = {s.name for s in syms if s.kind == "method"}
+    assert "content" in section_names
+    assert "sidebar" in section_names
+
+
+def test_blade_component_extracted():
+    syms = _symbols()
+    components = [s for s in syms if s.kind == "class"]
+    assert any(s.name == "alert" for s in components)
+
+
+def test_blade_include_extracted():
+    syms = _symbols()
+    includes = [s for s in syms if s.kind == "function"]
+    names = {s.name for s in includes}
+    assert "partials.avatar" in names
+    assert "partials.nav" in names
+
+
+def test_blade_push_extracted():
+    syms = _symbols()
+    pushes = [s for s in syms if s.kind == "constant" and s.name == "scripts"]
+    assert len(pushes) >= 1
+
+
+def test_blade_livewire_extracted():
+    syms = _symbols()
+    livewire = [s for s in syms if s.kind == "class" and s.name == "user-stats"]
+    assert len(livewire) == 1
+
+
+def test_blade_symbols_have_line_numbers():
+    syms = _symbols()
+    for s in syms:
+        assert s.line >= 1
+
+
+def test_blade_symbols_sorted_by_line():
+    syms = _symbols()
+    lines = [s.line for s in syms]
+    assert lines == sorted(lines)
+
+
+def test_blade_symbol_ids_unique():
+    syms = _symbols()
+    ids = [s.id for s in syms]
+    assert len(ids) == len(set(ids))
+
+
+def test_blade_language_field():
+    syms = _symbols()
+    for s in syms:
+        assert s.language == "blade"

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -764,7 +764,7 @@ wheels = [
 
 [[package]]
 name = "jcodemunch-mcp"
-version = "0.2.13"
+version = "0.2.22"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -790,6 +790,13 @@ test = [
     { name = "pytest-cov" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anthropic", marker = "extra == 'all'", specifier = ">=0.40.0" },
@@ -805,6 +812,13 @@ requires-dist = [
     { name = "tree-sitter-language-pack", specifier = ">=0.7.0,<1.0.0" },
 ]
 provides-extras = ["anthropic", "gemini", "all", "test"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+]
 
 [[package]]
 name = "jiter"


### PR DESCRIPTION
Adds symbol extraction for Laravel Blade templates (.blade.php) using a regex-based parser.

Since no tree-sitter grammar exists for Blade, this uses compiled regex patterns to extract meaningful structural directives as symbols:

@extends → layout inheritance (type)
@section / @yield / @slot → template sections (method)
@component / @livewire → component usage (class)
@include / @includeIf / @includeWhen / @includeUnless / @includeFirst → partial includes (function)
@push / @stack → asset stacks (constant)
Implementation notes:

Patterns compiled once at module load for performance
Per-file deduplication so repeated includes don't create duplicate symbols
Proper byte-offset tracking for accurate line numbers
@livewire support extends usefulness to Livewire-based projects
Tested against a real Laravel 12 project — 151 Blade files, 824 symbols extracted successfully.

Blade is the default templating engine for Laravel, which is one of the most widely used PHP frameworks. This makes jCodeMunch useful for full-stack Laravel development, not just the PHP backend.