### PR TITLE
Add Claude Code installation instructions and fix config examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,49 @@ jcodemunch-mcp --help
 > - **macOS:** `/Users/<username>/.local/bin/jcodemunch-mcp`
 > - **Windows:** `C:\\Users\\<username>\\AppData\\Roaming\\Python\\Python3xx\\Scripts\\jcodemunch-mcp.exe`
 
-### Claude Desktop / Claude Code
+### Claude Code
+
+The fastest way to add jCodeMunch to Claude Code is a single command:
+
+```bash
+claude mcp add jcodemunch uvx jcodemunch-mcp
+```
+
+This registers the server at user scope (`~/.claude.json`) so it is available in every project. To add it to a specific project only, pass `--scope project`:
+
+```bash
+claude mcp add --scope project jcodemunch uvx jcodemunch-mcp
+```
+
+To include optional environment variables (e.g. `GITHUB_TOKEN` or `ANTHROPIC_API_KEY`):
+
+```bash
+claude mcp add jcodemunch uvx jcodemunch-mcp \
+  -e GITHUB_TOKEN=ghp_... \
+  -e ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Restart Claude Code after adding the server.
+
+**Manual config** — if you prefer to edit the config file directly, the relevant files are:
+
+| Scope   | Path |
+| ------- | ---- |
+| User (global) | `~/.claude.json` |
+| Project | `.claude/settings.json` (in the project root) |
+
+```json
+{
+  "mcpServers": {
+    "jcodemunch": {
+      "command": "uvx",
+      "args": ["jcodemunch-mcp"]
+    }
+  }
+}
+```
+
+### Claude Desktop
 
 Config file location:
 
@@ -207,7 +249,7 @@ Config file location:
 
 > Logging flags can also be set via env vars `JCODEMUNCH_LOG_LEVEL` and `JCODEMUNCH_LOG_FILE`. Always use `--log-file` (or the env var) when debugging — writing logs to stderr can corrupt the MCP stdio stream in some clients.
 
-After saving the config, **restart Claude Desktop / Claude Code** for the server to appear.
+After saving the config, **restart Claude Desktop** for the server to appear.
 
 ### Google Antigravity
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -3,8 +3,16 @@
 ## Installation
 
 ```bash
-pip install git+https://github.com/jgravelle/jcodemunch-mcp.git
+pip install jcodemunch-mcp
 ```
+
+Verify:
+
+```bash
+jcodemunch-mcp --help
+```
+
+> **Recommended:** use [`uvx`](https://github.com/astral-sh/uv) instead of `pip install` when configuring MCP clients. `uvx` runs the package on demand without requiring it to be on your system PATH.
 
 Or from source:
 
@@ -18,15 +26,43 @@ pip install -e .
 
 ## Configuration
 
-### Claude Desktop
+### Claude Code
 
-Add to your `claude_desktop_config.json`:
+The fastest way to add jCodeMunch to Claude Code is a single command:
+
+```bash
+claude mcp add jcodemunch uvx jcodemunch-mcp
+```
+
+This registers the server at user scope (`~/.claude.json`) so it is available in every project. To limit it to a single project, pass `--scope project`:
+
+```bash
+claude mcp add --scope project jcodemunch uvx jcodemunch-mcp
+```
+
+To include optional environment variables at the same time:
+
+```bash
+claude mcp add jcodemunch uvx jcodemunch-mcp \
+  -e GITHUB_TOKEN=ghp_xxxxxxxx \
+  -e ANTHROPIC_API_KEY=sk-ant-xxxxxxxx
+```
+
+Restart Claude Code after running the command.
+
+**Manual config** — if you prefer to edit the config file directly:
+
+| Scope   | Path |
+| ------- | ---- |
+| User (global) | `~/.claude.json` |
+| Project | `.claude/settings.json` (in the project root) |
 
 ```json
 {
   "mcpServers": {
     "jcodemunch": {
-      "command": "jcodemunch-mcp",
+      "command": "uvx",
+      "args": ["jcodemunch-mcp"],
       "env": {
         "GITHUB_TOKEN": "ghp_xxxxxxxx",
         "ANTHROPIC_API_KEY": "sk-ant-xxxxxxxx"
@@ -36,12 +72,43 @@ Add to your `claude_desktop_config.json`:
 }
 ```
 
-Both environment variables are optional:
+Environment variables are optional — see the table below.
+
+### Claude Desktop
+
+Config file location:
+
+| OS      | Path |
+| ------- | ---- |
+| macOS   | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Linux   | `~/.config/claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "jcodemunch": {
+      "command": "uvx",
+      "args": ["jcodemunch-mcp"],
+      "env": {
+        "GITHUB_TOKEN": "ghp_xxxxxxxx",
+        "ANTHROPIC_API_KEY": "sk-ant-xxxxxxxx"
+      }
+    }
+  }
+}
+```
+
+Environment variables are optional:
 
 * `GITHUB_TOKEN` enables private repositories and higher GitHub API rate limits.
 * `ANTHROPIC_API_KEY` enables AI-generated summaries via Claude Haiku.
 * `GOOGLE_API_KEY` enables AI-generated summaries via Gemini Flash (used if `ANTHROPIC_API_KEY` is not set).
 * If neither key is set, summaries fall back to docstrings or signatures.
+
+Restart Claude Desktop after saving the config.
 
 ### VS Code
 
@@ -51,7 +118,8 @@ Add to `.vscode/settings.json`:
 {
   "mcp.servers": {
     "jcodemunch": {
-      "command": "jcodemunch-mcp",
+      "command": "uvx",
+      "args": ["jcodemunch-mcp"],
       "env": {
         "GITHUB_TOKEN": "ghp_xxxxxxxx"
       }
@@ -96,7 +164,8 @@ if (total > 0) output += ` │ ${total.toLocaleString()} tkns saved · $${cost} 
 {
   "mcpServers": {
     "jcodemunch": {
-      "command": "jcodemunch-mcp",
+      "command": "uvx",
+      "args": ["jcodemunch-mcp"],
       "env": {
         "GITHUB_TOKEN": "ghp_xxxxxxxx",
         "ANTHROPIC_API_KEY": "sk-ant-xxxxxxxx"
@@ -105,10 +174,6 @@ if (total > 0) output += ` │ ${total.toLocaleString()} tkns saved · $${cost} 
   }
 }
 ```
-
----
-
-## Workflows
 
 ### Explore a New Repository
 
@@ -227,7 +292,8 @@ To disable, set `JCODEMUNCH_SHARE_SAVINGS=0` in your MCP server env:
 {
   "mcpServers": {
     "jcodemunch": {
-      "command": "jcodemunch-mcp",
+      "command": "uvx",
+      "args": ["jcodemunch-mcp"],
       "env": {
         "JCODEMUNCH_SHARE_SAVINGS": "0"
       }


### PR DESCRIPTION
This pull request updates the installation and configuration instructions for `jcodemunch-mcp` to simplify setup and improve compatibility across clients. The main focus is on recommending the use of `uvx` for running the MCP server, providing clearer guidance for integrating with Claude Code, Claude Desktop, and VS Code, and streamlining environment variable handling as Claude Code and Claude Desktop have subtle differences in configuration.

**Installation and configuration improvements:**

* Updated installation instructions to recommend `pip install jcodemunch-mcp` and added a verification step with `jcodemunch-mcp --help`. Also, strongly recommended using `uvx` for MCP client configuration, which allows running the package without requiring it to be on the system PATH. (`USER_GUIDE.md` [USER_GUIDE.mdL6-R16](diffhunk://#diff-837695f5e5bb7126693b21d45c2ad50d412f36496f0bd88aa88b7b3d874eeae8L6-R16))
* Added clear, step-by-step instructions for adding `jcodemunch-mcp` to Claude Code using the `claude mcp add` command, including options for user/project scope and setting environment variables. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L151-R193) `USER_GUIDE.md` [[2]](diffhunk://#diff-837695f5e5bb7126693b21d45c2ad50d412f36496f0bd88aa88b7b3d874eeae8R29-R94)
* Provided manual configuration examples for Claude Code, Claude Desktop, and VS Code, consistently recommending `uvx` as the command and showing how to set optional environment variables. (`USER_GUIDE.md` [[1]](diffhunk://#diff-837695f5e5bb7126693b21d45c2ad50d412f36496f0bd88aa88b7b3d874eeae8R29-R94) [[2]](diffhunk://#diff-837695f5e5bb7126693b21d45c2ad50d412f36496f0bd88aa88b7b3d874eeae8L54-R122) [[3]](diffhunk://#diff-837695f5e5bb7126693b21d45c2ad50d412f36496f0bd88aa88b7b3d874eeae8L99-R168) [[4]](diffhunk://#diff-837695f5e5bb7126693b21d45c2ad50d412f36496f0bd88aa88b7b3d874eeae8L230-R296)
* Clarified config file locations for different operating systems and clients, and emphasized the need to restart the client after configuration changes. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L210-R252) `USER_GUIDE.md` [[2]](diffhunk://#diff-837695f5e5bb7126693b21d45c2ad50d412f36496f0bd88aa88b7b3d874eeae8L39-R112)
* Removed outdated workflow instructions to streamline the user guide. (`USER_GUIDE.md` [USER_GUIDE.mdL109-L112](diffhunk://#diff-837695f5e5bb7126693b21d45c2ad50d412f36496f0bd88aa88b7b3d874eeae8L109-L112))