### PR TITLE
Improves Swift parsing and adds Xcode ignore rules

### DIFF
--- a/src/jcodemunch_mcp/parser/languages.py
+++ b/src/jcodemunch_mcp/parser/languages.py
@@ -461,21 +461,27 @@ SWIFT_SPEC = LanguageSpec(
         "function_declaration": "function",
         "class_declaration": "class",    # covers class, struct, enum, extension
         "protocol_declaration": "type",
+        "typealias_declaration": "type",
         "init_declaration": "method",
+        "deinit_declaration": "method",
+        "property_declaration": "constant",
     },
     name_fields={
         "function_declaration": "name",  # simple_identifier child
         "class_declaration": "name",     # type_identifier child
         "protocol_declaration": "name",  # type_identifier child
+        "typealias_declaration": "name", # user_type child
         "init_declaration": "name",      # "init" keyword token
+        "deinit_declaration": "name",    # "deinit" keyword token
+        "property_declaration": "name",  # pattern child
     },
     param_fields={},  # Swift params are unnamed children; signature captured via source range
     return_type_fields={},  # return type shares field "name" with function identifier
     docstring_strategy="preceding_comment",  # /// and /* */ doc comments
     decorator_node_type=None,
     container_node_types=["class_declaration", "protocol_declaration"],
-    constant_patterns=["property_declaration"],  # let/var at file scope
-    type_patterns=["protocol_declaration"],
+    constant_patterns=[],  # property_declaration handled via symbol_node_types
+    type_patterns=["protocol_declaration", "typealias_declaration"],
 )
 
 

--- a/src/jcodemunch_mcp/security.py
+++ b/src/jcodemunch_mcp/security.py
@@ -306,4 +306,5 @@ SKIP_PATTERNS = [
     ".min.js", ".min.ts", ".bundle.js",
     "package-lock.json", "yarn.lock", "go.sum",
     "generated/", "proto/",
+    "*.xcodeproj/", "*.xcworkspace/", "DerivedData/", ".build/",
 ]

--- a/tests/test_swift_parser.py
+++ b/tests/test_swift_parser.py
@@ -1,0 +1,109 @@
+"""Tests for Swift and SwiftUI parsing."""
+
+import pytest
+from jcodemunch_mcp.parser import parse_file, LANGUAGE_REGISTRY
+import jcodemunch_mcp
+print(f"DEBUG: jcodemunch_mcp file: {jcodemunch_mcp.__file__}")
+print(f"DEBUG: swift in registry: {'swift' in LANGUAGE_REGISTRY}")
+
+SWIFT_SOURCE = '''
+struct MyStruct {
+    var count: Int = 0
+    func increment() { count += 1 }
+}
+
+class MyClass {
+    let name: String
+    init(name: String) { self.name = name }
+}
+
+enum MyEnum {
+    case one, two
+}
+
+protocol MyProtocol {
+    func doSomething()
+}
+
+extension MyStruct {
+    func decrement() { count -= 1 }
+}
+
+typealias MyInt = Int
+
+func globalFunc() {}
+let GLOBAL_CONST = 42
+'''
+
+SWIFTUI_SOURCE = '''
+import SwiftUI
+
+struct MyView: View {
+    @State private var count = 0
+    
+    var body: some View {
+        VStack {
+            Text("Count: \\(count)")
+            Button("Increment") {
+                count += 1
+            }
+        }
+    }
+}
+'''
+
+def test_parse_swift():
+    """Test basic Swift construct extraction."""
+    symbols = parse_file(SWIFT_SOURCE, "test.swift", "swift")
+    for s in symbols:
+        print(f"DEBUG SYMBOL: {s.name} ({s.kind}) line {s.line}")
+    
+    # Check struct
+    structs = [s for s in symbols if s.kind == "class" and s.name == "MyStruct"]
+    assert len(structs) >= 1
+    
+    # Check class
+    classes = [s for s in symbols if s.kind == "class" and s.name == "MyClass"]
+    assert len(classes) == 1
+    
+    # Check enum
+    enums = [s for s in symbols if s.kind == "class" and s.name == "MyEnum"]
+    assert len(enums) == 1
+    
+    # Check protocol
+    protocols = [s for s in symbols if s.kind == "type" and s.name == "MyProtocol"]
+    assert len(protocols) == 1
+    
+    # Check extension
+    extensions = [s for s in symbols if s.kind == "class" and s.name == "MyStruct" and s.line >= 20]
+    assert len(extensions) == 1
+    
+    # Check typealias
+    aliases = [s for s in symbols if s.kind == "type" and s.name == "MyInt"]
+    assert len(aliases) == 1
+    
+    # Check global function
+    funcs = [s for s in symbols if s.kind == "function" and s.name == "globalFunc"]
+    assert len(funcs) == 1
+    
+    # Check global constant
+    consts = [s for s in symbols if s.kind == "constant" and s.name == "GLOBAL_CONST"]
+    assert len(consts) == 1
+
+def test_parse_swiftui():
+    """Test SwiftUI view and property wrapper extraction."""
+    symbols = parse_file(SWIFTUI_SOURCE, "View.swift", "swift")
+    for s in symbols:
+        print(f"DEBUG SwiftUI SYMBOL: {s.name} ({s.kind}) line {s.line}")
+    
+    # Check SwiftUI struct
+    views = [s for s in symbols if s.kind == "class" and s.name == "MyView"]
+    assert len(views) == 1
+    
+    # Check body property
+    bodies = [s for s in symbols if s.name == "body" and s.parent == views[0].id]
+    assert len(bodies) == 1
+    
+    # Check @State property (currently extracted as generic property/constant)
+    states = [s for s in symbols if s.name == "count" and s.parent == views[0].id]
+    assert len(states) == 1


### PR DESCRIPTION
Enhances Swift language specification to correctly identify `typealias`, `deinit`, and `property_declaration` as distinct symbols.

Adds patterns to skip common Xcode project and build directories, improving scan efficiency.

Introduces unit tests for Swift and SwiftUI parsing to validate symbol extraction.