### PR TITLE
feat: add ANTHROPIC_MODEL and GOOGLE_MODEL env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,9 @@ For **LM Studio**, ensure the Local Server is running (usually on port 1234):
 | `GITHUB_TOKEN`              | GitHub API auth           | No       |
 | `ANTHROPIC_API_KEY`         | Symbol summaries via Claude Haiku (takes priority) | No       |
 | `ANTHROPIC_BASE_URL`        | Third-party Anthropic-compatible endpoints (e.g. z.ai) | No       |
+| `ANTHROPIC_MODEL`           | Model name for Claude summaries (default: `claude-haiku-4-5-20251001`) | No       |
 | `GOOGLE_API_KEY`            | Symbol summaries via Gemini Flash | No       |
+| `GOOGLE_MODEL`              | Model name for Gemini summaries (default: `gemini-2.5-flash-lite`) | No       |
 | `OPENAI_API_BASE`           | Base URL for local LLMs (e.g. `http://localhost:11434/v1`) | No |
 | `OPENAI_API_KEY`            | API key for local LLMs (default: `local-llm`) | No |
 | `OPENAI_MODEL`              | Model name for local LLMs (default: `qwen3-coder`) | No |

--- a/SPEC.md
+++ b/SPEC.md
@@ -278,5 +278,7 @@ All errors return:
 | ------------------- | -------------------------------------------------------- | -------- |
 | `GITHUB_TOKEN`      | GitHub API authentication (higher limits, private repos) | No       |
 | `ANTHROPIC_API_KEY` | AI summarization via Claude Haiku (takes priority if both keys set) | No       |
+| `ANTHROPIC_MODEL`   | Model name for Claude summaries (default: `claude-haiku-4-5-20251001`) | No       |
 | `GOOGLE_API_KEY`    | AI summarization via Gemini Flash (used if `ANTHROPIC_API_KEY` not set) | No       |
+| `GOOGLE_MODEL`      | Model name for Gemini summaries (default: `gemini-2.5-flash-lite`) | No       |
 | `CODE_INDEX_PATH`   | Custom storage path (default: `~/.code-index/`)          | No       |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -105,7 +105,9 @@ Environment variables are optional:
 
 * `GITHUB_TOKEN` enables private repositories and higher GitHub API rate limits.
 * `ANTHROPIC_API_KEY` enables AI-generated summaries via Claude Haiku.
+* `ANTHROPIC_MODEL` overrides the Claude model (default: `claude-haiku-4-5-20251001`).
 * `GOOGLE_API_KEY` enables AI-generated summaries via Gemini Flash (used if `ANTHROPIC_API_KEY` is not set).
+* `GOOGLE_MODEL` overrides the Gemini model (default: `gemini-2.5-flash-lite`).
 * If neither key is set, summaries fall back to docstrings or signatures.
 
 Restart Claude Desktop after saving the config.

--- a/src/jcodemunch_mcp/summarizer/batch_summarize.py
+++ b/src/jcodemunch_mcp/summarizer/batch_summarize.py
@@ -63,6 +63,7 @@ class BatchSummarizer:
             from anthropic import Anthropic
             api_key = os.environ.get("ANTHROPIC_API_KEY")
             if api_key:
+                self.model = os.environ.get("ANTHROPIC_MODEL", self.model)
                 base_url = os.environ.get("ANTHROPIC_BASE_URL")
                 kwargs = {"api_key": api_key}
                 if base_url:
@@ -182,7 +183,7 @@ class BatchSummarizer:
 class GeminiBatchSummarizer:
     """AI-based batch summarization using Google Gemini Flash (Tier 2)."""
 
-    model: str = "gemini-1.5-flash"
+    model: str = "gemini-2.5-flash-lite"
     max_tokens_per_batch: int = 500
 
     def __post_init__(self):
@@ -195,6 +196,7 @@ class GeminiBatchSummarizer:
             import google.generativeai as genai
             api_key = os.environ.get("GOOGLE_API_KEY")
             if api_key:
+                self.model = os.environ.get("GOOGLE_MODEL", self.model)
                 genai.configure(api_key=api_key)
                 self.client = genai.GenerativeModel(self.model)
         except ImportError:


### PR DESCRIPTION
## Summary
- Add `ANTHROPIC_MODEL` env var to override the default Claude model (`claude-haiku-4-5-20251001`) used for symbol summarization
- Add `GOOGLE_MODEL` env var to override the default Gemini model used for symbol summarization
- Change default Gemini model from `gemini-1.5-flash` to `gemini-2.5-flash-lite` — `gemini-1.5-flash` returns 404s and is no longer available
- Consistent with the existing `OPENAI_MODEL` pattern
- Document new env vars in README, SPEC, and USER_GUIDE

## Test plan
- [ ] Set `ANTHROPIC_MODEL=claude-opus-4-6` and verify summarizer uses that model
- [ ] Set `GOOGLE_MODEL=gemini-2.0-flash` and verify summarizer uses that model
- [ ] Verify `gemini-2.5-flash-lite` works as the default without 404s
- [ ] Verify existing behavior unchanged when vars are unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)