### PR TITLE
feat: speed up folder indexing

### DIFF
--- a/src/jcodemunch_mcp/security.py
+++ b/src/jcodemunch_mcp/security.py
@@ -150,8 +150,8 @@ SKIP_DIRECTORIES = [
     "node_modules", "vendor", "venv", ".venv", "__pycache__",
     "dist", "build", ".git", ".tox", ".mypy_cache", "target",
     ".gradle", "test_data", "testdata", "fixtures", "snapshots",
-    "migrations", "generated", "proto", ".*.xcodeproj", 
-    ".*.xcworkspace", "DerivedData", ".build"
+    "migrations", "generated", "proto", "[^/]*.xcodeproj", 
+    "[^/]*.xcworkspace", "DerivedData", ".build"
 ]
 
 SKIP_FILES = [

--- a/src/jcodemunch_mcp/tools/index_folder.py
+++ b/src/jcodemunch_mcp/tools/index_folder.py
@@ -33,7 +33,7 @@ from ..storage.index_store import _file_hash, _get_git_head
 from ..summarizer import summarize_symbols
 
 SKIP_DIRS_REGEX = re.compile("^(" + "|".join(SKIP_DIRECTORIES) + ")")
-SKIP_FILES_REGEX = re.compile("^(" + "|".join(SKIP_FILES) + ")")
+SKIP_FILES_REGEX = re.compile("(" + "|".join(SKIP_FILES) + ")$")
 
 def get_filtered_files(path: str) -> Generator[str, None, None]:
     """Generator function to filter directories and files"""


### PR DESCRIPTION
**Problem**: Folder indexing takes longer than it should due to walking and processing files from directories that are in the skip list.

This change adds a generator function to filter out directories and files from the skip list. When testing on a vite+react project, indexing time went from 12.5 minutes to just under 30 seconds. 