### PR TITLE
fix: add empty resources/prompts handlers for Windsurf compatibility

### DIFF
--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from mcp.server import Server
-from mcp.types import Tool, TextContent
+from mcp.types import Tool, TextContent, Resource
 
 from . import __version__
 from .tools.index_repo import index_repo
@@ -329,6 +329,18 @@ async def list_tools() -> list[Tool]:
             }
         ),
     ]
+
+
+@server.list_resources()
+async def list_resources() -> list[Resource]:
+    """Return empty resource list for client compatibility (e.g. Windsurf)."""
+    return []
+
+
+@server.list_prompts()
+async def list_prompts() -> list:
+    """Return empty prompt list for client compatibility (e.g. Windsurf)."""
+    return []
 
 
 @server.call_tool()


### PR DESCRIPTION
Windsurf Plugin in JetBrains Pycharm (and perhaps Windsurf IDE too) calls `resources/list` during MCP initialization 
before attempting to use tools. When the server doesn't handle this method, 
Windsurf receives an error and refuses to call any tools for the rest of 
the session — even though `tools/list` succeeds and Windsurf displays 
the correct tool count in its settings panel.

### Reproduction steps

1. Configure jcodemunch-mcp in Windsurf's `mcp_config.json`
2. Ask Windsurf to use any jcodemunch tool (e.g. `index_folder`)
3. Windsurf calls `resources/list` first, gets an error, and gives up

### What Windsurf logs show
```
initialize       → OK
tools/list       → OK (12 tools found)
resources/list   → ERROR: Unknown method
```

After the error, Windsurf's AI says "I don't have access to MCP tools" 
despite showing them in the Windsurf plugin settings (inside PyCharm settings).

## Fix

Two no-op handlers that return empty lists:

- `@server.list_resources()` → returns `[]`
- `@server.list_prompts()` → returns `[]`

Plus `Resource` added to the `mcp.types` import.

## Impact

- **Zero behavioral change** for existing clients (Claude Desktop, VS Code, 
  Claude Code, OpenCode) — they either don't probe these methods or already 
  handle empty responses gracefully.
- **Fixes Windsurf** — the initialization sequence completes without errors, 
  and tools become callable.

This follows the same pattern used by other MCP servers to ensure broad 
client compatibility.

Tested with Windsurf plugin in PyCharm (JetBrains).

[PR author Claude Opus 4.6]