### PR TITLE
feat: cross-platform file locking and atomic writes for token tracker

### DIFF
--- a/src/jcodemunch_mcp/storage/token_tracker.py
+++ b/src/jcodemunch_mcp/storage/token_tracker.py
@@ -14,6 +14,8 @@ Set JCODEMUNCH_SHARE_SAVINGS=0 to disable.
 
 import json
 import os
+import sys
+import tempfile
 import threading
 import uuid
 from pathlib import Path
@@ -22,6 +24,9 @@ from typing import Optional
 _SAVINGS_FILE = "_savings.json"
 _BYTES_PER_TOKEN = 4  # ~4 bytes per token (rough but consistent)
 _TELEMETRY_URL = "https://j.gravelle.us/APIs/savings/post.php"
+
+# In-process lock — protects against concurrent async tasks within one server
+_lock = threading.Lock()
 
 # Input token pricing ($ per token). Update as models reprice.
 PRICING = {
@@ -34,6 +39,31 @@ def _savings_path(base_path: Optional[str] = None) -> Path:
     root = Path(base_path) if base_path else Path.home() / ".code-index"
     root.mkdir(parents=True, exist_ok=True)
     return root / _SAVINGS_FILE
+
+
+def _lock_file(f):
+    """Acquire an exclusive lock on an open file. Cross-platform."""
+    if sys.platform == "win32":
+        import msvcrt
+        # Ensure file has content and position is at byte 0 for msvcrt
+        f.write("L")
+        f.flush()
+        f.seek(0)
+        msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
+    else:
+        import fcntl
+        fcntl.flock(f, fcntl.LOCK_EX)
+
+
+def _unlock_file(f):
+    """Release the exclusive lock on an open file. Cross-platform."""
+    if sys.platform == "win32":
+        import msvcrt
+        f.seek(0)
+        msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+        fcntl.flock(f, fcntl.LOCK_UN)
 
 
 def _get_or_create_anon_id(data: dict) -> str:
@@ -59,26 +89,78 @@ def _share_savings(delta: int, anon_id: str) -> None:
     threading.Thread(target=_post, daemon=True).start()
 
 
-def record_savings(tokens_saved: int, base_path: Optional[str] = None) -> int:
-    """Add tokens_saved to the running total. Returns new cumulative total."""
-    path = _savings_path(base_path)
+def _read_locked(path: Path) -> dict:
+    """Read and parse the savings JSON, returning {} on any failure."""
     try:
-        data = json.loads(path.read_text()) if path.exists() else {}
-    except Exception:
-        data = {}
-
-    delta = max(0, tokens_saved)
-    total = data.get("total_tokens_saved", 0) + delta
-    data["total_tokens_saved"] = total
-
-    if delta > 0 and os.environ.get("JCODEMUNCH_SHARE_SAVINGS", "1") != "0":
-        anon_id = _get_or_create_anon_id(data)
-        _share_savings(delta, anon_id)
-
-    try:
-        path.write_text(json.dumps(data))
+        if path.exists():
+            return json.loads(path.read_text())
     except Exception:
         pass
+    return {}
+
+
+def _atomic_write(path: Path, data: dict) -> None:
+    """Write JSON atomically via temp file + rename (prevents corruption)."""
+    try:
+        content = json.dumps(data)
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+        closed = False
+        try:
+            os.write(fd, content.encode())
+            os.close(fd)
+            closed = True
+            os.replace(tmp, str(path))
+        except Exception:
+            if not closed:
+                os.close(fd)
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except Exception:
+        pass
+
+
+def record_savings(tokens_saved: int, base_path: Optional[str] = None) -> int:
+    """Add tokens_saved to the running total. Returns new cumulative total.
+
+    Uses a cross-process file lock + in-process threading lock to prevent
+    concurrent read-modify-write races that silently drop accumulated savings.
+    """
+    delta = max(0, tokens_saved)
+    if delta == 0:
+        return get_total_saved(base_path)
+
+    path = _savings_path(base_path)
+    lock_path = path.with_suffix(".lock")
+
+    with _lock:  # in-process safety
+        try:
+            # Cross-process lock via a dedicated lock file
+            with open(lock_path, "a+") as lf:
+                _lock_file(lf)
+                try:
+                    data = _read_locked(path)
+                    total = data.get("total_tokens_saved", 0) + delta
+                    data["total_tokens_saved"] = total
+
+                    if os.environ.get("JCODEMUNCH_SHARE_SAVINGS", "1") != "0":
+                        anon_id = _get_or_create_anon_id(data)
+                        _share_savings(delta, anon_id)
+
+                    _atomic_write(path, data)
+                finally:
+                    _unlock_file(lf)
+        except Exception:
+            # Last resort: unlocked write (better than losing data silently)
+            try:
+                data = _read_locked(path)
+                total = data.get("total_tokens_saved", 0) + delta
+                data["total_tokens_saved"] = total
+                _atomic_write(path, data)
+            except Exception:
+                total = delta
 
     return total
 


### PR DESCRIPTION
## Summary
- Cross-process file lock (`fcntl` on Unix, `msvcrt` on Windows) prevents concurrent MCP server instances from silently dropping accumulated token savings
- In-process threading lock for async task safety
- Atomic writes via `tempfile.mkstemp()` + `os.replace()` instead of naive `path.write_text()` — prevents corruption on crash/kill
- Early return on zero delta to avoid unnecessary I/O

## Problem
When multiple MCP server instances run concurrently (e.g., parallel Claude Code sessions), the `_savings.json` file experiences read-modify-write races. Two processes read the same total, each adds their delta independently, and the last writer wins — silently losing the other's accumulated savings.

The naive `path.write_text()` also risks corruption if the process is killed mid-write.

## Test plan
- [ ] Verify savings accumulate correctly with single MCP server
- [ ] Verify no savings loss with 2+ concurrent MCP server instances
- [ ] Verify atomic write handles process kill during write (no corruption)
- [ ] Verify cross-platform: works on both Unix (fcntl) and Windows (msvcrt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)