### PR TITLE
fix: anchor SKIP_DIRS_REGEX to prevent prefix-matching subdirectories

### DIFF
--- a/src/jcodemunch_mcp/tools/index_folder.py
+++ b/src/jcodemunch_mcp/tools/index_folder.py
@@ -34,7 +34,7 @@ from ..storage import IndexStore
 from ..storage.index_store import _file_hash, _get_git_head
 from ..summarizer import summarize_symbols
 
-SKIP_DIRS_REGEX = re.compile("^(" + "|".join(SKIP_DIRECTORIES) + ")")
+SKIP_DIRS_REGEX = re.compile("^(" + "|".join(SKIP_DIRECTORIES) + ")$")
 SKIP_FILES_REGEX = re.compile("(" + "|".join(re.escape(p) for p in SKIP_FILES) + ")$")
 
 def get_filtered_files(path: str) -> Generator[str, None, None]:


### PR DESCRIPTION
## Summary

- Adds missing `$` end anchor to `SKIP_DIRS_REGEX` in `index_folder.py`, fixing silent directory pruning when a skip entry (e.g. `"proto"`) prefix-matches unrelated subdirectory names (e.g. `protoc-gen-protosource`, `protobinaryserializer`)

Fixes #108

## Root cause

The regex `^(node_modules|vendor|...|proto|...)` had no end anchor, so `re.match("proto")` would match any directory **starting with** `"proto"`. Since `os.walk` directory pruning (`dirnames[:] = ...`) removes entire subtrees, files in those directories were never seen — and never reported in any skip category.

## Test plan

- [x] Verified regex now correctly skips `proto` but allows `protoc-gen-protosource`, `protobinaryserializer`, `protojsonserializer`
- [x] Also verified `.github` is no longer incorrectly matched by `.git`, `buildtools` not matched by `build`, etc.
- [x] All 608 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)