### PR TITLE
fix: use signal.signal() fallback on Windows for watch subcommand

### DIFF
--- a/src/jcodemunch_mcp/watcher.py
+++ b/src/jcodemunch_mcp/watcher.py
@@ -133,9 +133,13 @@ async def watch_folders(
 
     # Handle graceful shutdown
     stop_event = asyncio.Event()
-    loop = asyncio.get_event_loop()
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        loop.add_signal_handler(sig, stop_event.set)
+    if sys.platform == "win32":
+        signal.signal(signal.SIGINT, lambda s, f: stop_event.set())
+        signal.signal(signal.SIGTERM, lambda s, f: stop_event.set())
+    else:
+        loop = asyncio.get_event_loop()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(sig, stop_event.set)
 
     tasks = [
         asyncio.create_task(


### PR DESCRIPTION
loop.add_signal_handler() raises NotImplementedError on Windows (ProactorEventLoop). 
This makes the watch subcommand unusable on Windows entirely.

Falls back to signal.signal() on Windows, which works cross-platform. Keeps add_signal_handler() on Unix-like systems where it's preferred (async-safe).

Tested on Windows 11 — watcher starts, detects changes, and shuts down cleanly on Ctrl+C.
Fixes the crash introduced in #113 (v1.6.1).