### PR TITLE
feat: auto-discover and watch Claude Code worktrees

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -316,7 +316,17 @@ Enhancements to incremental indexing include:
 
 ### Watch mode
 
-The watch subcommand continuously monitors one or more directories using `watchfiles` and triggers incremental reindexing on change. This is useful for large repositories and multi-worktree development flows where manual reindexing would be inefficient.
+The `watch` subcommand continuously monitors one or more directories using `watchfiles` and triggers incremental reindexing on change. This is useful for large repositories and multi-worktree development flows where manual reindexing would be inefficient.
+
+### watch-claude mode
+
+The `watch-claude` subcommand extends watch mode for Claude Code's worktree workflow. Claude Code creates git worktrees when opening parallel sessions, and removes them when sessions end. Rather than requiring users to manually pass paths, `watch-claude` discovers worktrees automatically via two complementary mechanisms:
+
+* **Hook-driven discovery** — Claude Code's `WorktreeCreate` and `WorktreeRemove` hooks call `jcodemunch-mcp hook-event create|remove`, which appends events to a JSONL manifest at `~/.claude/jcodemunch-worktrees.jsonl`. The `watch-claude` process watches this file with `watchfiles` and reacts to new lines instantly — no polling.
+
+* **Git-based discovery** — When `--repos` paths are specified, `watch-claude` periodically runs `git worktree list --porcelain` on each repo and filters for Claude-created worktrees (branches matching `claude/*` or `worktree-*`). This works with any worktree layout without requiring hooks.
+
+Both modes can run concurrently, sharing a single `active` task map to avoid double-watching. On worktree removal, the watcher task is cancelled and `invalidate_cache` cleans up the index. Crashed watcher tasks are automatically restarted by the repos poller.
 
 ---
 
@@ -479,9 +489,9 @@ A minimal CLI is provided over the shared index store, covering operations such 
 
 ### Watch mode
 
-The `watch` subcommand monitors one or more directories and performs incremental reindexing with debounce. It uses the same underlying store as the MCP server, so updates become immediately visible to MCP consumers.
+The `watch` subcommand monitors one or more directories and performs incremental reindexing with debounce. The `watch-claude` subcommand builds on this for Claude Code's worktree workflow, using hook-driven events and/or `git worktree list` polling to discover worktrees automatically. Both use the same underlying store as the MCP server, so updates become immediately visible to MCP consumers.
 
-Architecturally, both CLI and watch mode are thin interfaces over the same parser, storage, indexing, and retrieval core.
+Architecturally, CLI, watch, and watch-claude are all thin interfaces over the same parser, storage, indexing, and retrieval core.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to jcodemunch-mcp are documented here.
 
+## [Unreleased]
+
+### Added
+- **`watch-claude` CLI subcommand** — auto-discover and watch Claude Code worktrees via two complementary modes:
+  - **Hook-driven mode** (recommended): install `WorktreeCreate`/`WorktreeRemove` hooks that call `jcodemunch-mcp hook-event create|remove`. Events are written to `~/.claude/jcodemunch-worktrees.jsonl` and `watch-claude` reacts instantly via filesystem watch.
+  - **`--repos` mode**: `jcodemunch-mcp watch-claude --repos ~/project1 ~/project2` polls `git worktree list --porcelain` and filters for Claude-created worktrees (branches matching `claude/*` or `worktree-*`).
+  - Both modes can run simultaneously. When a worktree is removed, the watcher stops and the index is invalidated.
+- **`hook-event` CLI subcommand** — `jcodemunch-mcp hook-event create|remove` reads Claude Code's hook JSON from stdin and appends to the JSONL manifest. Designed to be called from Claude Code's `WorktreeCreate`/`WorktreeRemove` hooks.
+
+### Changed
+- `main()` subcommand set expanded to include `hook-event` and `watch-claude`.
+
 ## [1.7.2] - 2026-03-17
 
 ### Fixed

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -132,7 +132,74 @@ pip install "jcodemunch-mcp[watch]"
 jcodemunch-mcp watch /path/to/repo
 ```
 
-The watcher shares the same index storage as the MCP server — no extra configuration needed. See the [File Watching](README.md#file-watching-large-repos) section in the README for full options.
+The watcher shares the same index storage as the MCP server — no extra configuration needed.
+
+### Auto-watching Claude Code worktrees
+
+If you use Claude Code, each session can create a git worktree. `watch-claude` automatically discovers these worktrees and indexes them — no manual paths needed. There are two discovery modes that can be used independently or together.
+
+#### Hook-driven mode (recommended)
+
+This is the fastest option: zero polling, instant reaction. Claude Code's `WorktreeCreate` and `WorktreeRemove` hooks notify jcodemunch-mcp directly.
+
+**Step 1: Install the hooks.** Add the following to your `~/.claude/settings.json` (`%USERPROFILE%\.claude\settings.json` on Windows). If you already have a `hooks` section, merge these entries into it:
+
+```json
+{
+  "hooks": {
+    "WorktreeCreate": [{
+      "matcher": "",
+      "hooks": [{"type": "command", "command": "jcodemunch-mcp hook-event create"}]
+    }],
+    "WorktreeRemove": [{
+      "matcher": "",
+      "hooks": [{"type": "command", "command": "jcodemunch-mcp hook-event remove"}]
+    }]
+  }
+}
+```
+
+> If you installed with `uvx` instead of `pip`, use `uvx jcodemunch-mcp hook-event create` and `uvx jcodemunch-mcp hook-event remove` in the hook commands.
+
+**Step 2: Run watch-claude** in a separate terminal:
+
+```bash
+jcodemunch-mcp watch-claude
+```
+
+Every time Claude Code creates a worktree, the hook records the event to `~/.claude/jcodemunch-worktrees.jsonl` and `watch-claude` picks it up instantly. When a worktree is removed, the watcher stops and the index is cleaned up.
+
+#### `--repos` mode (no hooks needed)
+
+If you prefer not to install hooks, point `watch-claude` at your git repositories. It polls `git worktree list` every 5 seconds and automatically watches any Claude-created worktrees it finds (those with branches named `claude/*` or `worktree-*`):
+
+```bash
+# Watch worktrees across multiple repos
+jcodemunch-mcp watch-claude --repos ~/projects/myapp ~/projects/api
+
+# Custom poll interval (seconds)
+jcodemunch-mcp watch-claude --repos ~/projects/myapp --poll-interval 10
+```
+
+This works with any worktree layout — whether Claude Code puts them in `<repo>/.claude/worktrees/`, `~/.claude-worktrees/`, or a custom location.
+
+#### Combining both modes
+
+If you have hooks installed and also want to cover repos that might have existing worktrees from before the hooks were set up:
+
+```bash
+jcodemunch-mcp watch-claude --repos ~/projects/myapp ~/projects/api
+```
+
+When a manifest file exists, `watch-claude` uses both hook events and git polling. Worktrees discovered by either method are not double-watched.
+
+#### Shared options
+
+All standard watch options work with `watch-claude`:
+
+```bash
+jcodemunch-mcp watch-claude --repos ~/project --debounce 5000 --no-ai-summaries --follow-symlinks
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ That means:
 
 It indexes your codebase once using tree-sitter, stores structured symbol metadata plus byte offsets into the original source, and retrieves exact implementations on demand instead of re-reading entire files over and over.
 
-Recent releases have also made that retrieval workflow sharper and more useful in real engineering work, with BM25-based symbol search, context bundles, compact search modes, query suggestions for unfamiliar repos, dependency graphs, class hierarchy traversal, blast-radius analysis, multi-symbol bundles, live watch-based reindexing, and benchmark reproducibility improvements.
+Recent releases have also made that retrieval workflow sharper and more useful in real engineering work, with BM25-based symbol search, context bundles, compact search modes, query suggestions for unfamiliar repos, dependency graphs, class hierarchy traversal, blast-radius analysis, multi-symbol bundles, live watch-based reindexing, automatic Claude Code worktree discovery (`watch-claude`), and benchmark reproducibility improvements.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -758,6 +758,8 @@ Cross-process locking is used to reduce the risk of index corruption under concu
 
 A watch-oriented interface may monitor directories and trigger incremental reindexing automatically.
 
+The `watch-claude` variant extends this for Claude Code specifically: it discovers worktrees via hook-driven events (`WorktreeCreate`/`WorktreeRemove` writing to a JSONL manifest) and/or by polling `git worktree list` on specified repositories. Both mechanisms are cross-platform and layout-agnostic.
+
 ---
 
 ## Token Savings Semantics

--- a/src/jcodemunch_mcp/hook_event.py
+++ b/src/jcodemunch_mcp/hook_event.py
@@ -1,0 +1,64 @@
+"""Hook event handler — receives Claude Code worktree events and writes to a JSONL manifest."""
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+DEFAULT_MANIFEST_PATH = Path.home() / ".claude" / "jcodemunch-worktrees.jsonl"
+
+
+def handle_hook_event(event_type: str, manifest_path: Path = DEFAULT_MANIFEST_PATH) -> None:
+    """Read worktree JSON from stdin, append an event line to the JSONL manifest.
+
+    Called by Claude Code's WorktreeCreate/WorktreeRemove hooks via:
+        jcodemunch-mcp hook-event create
+        jcodemunch-mcp hook-event remove
+    """
+    payload = json.load(sys.stdin)
+    worktree_path = payload.get("worktreePath") or payload.get("worktree_path")
+    if not worktree_path:
+        print("ERROR: no worktreePath in stdin payload", file=sys.stderr)
+        sys.exit(1)
+
+    resolved = str(Path(worktree_path).resolve())
+    entry = {
+        "event": event_type,
+        "path": resolved,
+        "ts": datetime.now(timezone.utc).isoformat(),
+    }
+
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(manifest_path, "a") as f:
+        f.write(json.dumps(entry) + "\n")
+        f.flush()
+
+    print(f"jcodemunch-mcp: recorded {event_type} for {resolved}", file=sys.stderr)
+
+
+def read_manifest(manifest_path: Path = DEFAULT_MANIFEST_PATH) -> set[str]:
+    """Read the JSONL manifest and return the set of currently active worktree paths.
+
+    Replays all events in order: a 'create' adds a path, a 'remove' removes it.
+    """
+    active: dict[str, bool] = {}
+    if not manifest_path.is_file():
+        return set()
+
+    with open(manifest_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            path = entry.get("path")
+            event = entry.get("event")
+            if not path or event not in ("create", "remove"):
+                continue
+            active[path] = event == "create"
+
+    return {p for p, is_active in active.items() if is_active}

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -1085,6 +1085,57 @@ def main(argv: Optional[list[str]] = None):
     )
     _add_common_args(watch_parser)
 
+    # --- hook-event ---
+    hook_parser = subparsers.add_parser(
+        "hook-event",
+        help="Record a Claude Code worktree lifecycle event (used by hooks)",
+    )
+    hook_parser.add_argument(
+        "event_type",
+        choices=["create", "remove"],
+        help="Event type: 'create' when a worktree is created, 'remove' when deleted",
+    )
+    _add_common_args(hook_parser)
+
+    # --- watch-claude ---
+    wc_parser = subparsers.add_parser(
+        "watch-claude",
+        help="Auto-discover and watch Claude Code worktrees",
+    )
+    wc_parser.add_argument(
+        "--repos",
+        nargs="+",
+        help="One or more git repository paths to poll for worktrees via `git worktree list`",
+    )
+    wc_parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=float(os.environ.get("JCODEMUNCH_CLAUDE_POLL_INTERVAL", "5")),
+        help="How often (in seconds) to poll git for worktrees (default: 5, only with --repos)",
+    )
+    wc_parser.add_argument(
+        "--debounce",
+        type=int,
+        default=int(os.environ.get("JCODEMUNCH_WATCH_DEBOUNCE_MS", "2000")),
+        help="Debounce interval in milliseconds for file watching (default: 2000)",
+    )
+    wc_parser.add_argument(
+        "--no-ai-summaries",
+        action="store_true",
+        help="Disable AI-generated summaries during re-indexing",
+    )
+    wc_parser.add_argument(
+        "--follow-symlinks",
+        action="store_true",
+        help="Include symlinked files in indexing",
+    )
+    wc_parser.add_argument(
+        "--extra-ignore",
+        nargs="*",
+        help="Additional gitignore-style patterns to exclude",
+    )
+    _add_common_args(wc_parser)
+
     # Backwards compat: if first non-flag arg isn't a known subcommand,
     # prepend "serve" so legacy invocations like `jcodemunch-mcp --transport sse` still work.
     # But let --help and -V be handled by the top-level parser first.
@@ -1093,7 +1144,7 @@ def main(argv: Optional[list[str]] = None):
     if any(arg in top_level_flags for arg in raw_argv):
         args = parser.parse_args(raw_argv)
     else:
-        known_commands = {"serve", "watch"}
+        known_commands = {"serve", "watch", "hook-event", "watch-claude"}
         has_subcommand = any(arg in known_commands for arg in raw_argv if not arg.startswith("-"))
         if not has_subcommand:
             raw_argv = ["serve"] + list(raw_argv)
@@ -1114,6 +1165,25 @@ def main(argv: Optional[list[str]] = None):
                 extra_ignore_patterns=args.extra_ignore,
                 follow_symlinks=args.follow_symlinks,
                 idle_timeout_minutes=args.idle_timeout,
+            )
+        )
+    elif args.command == "hook-event":
+        from .hook_event import handle_hook_event
+
+        handle_hook_event(event_type=args.event_type)
+    elif args.command == "watch-claude":
+        from .watcher import watch_claude_worktrees
+
+        use_ai = not args.no_ai_summaries and _default_use_ai_summaries()
+        asyncio.run(
+            watch_claude_worktrees(
+                repos=args.repos,
+                poll_interval=args.poll_interval,
+                debounce_ms=args.debounce,
+                use_ai_summaries=use_ai,
+                storage_path=os.environ.get("CODE_INDEX_PATH"),
+                extra_ignore_patterns=args.extra_ignore,
+                follow_symlinks=args.follow_symlinks,
             )
         )
     else:

--- a/src/jcodemunch_mcp/watcher.py
+++ b/src/jcodemunch_mcp/watcher.py
@@ -5,7 +5,9 @@ import hashlib
 import json
 import logging
 import os
+import re
 import signal
+import subprocess
 import sys
 import time
 from datetime import datetime, timezone
@@ -14,7 +16,9 @@ from typing import Callable, Optional
 
 from watchfiles import awatch, Change
 
+from .hook_event import DEFAULT_MANIFEST_PATH, read_manifest
 from .tools.index_folder import index_folder
+from .tools.invalidate_cache import invalidate_cache
 
 logger = logging.getLogger(__name__)
 
@@ -440,4 +444,298 @@ async def watch_folders(
     for folder in locked_folders:
         _release_lock(folder, storage_path)
 
+    print("Done.", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# watch-claude helpers
+# ---------------------------------------------------------------------------
+
+# Branch patterns that indicate a Claude Code-created worktree
+_CLAUDE_BRANCH_RE = re.compile(r"^refs/heads/(claude/|worktree-)")
+
+
+def _local_repo_id(folder_path: str) -> str:
+    """Compute the repo identifier that index_folder would use for a local path."""
+    p = Path(folder_path).resolve()
+    digest = hashlib.sha1(str(p).encode("utf-8")).hexdigest()[:8]
+    return f"local/{p.name}-{digest}"
+
+
+def parse_git_worktrees(repo_path: str) -> set[str]:
+    """Run ``git worktree list --porcelain`` and return paths of Claude-created worktrees.
+
+    Filters to worktrees whose branch matches ``claude/*`` or ``worktree-*``.
+    Skips the first entry (the main working copy) and prunable entries.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", repo_path, "worktree", "list", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return set()
+
+    if result.returncode != 0:
+        return set()
+
+    worktrees: set[str] = set()
+    current_path: Optional[str] = None
+    current_branch: Optional[str] = None
+    is_prunable = False
+    is_first = True
+
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            # Flush previous entry
+            if current_path and not is_first:
+                if current_branch and _CLAUDE_BRANCH_RE.match(current_branch) and not is_prunable:
+                    worktrees.add(current_path)
+            current_path = line[len("worktree "):]
+            current_branch = None
+            is_prunable = False
+            is_first = False if current_path else is_first
+        elif line.startswith("branch "):
+            current_branch = line[len("branch "):]
+        elif line.startswith("prunable"):
+            is_prunable = True
+        elif line == "":
+            # Blank line separates entries; flush
+            if current_path and not is_first:
+                if current_branch and _CLAUDE_BRANCH_RE.match(current_branch) and not is_prunable:
+                    worktrees.add(current_path)
+            # The very first entry was already processed when we hit the second "worktree" line,
+            # but handle the edge case of only one entry
+            current_path = None
+            current_branch = None
+            is_prunable = False
+
+    # Flush last entry (no trailing blank line in some git versions)
+    if current_path and current_branch and _CLAUDE_BRANCH_RE.match(current_branch) and not is_prunable:
+        worktrees.add(current_path)
+
+    return worktrees
+
+
+# ---------------------------------------------------------------------------
+# watch-claude main
+# ---------------------------------------------------------------------------
+
+
+async def watch_claude_worktrees(
+    repos: Optional[list[str]] = None,
+    poll_interval: float = 5,
+    debounce_ms: int = DEFAULT_DEBOUNCE_MS,
+    use_ai_summaries: bool = True,
+    storage_path: Optional[str] = None,
+    extra_ignore_patterns: Optional[list[str]] = None,
+    follow_symlinks: bool = False,
+) -> None:
+    """Watch Claude Code worktrees via JSONL manifest and/or git repo polling."""
+    manifest_path = DEFAULT_MANIFEST_PATH
+    use_manifest = manifest_path.is_file() or not repos
+    use_repos = bool(repos)
+
+    if not use_manifest and not use_repos:
+        print(
+            "ERROR: no manifest file found and no --repos specified.\n"
+            "Either install Claude Code hooks (see docs) or pass --repos.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    modes = []
+    if use_manifest:
+        modes.append(f"manifest ({manifest_path})")
+    if use_repos:
+        modes.append(f"repos ({len(repos)} repo(s), poll every {poll_interval}s)")
+    print(f"jcodemunch-mcp watch-claude: {' + '.join(modes)}", file=sys.stderr)
+
+    # Handle graceful shutdown
+    stop_event = asyncio.Event()
+    if sys.platform == "win32":
+        signal.signal(signal.SIGINT, lambda s, f: stop_event.set())
+        signal.signal(signal.SIGTERM, lambda s, f: stop_event.set())
+    else:
+        loop = asyncio.get_event_loop()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(sig, stop_event.set)
+
+    # Track active watchers: path -> task
+    active: dict[str, asyncio.Task] = {}
+
+    def _start_watching(folder: str) -> asyncio.Task:
+        return asyncio.create_task(
+            _watch_single(
+                folder_path=folder,
+                debounce_ms=debounce_ms,
+                use_ai_summaries=use_ai_summaries,
+                storage_path=storage_path,
+                extra_ignore_patterns=extra_ignore_patterns,
+                follow_symlinks=follow_symlinks,
+            ),
+            name=f"watch:{folder}",
+        )
+
+    async def _stop_watching(folder: str) -> None:
+        task = active.pop(folder, None)
+        if task:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+        repo_id = _local_repo_id(folder)
+        try:
+            result = await asyncio.to_thread(
+                invalidate_cache, repo=repo_id, storage_path=storage_path,
+            )
+            if result.get("success"):
+                print(f"  Cleaned up index for {repo_id}", file=sys.stderr)
+            else:
+                print(
+                    f"  WARNING: could not clean up index for {repo_id}: {result.get('error')}",
+                    file=sys.stderr,
+                )
+        except Exception as e:
+            logger.warning("Failed to invalidate cache for %s: %s", repo_id, e)
+
+    def _ensure_watching(folder: str) -> None:
+        if folder not in active and Path(folder).is_dir():
+            print(f"  New worktree detected: {folder}", file=sys.stderr)
+            active[folder] = _start_watching(folder)
+
+    # --- Initial discovery ---
+
+    if use_manifest:
+        for folder in sorted(read_manifest(manifest_path)):
+            _ensure_watching(folder)
+
+    if use_repos:
+        for repo in repos:
+            for folder in sorted(parse_git_worktrees(repo)):
+                _ensure_watching(folder)
+
+    if active:
+        print(f"  Found {len(active)} existing worktree(s)", file=sys.stderr)
+    else:
+        print("  No existing worktrees found, waiting for new ones...", file=sys.stderr)
+
+    # --- Manifest watcher task ---
+
+    async def _manifest_watcher() -> None:
+        """Watch the JSONL manifest for new lines and react to create/remove events."""
+        # Track file position to only read new lines
+        if manifest_path.is_file():
+            last_size = manifest_path.stat().st_size
+        else:
+            last_size = 0
+
+        async for _changes in awatch(
+            str(manifest_path.parent),
+            debounce=500,
+            recursive=False,
+            step=100,
+        ):
+            if not manifest_path.is_file():
+                continue
+            current_size = manifest_path.stat().st_size
+            if current_size <= last_size:
+                last_size = current_size
+                continue
+
+            # Read only new lines
+            import json as _json
+
+            with open(manifest_path) as f:
+                f.seek(last_size)
+                new_lines = f.read()
+            last_size = current_size
+
+            for line in new_lines.strip().splitlines():
+                try:
+                    entry = _json.loads(line)
+                except _json.JSONDecodeError:
+                    continue
+                path = entry.get("path")
+                event = entry.get("event")
+                if not path:
+                    continue
+                if event == "create":
+                    _ensure_watching(path)
+                elif event == "remove":
+                    if path in active:
+                        print(f"  Worktree removed (hook): {path}", file=sys.stderr)
+                        await _stop_watching(path)
+
+    # --- Repos poll task ---
+
+    async def _repos_poller() -> None:
+        """Poll git worktree list on each repo and start/stop watchers."""
+        while not stop_event.is_set():
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=poll_interval)
+                return
+            except asyncio.TimeoutError:
+                pass
+
+            current: set[str] = set()
+            for repo in repos:
+                current |= await asyncio.to_thread(parse_git_worktrees, repo)
+
+            # Only manage worktrees discovered via repos mode — don't touch
+            # manifest-discovered ones. We track repos-discovered paths via task names.
+            repos_known = {
+                folder for folder in active
+                if active[folder].get_name().startswith("watch:")
+            }
+
+            for folder in sorted(current - repos_known):
+                _ensure_watching(folder)
+
+            for folder in sorted(repos_known - current):
+                if folder in active:
+                    print(f"  Worktree removed (git): {folder}", file=sys.stderr)
+                    await _stop_watching(folder)
+
+            # Restart crashed watcher tasks
+            for folder in list(active):
+                task = active[folder]
+                if task.done() and not task.cancelled():
+                    exc = task.exception() if not task.cancelled() else None
+                    if exc:
+                        print(f"  Watcher crashed for {folder}: {exc}, restarting...", file=sys.stderr)
+                        active[folder] = _start_watching(folder)
+
+    # --- Launch tasks ---
+
+    management_tasks: list[asyncio.Task] = []
+
+    if use_manifest:
+        management_tasks.append(
+            asyncio.create_task(_manifest_watcher(), name="manifest-watcher")
+        )
+
+    if use_repos:
+        management_tasks.append(
+            asyncio.create_task(_repos_poller(), name="repos-poller")
+        )
+
+    # Wait until stop signal or a management task finishes
+    stop_waiter = asyncio.ensure_future(stop_event.wait())
+    await asyncio.wait(
+        [stop_waiter] + management_tasks,
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+
+    # Clean up
+    print("\nShutting down watch-claude...", file=sys.stderr)
+    for t in management_tasks:
+        t.cancel()
+    for t in active.values():
+        t.cancel()
+    all_tasks = list(active.values()) + management_tasks
+    await asyncio.gather(*all_tasks, return_exceptions=True)
     print("Done.", file=sys.stderr)

--- a/tests/test_watch_claude.py
+++ b/tests/test_watch_claude.py
@@ -1,0 +1,391 @@
+"""Tests for watch-claude v2: hook-event, manifest, git worktree parsing, integration."""
+
+import asyncio
+import hashlib
+import json
+import textwrap
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from jcodemunch_mcp.hook_event import handle_hook_event, read_manifest
+from jcodemunch_mcp.server import main
+from jcodemunch_mcp.watcher import (
+    _local_repo_id,
+    parse_git_worktrees,
+    watch_claude_worktrees,
+)
+
+
+# ---------------------------------------------------------------------------
+# hook-event tests
+# ---------------------------------------------------------------------------
+
+
+class TestHookEvent:
+    def test_create_appends_to_manifest(self, tmp_path):
+        manifest = tmp_path / "manifest.jsonl"
+        payload = json.dumps({"worktreePath": "/tmp/my-wt"})
+        with patch("sys.stdin", StringIO(payload)):
+            handle_hook_event("create", manifest_path=manifest)
+        lines = manifest.read_text().strip().splitlines()
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["event"] == "create"
+        assert entry["path"] == str(Path("/tmp/my-wt").resolve())
+        assert "ts" in entry
+
+    def test_remove_appends_to_manifest(self, tmp_path):
+        manifest = tmp_path / "manifest.jsonl"
+        payload = json.dumps({"worktreePath": "/tmp/my-wt"})
+        with patch("sys.stdin", StringIO(payload)):
+            handle_hook_event("create", manifest_path=manifest)
+        with patch("sys.stdin", StringIO(payload)):
+            handle_hook_event("remove", manifest_path=manifest)
+        lines = manifest.read_text().strip().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[1])["event"] == "remove"
+
+    def test_creates_manifest_if_missing(self, tmp_path):
+        manifest = tmp_path / "subdir" / "manifest.jsonl"
+        payload = json.dumps({"worktreePath": "/tmp/wt"})
+        with patch("sys.stdin", StringIO(payload)):
+            handle_hook_event("create", manifest_path=manifest)
+        assert manifest.is_file()
+
+    def test_reads_worktree_path_snake_case(self, tmp_path):
+        """Also accept worktree_path (snake_case) for robustness."""
+        manifest = tmp_path / "manifest.jsonl"
+        payload = json.dumps({"worktree_path": "/tmp/wt2"})
+        with patch("sys.stdin", StringIO(payload)):
+            handle_hook_event("create", manifest_path=manifest)
+        entry = json.loads(manifest.read_text().strip())
+        assert entry["path"] == str(Path("/tmp/wt2").resolve())
+
+    def test_exits_on_missing_path(self, tmp_path):
+        manifest = tmp_path / "manifest.jsonl"
+        payload = json.dumps({"unrelated": "data"})
+        with patch("sys.stdin", StringIO(payload)):
+            with pytest.raises(SystemExit):
+                handle_hook_event("create", manifest_path=manifest)
+
+
+# ---------------------------------------------------------------------------
+# Manifest parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestReadManifest:
+    def test_empty_file(self, tmp_path):
+        manifest = tmp_path / "manifest.jsonl"
+        manifest.write_text("")
+        assert read_manifest(manifest) == set()
+
+    def test_missing_file(self, tmp_path):
+        assert read_manifest(tmp_path / "nope.jsonl") == set()
+
+    def test_create_then_remove(self, tmp_path):
+        manifest = tmp_path / "manifest.jsonl"
+        manifest.write_text(
+            json.dumps({"event": "create", "path": "/a"}) + "\n"
+            + json.dumps({"event": "remove", "path": "/a"}) + "\n"
+        )
+        assert read_manifest(manifest) == set()
+
+    def test_multiple_active(self, tmp_path):
+        manifest = tmp_path / "manifest.jsonl"
+        manifest.write_text(
+            json.dumps({"event": "create", "path": "/a"}) + "\n"
+            + json.dumps({"event": "create", "path": "/b"}) + "\n"
+            + json.dumps({"event": "create", "path": "/c"}) + "\n"
+        )
+        assert read_manifest(manifest) == {"/a", "/b", "/c"}
+
+    def test_skips_malformed_lines(self, tmp_path):
+        manifest = tmp_path / "manifest.jsonl"
+        manifest.write_text(
+            "not json\n"
+            + json.dumps({"event": "create", "path": "/ok"}) + "\n"
+            + "\n"
+        )
+        assert read_manifest(manifest) == {"/ok"}
+
+
+# ---------------------------------------------------------------------------
+# Git worktree parsing tests
+# ---------------------------------------------------------------------------
+
+PORCELAIN_OUTPUT = textwrap.dedent("""\
+    worktree /home/user/project
+    HEAD abc123
+    branch refs/heads/main
+
+    worktree /home/user/.claude-worktrees/project/dreamy-fox
+    HEAD def456
+    branch refs/heads/claude/dreamy-fox
+
+    worktree /home/user/.claude/worktrees/feature-auth
+    HEAD 789abc
+    branch refs/heads/worktree-feature-auth
+
+    worktree /home/user/.claude/worktrees/manual-branch
+    HEAD aaa111
+    branch refs/heads/feature/manual
+
+    worktree /home/user/.claude-worktrees/project/old-session
+    HEAD bbb222
+    branch refs/heads/claude/old-session
+    prunable gitdir file points to non-existent location
+
+""")
+
+
+class TestParseGitWorktrees:
+    def _run_with_output(self, stdout):
+        import subprocess
+
+        fake_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=stdout, stderr=""
+        )
+        with patch("jcodemunch_mcp.watcher.subprocess.run", return_value=fake_result):
+            return parse_git_worktrees("/fake/repo")
+
+    def test_filters_by_branch(self):
+        result = self._run_with_output(PORCELAIN_OUTPUT)
+        # Should include claude/* and worktree-* but not main or feature/manual
+        assert "/home/user/.claude-worktrees/project/dreamy-fox" in result
+        assert "/home/user/.claude/worktrees/feature-auth" in result
+        assert "/home/user/.claude/worktrees/manual-branch" not in result
+
+    def test_skips_main_worktree(self):
+        result = self._run_with_output(PORCELAIN_OUTPUT)
+        assert "/home/user/project" not in result
+
+    def test_skips_prunable(self):
+        result = self._run_with_output(PORCELAIN_OUTPUT)
+        assert "/home/user/.claude-worktrees/project/old-session" not in result
+
+    def test_handles_git_failure(self):
+        import subprocess
+
+        fake_result = subprocess.CompletedProcess(
+            args=[], returncode=128, stdout="", stderr="not a git repo"
+        )
+        with patch("jcodemunch_mcp.watcher.subprocess.run", return_value=fake_result):
+            assert parse_git_worktrees("/fake/repo") == set()
+
+    def test_handles_empty_output(self):
+        result = self._run_with_output("")
+        assert result == set()
+
+
+# ---------------------------------------------------------------------------
+# _local_repo_id
+# ---------------------------------------------------------------------------
+
+
+class TestLocalRepoId:
+    def test_matches_index_folder_convention(self, tmp_path):
+        folder = tmp_path / "my-worktree"
+        folder.mkdir()
+        repo_id = _local_repo_id(str(folder))
+        resolved = str(folder.resolve())
+        digest = hashlib.sha1(resolved.encode("utf-8")).hexdigest()[:8]
+        assert repo_id == f"local/my-worktree-{digest}"
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_watch_claude_help(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            main(["watch-claude", "--help"])
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "--repos" in out
+
+    def test_hook_event_help(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            main(["hook-event", "--help"])
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "create" in out
+        assert "remove" in out
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (mocked _watch_single)
+# ---------------------------------------------------------------------------
+
+
+class TestWatchClaudeIntegration:
+    @pytest.mark.asyncio
+    async def test_manifest_mode_starts_existing_worktrees(self, tmp_path):
+        """Worktrees listed in manifest should be watched on startup."""
+        wt = tmp_path / "wt-1"
+        wt.mkdir()
+        (wt / "main.py").write_text("x = 1\n")
+
+        manifest = tmp_path / "manifest.jsonl"
+        manifest.write_text(
+            json.dumps({"event": "create", "path": str(wt)}) + "\n"
+        )
+
+        started = []
+
+        async def fake_watch_single(folder_path, **kwargs):
+            started.append(folder_path)
+            await asyncio.Event().wait()
+
+        with (
+            patch("jcodemunch_mcp.watcher._watch_single", side_effect=fake_watch_single),
+            patch("jcodemunch_mcp.watcher.DEFAULT_MANIFEST_PATH", manifest),
+        ):
+            task = asyncio.create_task(
+                watch_claude_worktrees(use_ai_summaries=False)
+            )
+            await asyncio.sleep(0.3)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert len(started) == 1
+        assert started[0] == str(wt)
+
+    @pytest.mark.asyncio
+    async def test_manifest_mode_reacts_to_new_event(self, tmp_path):
+        """A create event appended to the manifest should trigger a new watcher."""
+        manifest = tmp_path / "manifest.jsonl"
+        manifest.write_text("")  # empty initially
+
+        wt = tmp_path / "new-wt"
+        wt.mkdir()
+
+        started = []
+
+        async def fake_watch_single(folder_path, **kwargs):
+            started.append(folder_path)
+            await asyncio.Event().wait()
+
+        with (
+            patch("jcodemunch_mcp.watcher._watch_single", side_effect=fake_watch_single),
+            patch("jcodemunch_mcp.watcher.DEFAULT_MANIFEST_PATH", manifest),
+        ):
+            task = asyncio.create_task(
+                watch_claude_worktrees(use_ai_summaries=False)
+            )
+            await asyncio.sleep(0.3)
+            assert len(started) == 0
+
+            # Simulate hook appending a create event
+            with open(manifest, "a") as f:
+                f.write(json.dumps({"event": "create", "path": str(wt)}) + "\n")
+
+            # Wait for watchfiles to pick it up
+            await asyncio.sleep(1.5)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert len(started) == 1
+        assert started[0] == str(wt)
+
+    @pytest.mark.asyncio
+    async def test_repos_mode_discovers_worktrees(self, tmp_path):
+        """--repos mode should discover worktrees via git worktree list."""
+        started = []
+
+        async def fake_watch_single(folder_path, **kwargs):
+            started.append(folder_path)
+            await asyncio.Event().wait()
+
+        wt_path = str(tmp_path / "wt-from-git")
+        (tmp_path / "wt-from-git").mkdir()
+
+        def fake_parse(repo_path):
+            return {wt_path}
+
+        manifest = tmp_path / "no-manifest.jsonl"  # nonexistent
+
+        with (
+            patch("jcodemunch_mcp.watcher._watch_single", side_effect=fake_watch_single),
+            patch("jcodemunch_mcp.watcher.parse_git_worktrees", side_effect=fake_parse),
+            patch("jcodemunch_mcp.watcher.DEFAULT_MANIFEST_PATH", manifest),
+        ):
+            task = asyncio.create_task(
+                watch_claude_worktrees(
+                    repos=["/fake/repo"],
+                    poll_interval=0.1,
+                    use_ai_summaries=False,
+                )
+            )
+            await asyncio.sleep(0.3)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert len(started) == 1
+        assert started[0] == wt_path
+
+    @pytest.mark.asyncio
+    async def test_repos_mode_cleans_up_removed(self, tmp_path):
+        """When a worktree disappears from git, it should be stopped and cache invalidated."""
+        started = []
+        invalidated = []
+
+        async def fake_watch_single(folder_path, **kwargs):
+            started.append(folder_path)
+            await asyncio.Event().wait()
+
+        def fake_invalidate(repo, storage_path=None):
+            invalidated.append(repo)
+            return {"success": True}
+
+        wt_path = str(tmp_path / "wt-gone")
+        (tmp_path / "wt-gone").mkdir()
+
+        call_count = 0
+
+        def fake_parse(repo_path):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return {wt_path}
+            return set()  # worktree gone
+
+        manifest = tmp_path / "no-manifest.jsonl"
+
+        with (
+            patch("jcodemunch_mcp.watcher._watch_single", side_effect=fake_watch_single),
+            patch("jcodemunch_mcp.watcher.parse_git_worktrees", side_effect=fake_parse),
+            patch("jcodemunch_mcp.watcher.invalidate_cache", side_effect=fake_invalidate),
+            patch("jcodemunch_mcp.watcher.DEFAULT_MANIFEST_PATH", manifest),
+        ):
+            task = asyncio.create_task(
+                watch_claude_worktrees(
+                    repos=["/fake/repo"],
+                    poll_interval=0.1,
+                    use_ai_summaries=False,
+                )
+            )
+            await asyncio.sleep(0.8)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert len(started) == 1
+        assert len(invalidated) == 1
+        assert invalidated[0].startswith("local/wt-gone-")


### PR DESCRIPTION
## Summary

- Adds `watch-claude` CLI subcommand that auto-discovers and watches Claude Code worktrees via hook-driven events (JSONL manifest at `~/.claude/jcodemunch-worktrees.jsonl`) and/or `git worktree list` polling (`--repos` mode)
- Adds `hook-event` CLI subcommand (`jcodemunch-mcp hook-event create|remove`) for use in Claude Code's `WorktreeCreate`/`WorktreeRemove` hooks
- Both discovery modes can run concurrently with deduplication; worktree removal triggers watcher cleanup and index invalidation

Closes #123

## Changes

- **`src/jcodemunch_mcp/hook_event.py`** (new) — reads hook JSON from stdin, appends to JSONL manifest
- **`src/jcodemunch_mcp/watcher.py`** — adds `watch_claude_worktrees()`, manifest watcher, git poller, and per-worktree watcher lifecycle management
- **`src/jcodemunch_mcp/server.py`** — registers `hook-event` and `watch-claude` subcommands in CLI parser
- **`tests/test_watch_claude.py`** (new) — unit tests for hook event handling, manifest parsing, git worktree discovery, and watcher lifecycle
- **Docs** — QUICKSTART (detailed setup for both modes), ARCHITECTURE, CHANGELOG, README, SPEC all updated

## Test plan

- [ ] `jcodemunch-mcp hook-event create` with piped JSON writes correct JSONL
- [ ] `jcodemunch-mcp hook-event remove` with piped JSON writes correct JSONL
- [ ] `jcodemunch-mcp watch-claude` with manifest watches and reacts to new entries
- [ ] `jcodemunch-mcp watch-claude --repos /path/to/repo` discovers existing worktrees
- [ ] Worktree removal triggers watcher stop and index cleanup
- [ ] Both modes running together do not double-watch
- [ ] Works on macOS, Linux, and Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)