### PR TITLE
fix: watch all non-main worktrees regardless of branch name

### DIFF
--- a/src/jcodemunch_mcp/watcher.py
+++ b/src/jcodemunch_mcp/watcher.py
@@ -529,10 +529,6 @@ async def watch_folders(
 # worktree helpers
 # ---------------------------------------------------------------------------
 
-# Branch patterns that indicate an agent-created worktree
-_WORKTREE_BRANCH_RE = re.compile(r"^refs/heads/(claude/|agent/|worktree-)")
-
-
 def _local_repo_id(folder_path: str) -> str:
     """Compute the repo identifier that index_folder would use for a local path."""
     p = Path(folder_path).resolve()
@@ -541,9 +537,8 @@ def _local_repo_id(folder_path: str) -> str:
 
 
 def parse_git_worktrees(repo_path: str) -> set[str]:
-    """Run ``git worktree list --porcelain`` and return paths of agent-created worktrees.
+    """Run ``git worktree list --porcelain`` and return paths of non-main worktrees.
 
-    Filters to worktrees whose branch matches ``agent/*`` or ``worktree-*``.
     Skips the first entry (the main working copy) and prunable entries.
     """
     try:
@@ -561,37 +556,29 @@ def parse_git_worktrees(repo_path: str) -> set[str]:
 
     worktrees: set[str] = set()
     current_path: Optional[str] = None
-    current_branch: Optional[str] = None
     is_prunable = False
-    is_first = True
+    first_path: Optional[str] = None
 
     for line in result.stdout.splitlines():
         if line.startswith("worktree "):
             # Flush previous entry
-            if current_path and not is_first:
-                if current_branch and _WORKTREE_BRANCH_RE.match(current_branch) and not is_prunable:
-                    worktrees.add(current_path)
+            if current_path and current_path != first_path and not is_prunable:
+                worktrees.add(current_path)
             current_path = line[len("worktree "):]
-            current_branch = None
+            if first_path is None:
+                first_path = current_path
             is_prunable = False
-            is_first = False if current_path else is_first
-        elif line.startswith("branch "):
-            current_branch = line[len("branch "):]
         elif line.startswith("prunable"):
             is_prunable = True
         elif line == "":
             # Blank line separates entries; flush
-            if current_path and not is_first:
-                if current_branch and _WORKTREE_BRANCH_RE.match(current_branch) and not is_prunable:
-                    worktrees.add(current_path)
-            # The very first entry was already processed when we hit the second "worktree" line,
-            # but handle the edge case of only one entry
+            if current_path and current_path != first_path and not is_prunable:
+                worktrees.add(current_path)
             current_path = None
-            current_branch = None
             is_prunable = False
 
     # Flush last entry (no trailing blank line in some git versions)
-    if current_path and current_branch and _WORKTREE_BRANCH_RE.match(current_branch) and not is_prunable:
+    if current_path and current_path != first_path and not is_prunable:
         worktrees.add(current_path)
 
     return worktrees

--- a/tests/test_watch_claude.py
+++ b/tests/test_watch_claude.py
@@ -155,13 +155,13 @@ class TestParseGitWorktrees:
         with patch("jcodemunch_mcp.watcher.subprocess.run", return_value=fake_result):
             return parse_git_worktrees("/fake/repo")
 
-    def test_filters_by_branch(self):
+    def test_includes_all_non_main_worktrees(self):
         result = self._run_with_output(PORCELAIN_OUTPUT)
-        # Should include agent/*, claude/* and worktree-* but not main or feature/manual
+        # Should include all non-main, non-prunable worktrees regardless of branch name
         assert "/home/user/.claude-worktrees/project/dreamy-fox" in result
         assert "/home/user/.claude/worktrees/feature-auth" in result
         assert "/home/user/.claude/worktrees/claude-feature-x" in result
-        assert "/home/user/.claude/worktrees/manual-branch" not in result
+        assert "/home/user/.claude/worktrees/manual-branch" in result
 
     def test_skips_main_worktree(self):
         result = self._run_with_output(PORCELAIN_OUTPUT)


### PR DESCRIPTION
## Summary

- Remove `_WORKTREE_BRANCH_RE` branch-name filter from `parse_git_worktrees` so `--repos` mode discovers all non-main, non-prunable worktrees
- Fix latent bug in `is_first` tracking that was masked by the regex filter
- Update tests to reflect new behavior

Fixes #133

## Test plan

- [x] All 22 `test_watch_claude.py` tests pass
- [x] `test_includes_all_non_main_worktrees` verifies worktrees with arbitrary branch names are now included
- [x] `test_skips_main_worktree` still passes — main working copy is excluded
- [x] `test_skips_prunable` still passes — prunable entries are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)