### PR TITLE
fix: shutdown WAL checkpoint now works for hyphenated GitHub owners

### DIFF
--- a/src/jcodemunch_mcp/storage/index_store.py
+++ b/src/jcodemunch_mcp/storage/index_store.py
@@ -217,12 +217,7 @@ class IndexStore:
         if not self.base_path.exists():
             return
         for db_file in self.base_path.glob("*.db"):
-            slug = db_file.stem  # e.g. "local-myrepo-abc123"
-            # Extract owner and name from the slug: first segment = owner, rest = name
-            parts = slug.split("-", 1)
-            if len(parts) == 2:
-                owner, name = parts
-                self._sqlite.checkpoint_and_close(owner, name)
+            self._sqlite.checkpoint_db(db_file)
 
     def _safe_repo_component(self, value: str, field_name: str) -> str:
         """Validate and sanitize owner/name components used in on-disk cache paths.

--- a/src/jcodemunch_mcp/storage/sqlite_store.py
+++ b/src/jcodemunch_mcp/storage/sqlite_store.py
@@ -137,7 +137,14 @@ class SQLiteIndexStore:
 
     def checkpoint_and_close(self, owner: str, name: str) -> None:
         """Compact WAL file on graceful shutdown. Call from server shutdown hook."""
-        db_path = self._db_path(owner, name)
+        self.checkpoint_db(self._db_path(owner, name))
+
+    def checkpoint_db(self, db_path: Path) -> None:
+        """Checkpoint and close a WAL database by path.
+
+        Unlike checkpoint_and_close(), this does not require owner/name
+        parsing — useful when iterating *.db files directly.
+        """
         if not db_path.exists():
             return
         conn = self._connect(db_path)

--- a/tests/test_local_integration.py
+++ b/tests/test_local_integration.py
@@ -350,6 +350,67 @@ def test_checkpoint_compacts_wal(tmp_path):
     )
 
 
+def test_checkpoint_db_by_path(tmp_path):
+    """checkpoint_db works with a db_path directly — no owner/name parsing."""
+    store = SQLiteIndexStore(base_path=str(tmp_path))
+    _full_save(store, n_files=5)
+
+    db_path = store._db_path("local", "test-abc123")
+    wal_path = Path(str(db_path) + "-wal")
+
+    # Force WAL content
+    if not wal_path.exists() or wal_path.stat().st_size == 0:
+        store.incremental_save(
+            owner="local",
+            name="test-abc123",
+            changed_files=["file_0.py"],
+            new_files=[],
+            deleted_files=[],
+            new_symbols=[_sym("extra", "file_0.py")],
+            raw_files={"file_0.py": "def extra(): pass"},
+            file_hashes={"file_0.py": "hextra"},
+        )
+
+    store.checkpoint_db(db_path)
+
+    wal_size_after = wal_path.stat().st_size if wal_path.exists() else 0
+    assert wal_size_after == 0, (
+        f"WAL should be 0 bytes after checkpoint_db, got {wal_size_after}"
+    )
+
+
+def test_index_store_close_checkpoints_all(tmp_path):
+    """IndexStore.close() checkpoints all *.db files without slug parsing."""
+    from jcodemunch_mcp.storage import IndexStore
+
+    idx = IndexStore(base_path=str(tmp_path))
+    store = SQLiteIndexStore(base_path=str(tmp_path))
+    _full_save(store, n_files=5)
+
+    db_path = store._db_path("local", "test-abc123")
+    wal_path = Path(str(db_path) + "-wal")
+
+    # Force WAL content
+    if not wal_path.exists() or wal_path.stat().st_size == 0:
+        store.incremental_save(
+            owner="local",
+            name="test-abc123",
+            changed_files=["file_0.py"],
+            new_files=[],
+            deleted_files=[],
+            new_symbols=[_sym("extra", "file_0.py")],
+            raw_files={"file_0.py": "def extra(): pass"},
+            file_hashes={"file_0.py": "hextra"},
+        )
+
+    idx.close()
+
+    wal_size_after = wal_path.stat().st_size if wal_path.exists() else 0
+    assert wal_size_after == 0, (
+        f"WAL should be 0 bytes after IndexStore.close(), got {wal_size_after}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # 6. JSON migration safety
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

  - `IndexStore.close()` used `slug.split('-', 1)` to reverse-engineer owner/name from `*.db` filenames, then reconstructed the path via `_db_path()`.
  This silently failed for GitHub owners with hyphens (e.g., `my-org/my-repo`), meaning the shutdown WAL checkpoint never fired for those repos.
  - Added `checkpoint_db(db_path)` to `SQLiteIndexStore` that accepts the database path directly, bypassing the fragile owner/name round-trip.
  - `IndexStore.close()` now passes each discovered `*.db` file straight through — reliable for all repo types (local, GitHub, hyphenated owners).

  ## Test plan

  - [x] Existing `test_checkpoint_compacts_wal` still passes
  - [x] New `test_checkpoint_db_by_path` — verifies `checkpoint_db()` works with a path directly
  - [x] New `test_index_store_close_checkpoints_all` — verifies `IndexStore.close()` checkpoints without slug parsing
  - [x] Full suite: 825 passed, 0 failures