### PR TITLE
feat: add Razor .cshtml mixed-language parsing and fixture coverage

### DIFF
--- a/src/jcodemunch_mcp/parser/extractor.py
+++ b/src/jcodemunch_mcp/parser/extractor.py
@@ -30,6 +30,8 @@ def parse_file(content: str, filename: str, language: str) -> list[Symbol]:
         symbols = _parse_elixir_symbols(source_bytes, filename)
     elif language == "blade":
         symbols = _parse_blade_symbols(source_bytes, filename)
+    elif language == "razor":
+        symbols = _parse_razor_symbols(source_bytes, filename)
     elif language == "nix":
         symbols = _parse_nix_symbols(source_bytes, filename)
     elif language == "vue":
@@ -3392,6 +3394,302 @@ def _parse_ejs_symbols(source_bytes: bytes, filename: str) -> list[Symbol]:
         ))
 
     return symbols
+
+
+# ---------------------------------------------------------------------------
+# Razor (.cshtml) custom symbol extractor
+# ---------------------------------------------------------------------------
+
+_RAZOR_SCRIPT_RE = re.compile(r"<script\b([^>]*)>(.*?)</script>", re.IGNORECASE | re.DOTALL)
+_RAZOR_STYLE_RE = re.compile(r"<style\b([^>]*)>(.*?)</style>", re.IGNORECASE | re.DOTALL)
+_RAZOR_ID_RE = re.compile(r"""\bid\s*=\s*["']([^"'<>]+)["']""", re.IGNORECASE)
+_RAZOR_SCRIPT_SRC_RE = re.compile(r"""\bsrc\s*=\s*["']([^"'<>]+)["']""", re.IGNORECASE)
+_RAZOR_CODE_BLOCK_RE = re.compile(r"@(?:functions|code)\s*\{", re.IGNORECASE)
+
+
+def _parse_razor_symbols(source_bytes: bytes, filename: str) -> list[Symbol]:
+    """Extract symbols from Razor (.cshtml) templates.
+
+    Strategy:
+    - Synthetic view symbol from filename
+    - HTML ids as constant symbols
+    - <script src="..."> as function symbols
+    - Inline <script> blocks re-parsed as JavaScript
+    - @functions/@code blocks re-parsed as C# inside a synthetic shim class
+    - <style> blocks emitted as constant symbols for retrievable structure
+    """
+    from pathlib import Path as _Path
+
+    content = source_bytes.decode("utf-8", errors="replace")
+    view_name = _Path(filename).stem
+    total_lines = content.count("\n") + 1
+    symbols: list[Symbol] = []
+
+    view_symbol = Symbol(
+        id=make_symbol_id(filename, view_name, "class"),
+        file=filename,
+        name=view_name,
+        qualified_name=view_name,
+        kind="class",
+        language="razor",
+        signature=f"view {view_name}",
+        line=1,
+        end_line=total_lines,
+        byte_offset=0,
+        byte_length=len(source_bytes),
+        content_hash=compute_content_hash(source_bytes),
+    )
+    symbols.append(view_symbol)
+
+    def _line_for_offset(offset: int) -> int:
+        return content.count("\n", 0, offset) + 1
+
+    def _rewrap_symbol(
+        sym: Symbol,
+        block_offset: int,
+        line_offset_zero_based: int,
+        block_length: int,
+        parent: Optional[Symbol],
+        qualified_prefix: Optional[str] = None,
+    ) -> Symbol:
+        qualified_name = sym.qualified_name
+        if qualified_prefix:
+            if qualified_name.startswith("__RazorShim__."):
+                qualified_name = qualified_name[len("__RazorShim__."):]
+            qualified_name = f"{qualified_prefix}.{qualified_name}"
+        elif qualified_name.startswith("__RazorShim__."):
+            qualified_name = qualified_name[len("__RazorShim__."):]
+
+        return Symbol(
+            id=make_symbol_id(filename, qualified_name, sym.kind),
+            file=filename,
+            name=sym.name,
+            qualified_name=qualified_name,
+            kind=sym.kind,
+            language=sym.language,
+            signature=sym.signature,
+            docstring=sym.docstring,
+            summary=sym.summary,
+            decorators=list(sym.decorators),
+            keywords=list(sym.keywords),
+            parent=parent.id if parent else None,
+            line=sym.line + line_offset_zero_based,
+            end_line=sym.end_line + line_offset_zero_based,
+            byte_offset=max(block_offset, block_offset + max(0, sym.byte_offset)),
+            byte_length=min(sym.byte_length, block_length),
+            content_hash=sym.content_hash,
+            ecosystem_context=sym.ecosystem_context,
+        )
+
+    # HTML ids and external script refs
+    seen_ids: set[str] = set()
+    for match in _RAZOR_ID_RE.finditer(content):
+        elem_id = match.group(1)
+        if elem_id in seen_ids:
+            continue
+        seen_ids.add(elem_id)
+        line_no = _line_for_offset(match.start())
+        snippet = match.group(0).encode("utf-8")
+        symbols.append(Symbol(
+            id=make_symbol_id(filename, f"{view_name}.{elem_id}", "constant"),
+            file=filename,
+            name=elem_id,
+            qualified_name=f"{view_name}.{elem_id}",
+            kind="constant",
+            language="razor",
+            signature=match.group(0),
+            parent=view_symbol.id,
+            line=line_no,
+            end_line=line_no,
+            byte_offset=match.start(),
+            byte_length=len(snippet),
+            content_hash=compute_content_hash(snippet),
+        ))
+
+    seen_script_src: set[str] = set()
+    script_index = 0
+    for script_match in _RAZOR_SCRIPT_RE.finditer(content):
+        script_index += 1
+        attrs = script_match.group(1) or ""
+        body = script_match.group(2) or ""
+        line_no = _line_for_offset(script_match.start())
+
+        src_match = _RAZOR_SCRIPT_SRC_RE.search(attrs)
+        if src_match:
+            src = src_match.group(1)
+            if src not in seen_script_src:
+                seen_script_src.add(src)
+                name = src.rsplit("/", 1)[-1] if "/" in src else src
+                snippet = src_match.group(0).encode("utf-8")
+                symbols.append(Symbol(
+                    id=make_symbol_id(filename, f"{view_name}.{src}", "function"),
+                    file=filename,
+                    name=name,
+                    qualified_name=f"{view_name}.{src}",
+                    kind="function",
+                    language="razor",
+                    signature=f'<script src="{src}">',
+                    parent=view_symbol.id,
+                    line=line_no,
+                    end_line=line_no,
+                    byte_offset=script_match.start() + src_match.start(),
+                    byte_length=len(snippet),
+                    content_hash=compute_content_hash(snippet),
+                ))
+
+        if body.strip():
+            body_start = script_match.start(2)
+            body_line_offset = _line_for_offset(body_start) - 1
+            js_symbols = parse_file(body, f"{filename}#script{script_index}.js", "javascript")
+            for js_sym in js_symbols:
+                symbols.append(
+                    _rewrap_symbol(
+                        js_sym,
+                        block_offset=body_start,
+                        line_offset_zero_based=body_line_offset,
+                        block_length=len(body.encode("utf-8")),
+                        parent=view_symbol,
+                        qualified_prefix=view_name,
+                    )
+                )
+
+    for idx, style_match in enumerate(_RAZOR_STYLE_RE.finditer(content), start=1):
+        attrs = (style_match.group(1) or "").strip()
+        line_no = _line_for_offset(style_match.start())
+        style_name = f"style_{idx}"
+        tag_sig = "<style>"
+        if attrs:
+            tag_sig = f"<style{attrs}>"
+        snippet = style_match.group(0).encode("utf-8")
+        symbols.append(Symbol(
+            id=make_symbol_id(filename, f"{view_name}.{style_name}", "constant"),
+            file=filename,
+            name=style_name,
+            qualified_name=f"{view_name}.{style_name}",
+            kind="constant",
+            language="razor",
+            signature=tag_sig,
+            parent=view_symbol.id,
+            line=line_no,
+            end_line=_line_for_offset(style_match.end()),
+            byte_offset=style_match.start(),
+            byte_length=len(snippet),
+            content_hash=compute_content_hash(snippet),
+        ))
+
+    for code_match in _RAZOR_CODE_BLOCK_RE.finditer(content):
+        block = _extract_razor_brace_block(content, code_match.end() - 1)
+        if block is None:
+            continue
+        body_start, body_end = block
+        body = content[body_start:body_end]
+        if not body.strip():
+            continue
+
+        wrapper_prefix = "class __RazorShim__ {\n"
+        wrapper_suffix = "\n}"
+        wrapped = f"{wrapper_prefix}{body}{wrapper_suffix}"
+        csharp_symbols = parse_file(wrapped, f"{filename}#razor.cs", "csharp")
+        body_line_offset = _line_for_offset(body_start) - 2
+        body_offset = body_start - len(wrapper_prefix.encode("utf-8"))
+        body_length = len(body.encode("utf-8"))
+
+        for csharp_sym in csharp_symbols:
+            if csharp_sym.name == "__RazorShim__":
+                continue
+            symbols.append(
+                _rewrap_symbol(
+                    csharp_sym,
+                    block_offset=body_offset,
+                    line_offset_zero_based=body_line_offset,
+                    block_length=body_length,
+                    parent=view_symbol,
+                    qualified_prefix=view_name,
+                )
+            )
+
+    symbols.sort(key=lambda s: (s.line, s.byte_offset, s.name))
+    return symbols
+
+
+def _extract_razor_brace_block(content: str, brace_pos: int) -> Optional[tuple[int, int]]:
+    """Return the [start, end) slice inside a Razor @code/@functions block."""
+    if brace_pos < 0 or brace_pos >= len(content) or content[brace_pos] != "{":
+        return None
+
+    depth = 0
+    i = brace_pos
+    in_string = False
+    string_quote = ""
+    verbatim_string = False
+    in_line_comment = False
+    in_block_comment = False
+
+    while i < len(content):
+        ch = content[i]
+        nxt = content[i + 1] if i + 1 < len(content) else ""
+
+        if in_line_comment:
+            if ch == "\n":
+                in_line_comment = False
+            i += 1
+            continue
+
+        if in_block_comment:
+            if ch == "*" and nxt == "/":
+                in_block_comment = False
+                i += 2
+                continue
+            i += 1
+            continue
+
+        if in_string:
+            if verbatim_string:
+                if ch == '"' and nxt == '"':
+                    i += 2
+                    continue
+                if ch == '"':
+                    in_string = False
+                    verbatim_string = False
+            else:
+                if ch == "\\":
+                    i += 2
+                    continue
+                if ch == string_quote:
+                    in_string = False
+            i += 1
+            continue
+
+        if ch == "/" and nxt == "/":
+            in_line_comment = True
+            i += 2
+            continue
+        if ch == "/" and nxt == "*":
+            in_block_comment = True
+            i += 2
+            continue
+        if ch == "@" and nxt == '"':
+            in_string = True
+            string_quote = '"'
+            verbatim_string = True
+            i += 2
+            continue
+        if ch in ("'", '"'):
+            in_string = True
+            string_quote = ch
+            verbatim_string = False
+            i += 1
+            continue
+
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return brace_pos + 1, i
+        i += 1
+
+    return None
 
 
 def _parse_lua_symbols(source_bytes: bytes, filename: str) -> list[Symbol]:

--- a/src/jcodemunch_mcp/parser/languages.py
+++ b/src/jcodemunch_mcp/parser/languages.py
@@ -62,6 +62,7 @@ LANGUAGE_EXTENSIONS = {
     ".php": "php",
     ".dart": "dart",
     ".cs": "csharp",
+    ".cshtml": "razor",
     ".c": "c",
     ".h": "cpp",
     ".cpp": "cpp",
@@ -487,6 +488,26 @@ CSHARP_SPEC = LanguageSpec(
     container_node_types=["class_declaration", "struct_declaration", "record_declaration", "interface_declaration"],
     constant_patterns=[],
     type_patterns=["interface_declaration", "enum_declaration", "struct_declaration", "delegate_declaration", "record_declaration"],
+)
+
+
+# Razor / ASP.NET views specification
+# NOTE: .cshtml files are mixed-language documents containing Razor directives,
+# HTML markup, optional <script>/<style> blocks, and embedded C# in
+# @functions/@code regions. Extraction is handled by _parse_razor_symbols() in
+# extractor.py, which delegates subregions to the existing C#/JS parsers and
+# emits lightweight symbols for HTML ids, external scripts, and style blocks.
+RAZOR_SPEC = LanguageSpec(
+    ts_language="html",
+    symbol_node_types={},
+    name_fields={},
+    param_fields={},
+    return_type_fields={},
+    docstring_strategy="preceding_comment",
+    decorator_node_type=None,
+    container_node_types=[],
+    constant_patterns=[],
+    type_patterns=[],
 )
 
 
@@ -1308,6 +1329,7 @@ LANGUAGE_REGISTRY = {
     "php": PHP_SPEC,
     "dart": DART_SPEC,
     "csharp": CSHARP_SPEC,
+    "razor": RAZOR_SPEC,
     "c": C_SPEC,
     "swift": SWIFT_SPEC,
     "cpp": CPP_SPEC,

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -387,7 +387,7 @@ async def list_tools() -> list[Tool]:
                     "language": {
                         "type": "string",
                         "description": "Optional filter by language",
-                        "enum": ["python", "javascript", "typescript", "tsx", "go", "rust", "java", "php", "dart", "csharp", "c", "cpp", "swift", "elixir", "ruby", "perl", "gdscript", "blade", "kotlin", "scala", "haskell", "julia", "r", "lua", "bash", "css", "sql", "toml", "erlang", "fortran", "gleam", "nix", "vue", "ejs", "verse", "groovy", "objc", "proto", "hcl", "graphql", "autohotkey", "asm", "xml", "openapi", "al"]
+                        "enum": ["python", "javascript", "typescript", "tsx", "go", "rust", "java", "php", "dart", "csharp", "razor", "c", "cpp", "swift", "elixir", "ruby", "perl", "gdscript", "blade", "kotlin", "scala", "haskell", "julia", "r", "lua", "bash", "css", "sql", "toml", "erlang", "fortran", "gleam", "nix", "vue", "ejs", "verse", "groovy", "objc", "proto", "hcl", "graphql", "autohotkey", "asm", "xml", "openapi", "al"]
                     },
                     "max_results": {
                         "type": "integer",

--- a/tests/fixtures/razor/dotnet_aspnetcore_layout.cshtml
+++ b/tests/fixtures/razor/dotnet_aspnetcore_layout.cshtml
@@ -1,0 +1,57 @@
+@* Source: https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Views/Shared/_Layout.cshtml *@
+@* Copyright (c) .NET Foundation and Contributors. Licensed under the MIT License. *@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - Company.WebApplication1</title>
+    <script type="importmap"></script>
+    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/Company.WebApplication1.styles.css" asp-append-version="true" />
+</head>
+<body>
+    <header>
+        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
+            <div class="container-fluid">
+                <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">Company.WebApplication1</a>
+                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
+                        aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
+                    <ul class="navbar-nav flex-grow-1">
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
+                        </li>
+                    </ul>
+    @*#if (IndividualAuth || OrganizationalAuth)
+                    <partial name="_LoginPartial" />
+    #elseif (WindowsAuth)
+                    <p class="nav navbar-text">Hello, @User.Identity?.Name!</p>
+    #endif*@
+                </div>
+            </div>
+        </nav>
+    </header>
+    <div class="container">
+        <main role="main" class="pb-3">
+            @RenderBody()
+        </main>
+    </div>
+
+    <footer class="border-top footer text-muted">
+        <div class="container">
+            &copy; copyrightYear - Company.WebApplication1 - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
+        </div>
+    </footer>
+    <script src="~/lib/jquery/dist/jquery.min.js"></script>
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="~/js/site.js" asp-append-version="true"></script>
+    @await RenderSectionAsync("Scripts", required: false)
+</body>
+</html>

--- a/tests/fixtures/razor/sample.cshtml
+++ b/tests/fixtures/razor/sample.cshtml
@@ -1,0 +1,18 @@
+@model SampleApp.Models.ProfileViewModel
+
+@functions {
+    public string FullName() => $"{FirstName} {LastName}";
+    private int Count = 1;
+}
+
+<div id="profile-card">
+  <script src="/js/profile.js"></script>
+  <style>
+    .profile-card { color: red; }
+  </style>
+  <script>
+    function toggleCard(id) {
+      return document.getElementById(id);
+    }
+  </script>
+</div>

--- a/tests/test_razor.py
+++ b/tests/test_razor.py
@@ -1,0 +1,151 @@
+"""Tests for Razor (.cshtml) mixed-language symbol extraction."""
+
+from pathlib import Path
+
+from jcodemunch_mcp.parser import parse_file
+from jcodemunch_mcp.parser.languages import LANGUAGE_EXTENSIONS, get_language_for_path
+from jcodemunch_mcp.tools.index_folder import discover_local_files, index_folder
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "razor" / "sample.cshtml"
+PUBLIC_FIXTURE = Path(__file__).parent / "fixtures" / "razor" / "dotnet_aspnetcore_layout.cshtml"
+
+
+def _load():
+    return FIXTURE.read_text(encoding="utf-8")
+
+
+def _symbols():
+    return parse_file(_load(), "Views/Profile/Index.cshtml", "razor")
+
+
+def _load_public():
+    return PUBLIC_FIXTURE.read_text(encoding="utf-8")
+
+
+def test_cshtml_extension_detected():
+    assert get_language_for_path("Views/Profile/Index.cshtml") == "razor"
+
+
+def test_cshtml_extension_in_registry():
+    assert LANGUAGE_EXTENSIONS[".cshtml"] == "razor"
+
+
+def test_parse_razor_mixed_symbols():
+    symbols = _symbols()
+
+    view = next((s for s in symbols if s.name == "Index" and s.kind == "class"), None)
+    assert view is not None
+    assert view.language == "razor"
+
+    csharp_method = next((s for s in symbols if s.name == "FullName"), None)
+    assert csharp_method is not None
+    assert csharp_method.kind == "method"
+    assert csharp_method.language == "csharp"
+    assert csharp_method.qualified_name == "Index.FullName"
+    assert csharp_method.parent == view.id
+
+    csharp_field = next((s for s in symbols if s.name == "Count"), None)
+    assert csharp_field is not None
+    assert csharp_field.kind == "constant"
+    assert csharp_field.language == "csharp"
+    assert csharp_field.parent == view.id
+
+    html_id = next((s for s in symbols if s.name == "profile-card"), None)
+    assert html_id is not None
+    assert html_id.kind == "constant"
+    assert html_id.language == "razor"
+    assert html_id.parent == view.id
+
+    external_script = next((s for s in symbols if s.name == "profile.js"), None)
+    assert external_script is not None
+    assert external_script.kind == "function"
+    assert external_script.language == "razor"
+    assert external_script.parent == view.id
+
+    inline_js = next((s for s in symbols if s.name == "toggleCard"), None)
+    assert inline_js is not None
+    assert inline_js.kind == "function"
+    assert inline_js.language == "javascript"
+    assert inline_js.qualified_name == "Index.toggleCard"
+    assert inline_js.parent == view.id
+
+    style = next((s for s in symbols if s.name == "style_1"), None)
+    assert style is not None
+    assert style.kind == "constant"
+    assert style.language == "razor"
+    assert style.parent == view.id
+
+
+def test_parse_razor_code_block_handles_nested_braces_and_strings():
+    source = """\
+@code {
+    public string Render()
+    {
+        var json = "{ \\"enabled\\": true }";
+        if (json.Contains("{"))
+        {
+            return json;
+        }
+        return string.Empty;
+    }
+}
+"""
+
+    symbols = parse_file(source, "Views/Shared/Editor.cshtml", "razor")
+
+    view = next((s for s in symbols if s.name == "Editor" and s.kind == "class"), None)
+    assert view is not None
+
+    render = next((s for s in symbols if s.name == "Render"), None)
+    assert render is not None
+    assert render.kind == "method"
+    assert render.language == "csharp"
+    assert render.parent == view.id
+    assert render.line >= 2
+    assert render.end_line >= render.line
+
+
+def test_discover_local_files_includes_cshtml(tmp_path):
+    view = tmp_path / "Views" / "Home"
+    view.mkdir(parents=True)
+    (view / "Index.cshtml").write_text("<div id='hero'></div>", encoding="utf-8")
+
+    files, warnings, skip_counts = discover_local_files(tmp_path)
+    paths = {Path(f).name for f in files}
+
+    assert "Index.cshtml" in paths
+    assert warnings == []
+    assert skip_counts["wrong_extension"] == 0
+
+
+def test_index_folder_parses_razor_symbols(tmp_path):
+    root = tmp_path / "site"
+    views = root / "Views" / "Home"
+    views.mkdir(parents=True)
+    (views / "Index.cshtml").write_text(_load(), encoding="utf-8")
+
+    result = index_folder(str(root), use_ai_summaries=False, storage_path=str(tmp_path / "store"))
+
+    assert result["success"] is True
+    assert result["file_count"] == 1
+    assert result["languages"]["razor"] == 1
+    assert result["symbol_count"] >= 6
+    assert "Views/Home/Index.cshtml" in result["files"]
+
+
+def test_parse_public_razor_layout_fixture():
+    symbols = parse_file(_load_public(), "Views/Shared/_Layout.cshtml", "razor")
+
+    view = next((s for s in symbols if s.name == "_Layout" and s.kind == "class"), None)
+    assert view is not None
+    assert view.language == "razor"
+
+    scripts = {s.name: s for s in symbols if s.kind == "function"}
+    assert "jquery.min.js" in scripts
+    assert "bootstrap.bundle.min.js" in scripts
+    assert "site.js" in scripts
+
+    assert scripts["jquery.min.js"].parent == view.id
+    assert scripts["bootstrap.bundle.min.js"].parent == view.id
+    assert scripts["site.js"].parent == view.id

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -58,6 +58,7 @@ async def test_search_symbols_tool_schema():
     assert set(props["kind"]["enum"]) == {"function", "class", "method", "constant", "type", "template", "import"}
     assert "enum" in props["language"]
     assert "cpp" in props["language"]["enum"]
+    assert "razor" in props["language"]["enum"]
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "jcodemunch-mcp"
-version = "1.7.2"
+version = "1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Summary

  - Adds a dedicated `CshtmlExtractor` for parsing ASP.NET Core Razor (`.cshtml`) files, which embed C# within HTML
  templates
  - Registers `.cshtml` as a recognized extension mapped to the `razor` language profile
  - Adds two fixture files and a full test suite validating symbol extraction

  ## Motivation

  `.cshtml` files are ubiquitous in .NET web projects and contain a mix of C# logic and HTML markup. Without
  language-aware parsing, jCodeMunch treats them as opaque blobs — none of the symbols, methods, or directives are
  indexed. This PR closes that gap so .NET Razor projects get the same token-savings benefits as other supported
  languages.

  ## What changed

  | File | Change |
  |------|--------|
  | `src/jcodemunch_mcp/parser/extractor.py` | New `_parse_razor_symbols()` function (~300 lines) handling `@{ }` code
  blocks, `@functions { }` / `@code { }` blocks, C# method/class extraction, `@model` / `@using` / `@inject` directives,
   `<script>` and `<style>` blocks, and HTML element ID extraction |
  | `src/jcodemunch_mcp/parser/languages.py` | Registers `.cshtml` → `razor` in the extension map |
  | `src/jcodemunch_mcp/server.py` | Minor follow-on update |
  | `tests/fixtures/razor/sample.cshtml` | Minimal fixture for unit tests |
  | `tests/fixtures/razor/dotnet_aspnetcore_layout.cshtml` | Full real-world ASP.NET Core layout page fixture |
  | `tests/test_razor.py` | 151-line test file covering symbol extraction, directive parsing, method detection, index
  integration, and edge cases |

  ## Test plan

  - [ ] `pytest tests/test_razor.py` — all Razor-specific tests pass
  - [ ] `pytest tests/test_server.py` — no regressions in server tests
  - [ ] Manually verify `.cshtml` files are discovered and indexed via `index_folder`

  ## Notes

  No new dependencies introduced. The extractor uses only stdlib `re` patterns, consistent with the existing custom
  extractor approach used for Vue, Nix, and other languages in this codebase.