### PR TITLE
feat(config): centralized JSONC configuration with language filtering, tool gating, and meta control

### DIFF
--- a/.planning/phases/01-config-jsonc/phase-01-plan-SUMMARY.md
+++ b/.planning/phases/01-config-jsonc/phase-01-plan-SUMMARY.md
@@ -1,0 +1,165 @@
+---
+phase: 1
+plan: 2026-03-23-config-jsonc
+subsystem: config
+tags: [python, tdd, jsonc, mcp, config, cli]
+dependency-graph:
+  requires: []
+  provides: [centralized-jsonc-config]
+  affects: [server, security, cli]
+tech-stack:
+  added: []
+  patterns: [tdd, config-layering, env-var-deprecation]
+---
+
+# Phase 1 Plan: Centralized JSONC Config Implementation Summary
+
+## One-Liner
+
+Implemented two-layer JSONC config system (`~/.code-index/config.jsonc` + per-project `.jcodemunch.jsonc`) with TDD, replacing ~23 deprecated `JCODEMUNCH_*` env vars with a centralized config module.
+
+## Overview
+
+Replaced scattered `JCODEMUNCH_*` env var reads across server.py, security.py with a single `config.py` module supporting:
+- **JSONC parsing** with `//` and `/* */` comment stripping
+- **Two-layer config**: global `config.jsonc` + per-project `.jcodemunch.jsonc`
+- **Env var fallback**: deprecated env vars still work with one-time warnings (removed in v2.0)
+- **Token-control levers**: `disabled_tools`, `languages`, `meta_fields`, `descriptions`
+- **SQL gating**: `search_columns` auto-disabled when SQL not in languages
+
+## Tasks Completed
+
+| Task | Name | Commit |
+|------|------|--------|
+| 1.1 | JSONC line comment stripping | b597e00 |
+| 1.2 | JSONC block comment stripping | 0f2003c |
+| 1.3 | Config defaults and type definitions | 86d1cb1 |
+| 1.4 | Config loading - missing file | 08910cc |
+| 1.5 | Config loading - valid JSONC | 92d6f9e |
+| 1.6 | Config type validation | 9675d23 |
+| 1.7 | Project config loading with merge | 6d5f216 |
+| 1.8 | Tool and language checking functions | 5fbc5de |
+| 1.9 | Template generation | f1cc354 |
+| 1.10 | get_descriptions() | e2571ed |
+| 1.11 | Env var fallback with warnings | d8d7f01 |
+| 2.1 | Dynamic tool filtering | e31ebea |
+| 2.1b | Dynamic language enum | c502bc0 |
+| 2.2 | Remove suppress_meta, meta_fields config | 547bc3b |
+| 2.3/2.5 | Descriptions merge with _shared | 49ac94a |
+| 3.1 | Security module config integration | 2530e48 |
+| 4.1 | config --init CLI command | 8c5a7ca |
+| 6.1 | SQL gating auto-disables search_columns | 8788509 |
+| fix | test_tools.py env var tests | 5733602 |
+
+## Key Files Created/Modified
+
+### Created
+- `src/jcodemunch_mcp/config.py` — Centralized config module (~370 lines)
+  - `_strip_jsonc()` — JSONC comment stripper
+  - `DEFAULTS`, `CONFIG_TYPES`, `ENV_VAR_MAPPING` constants
+  - `load_config()`, `load_project_config()`, `get()`, `is_tool_disabled()`, `is_language_enabled()`, `get_descriptions()`, `generate_template()`
+  - `_validate_type()`, `_parse_env_value()`, `_apply_env_var_fallback()`
+- `tests/test_config.py` — 23 tests for config module
+
+### Modified
+- `src/jcodemunch_mcp/server.py` — 12 key changes:
+  - Import config module
+  - Add `_build_language_enum()` helper
+  - Add `_apply_description_overrides()` helper
+  - Dynamic tool filtering (disabled_tools)
+  - Dynamic language enum (languages)
+  - Remove suppress_meta param, replace with meta_fields config
+  - SQL gating (auto-disable search_columns when SQL absent)
+  - Config init CLI support
+- `src/jcodemunch_mcp/security.py` — 3 env var reads replaced with config.get():
+  - `get_max_index_files()`
+  - `get_max_folder_files()`
+  - `get_extra_ignore_patterns()`
+- `tests/test_security.py` — Updated 10 env-var tests to config-based
+- `tests/test_tools.py` — Updated 4 env-var tests to config-based
+- `tests/test_cli.py` — Added 2 tests for `config --init`
+- `tests/test_server.py` — Added 11 new tests for server integration
+
+## Decisions Made
+
+1. **JSONC template uses active values** — Template generates with ALL values active (no commented-out lines) to avoid trailing comma complexity in the JSONC parser. Users can edit to comment out unwanted values.
+
+2. **JSONC parser handles trailing commas** — Block comment `/* comment */` strips preceding `,` to avoid JSON parse errors from trailing commas left by commented-out lines.
+
+3. **Descriptions merge: tool-specific > _shared > original** — Tool-specific param descriptions override `_shared`, which overrides original. `_tool` replaces entire tool description.
+
+4. **SQL gating runs after disabled_tools filter** — SQL gating happens AFTER user-specified `disabled_tools`, so explicit `search_columns` in `disabled_tools` still works when SQL is in languages.
+
+5. **Env var fallback uses one-time warning** — `_DEPRECATED_ENV_VARS_LOGGED` set tracks which vars have been warned to avoid spam.
+
+6. **Config loaded once at startup** — Global `config.jsonc` loaded once, per-project `.jcodemunch.jsonc` cached by repo path.
+
+7. **Per-call max_files param still works** — `get_max_index_files(max_files=5)` and `get_max_folder_files(max_files=5)` take precedence over config for explicit overrides.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**[Rule 1 - Bug] JSONC parser missing trailing comma handling**
+- Found during: Task 1.9 (Template Generation)
+- Issue: When block comment `/* comment */` appears on its own line between JSON key-value pairs, the preceding `,` is left behind and breaks JSON parsing.
+- Fix: Enhanced `_strip_jsonc()` to detect `,` immediately before `/*` and strip both.
+- Files modified: `src/jcodemunch_mcp/config.py`
+- Commit: f1cc354
+
+**[Rule 2 - Missing] Descriptions merge only runs when tool-specific entry exists**
+- Found during: Phase 2.3 (descriptions merge)
+- Issue: `_apply_description_overrides` skipped tools without explicit entry in descriptions config, preventing `_shared` from applying.
+- Fix: Changed `tool_desc = descriptions.get(tool.name)` to `descriptions.get(tool.name, {})` and removed the `if not tool_desc: continue` guard.
+- Files modified: `src/jcodemunch_mcp/server.py`
+- Commit: a13f98d
+
+**[Rule 3 - Blocking] Type safety in get_max_index_files/get_max_folder_files**
+- Found during: Phase 3 (security integration)
+- Issue: `max(value, 0)` crashes when `config.get()` returns a string (invalid type).
+- Fix: Added `isinstance(value, int) and value > 0` guard before returning.
+- Files modified: `src/jcodemunch_mcp/security.py`
+- Commit: 2530e48
+
+## Test Results
+
+| Test Suite | Passed | Failed | Skipped |
+|-----------|--------|--------|---------|
+| test_config.py | 23 | 0 | 0 |
+| test_server.py | 38 | 0 | 0 |
+| test_security.py | 105 | 0 | 4 |
+| test_cli.py | 4 | 0 | 0 |
+| test_tools.py | ~50 | 0 | 0 |
+| **Total** | **997** | **0** | **4** |
+
+> Note: 1 pre-existing failure in `test_storage.py::test_index_integrity_checksum` (unrelated to this work, fails on baseline).
+
+## Commits (21 total on feat/centralized-config-jsonc)
+
+```
+8788509 test+feat: Phase 6 - SQL gating auto-disables search_columns
+5733602 fix: Update test_tools.py env var tests to use config
+8c5a7ca test+feat: Phase 4 - config --init CLI command
+2530e48 test+feat: Phase 3 - Security module config integration
+49ac94a test+feat: Complete Phase 2 - Server Integration
+a13f98d test+feat: Descriptions config merge in list_tools
+547bc3b test+feat: Remove suppress_meta param, add meta_fields config
+c502bc0 test+feat: Dynamic language enum in search_symbols schema
+e31ebea test+feat: Dynamic tool filtering in list_tools
+d8d7f01 test+feat: Env var fallback with deprecation warnings
+e2571ed test+feat: get_descriptions() function
+f1cc354 test+feat: Config template generation, improved JSONC parser
+5fbc5de test+feat: Tool and language checking functions
+6d5f216 test+feat: Project config loading with merge
+9675d23 test+feat: Config type validation with warnings
+92d6f9e test+feat: Config loading with valid JSONC
+08910cc test+feat: Config loading with missing file handling
+86d1cb1 test+feat: Config defaults and type definitions
+0f2003c test+feat: JSONC block comment stripping
+b597e00 test+feat: JSONC line comment stripping with TDD
+```
+
+## Duration
+
+Started: 2026-03-23 (session)
+Completed: 2026-03-23

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,295 @@
+# Configuration Guide
+
+jcodemunch-mcp uses a centralized JSONC configuration file instead of (or alongside) environment variables.
+
+## Config files
+
+| File | Purpose |
+|------|---------|
+| `~/.code-index/config.jsonc` | Global defaults — applies to all repos |
+| `<project>/.jcodemunch.jsonc` | Project overrides — committed to version control, merges over global |
+
+On first server start, the global config is auto-created with a commented template. You can regenerate it at any time:
+
+```bash
+jcodemunch-mcp config --init
+```
+
+## Resolution order
+
+Settings are resolved from lowest to highest priority:
+
+```
+1. Hardcoded defaults          ← always present
+2. Global config.jsonc         ← overwrites defaults
+3. Project .jcodemunch.jsonc   ← merges over global, per-repo
+4. Environment variables       ← FALLBACK only (fills gaps, doesn't override)
+5. CLI flags                   ← highest priority (serve/watch commands)
+```
+
+**Why env vars are fallback, not override:** If env vars overrode project config, a global `JCODEMUNCH_MAX_FOLDER_FILES=10000` in your shell profile would silently break every project's tuned settings. With fallback semantics, config file values always win. Env vars only apply when the config key is absent.
+
+Env vars emit a one-time deprecation warning when used, pointing to config.jsonc.
+
+## CLI commands
+
+```bash
+# Print effective configuration with source tracking (default/config/env)
+jcodemunch-mcp config
+
+# Generate a commented config template
+jcodemunch-mcp config --init
+
+# Validate config + check prerequisites (storage, AI packages, HTTP transport)
+jcodemunch-mcp config --check
+```
+
+## Configuration reference
+
+### Indexing
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `max_folder_files` | int | `2000` | Maximum files indexed for local folders. Lower than repo default because folder indexing runs synchronously within the MCP timeout window. |
+| `max_index_files` | int | `10000` | Maximum files indexed for GitHub repos (async, no timeout constraint). |
+| `use_ai_summaries` | bool | `true` | Enable AI-generated symbol summaries. Requires an API key (Anthropic, Google, or local LLM). |
+| `summarizer_concurrency` | int | `4` | Parallel batch requests to the AI summarizer. |
+| `allow_remote_summarizer` | bool | `false` | Allow remote AI summarizer even when local LLM is configured. |
+| `extra_ignore_patterns` | list | `[]` | Additional gitignore-style patterns to exclude from indexing. Merged with per-call patterns. |
+| `extra_extensions` | dict | `{}` | Map file extensions to language names (e.g. `{".jsx": "javascript"}`). Extends the built-in extension map. |
+| `context_providers` | bool | `true` | Enable context providers (dbt model detection, etc.) during indexing. |
+| `staleness_days` | int | `7` | Days before `get_repo_outline` emits a staleness warning for remote repos. |
+| `max_results` | int | `500` | Hard cap on `search_columns` result count. |
+
+### Languages
+
+Controls which languages are parsed during indexing. When set, only listed languages get tree-sitter symbol extraction. Files of other languages are still discovered (for content caching) but produce no symbols.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `languages` | list or null | `null` | Language filter. `null` = all languages enabled. Set to a list to restrict. |
+
+**Example — Python-only project:**
+
+```jsonc
+{
+  // Only parse Python files. JS, SQL, etc. are discovered but not symbol-extracted.
+  // This also auto-disables search_columns and the dbt context provider.
+  "languages": ["python"]
+}
+```
+
+**Example — Python + TypeScript monorepo:**
+
+```jsonc
+{
+  "languages": ["python", "typescript", "tsx"]
+}
+```
+
+When `"sql"` is removed from the list:
+- `search_columns` tool is auto-removed from `list_tools()`
+- The dbt context provider is disabled
+- SQL files are not parsed (no symbols extracted)
+
+The full list of supported language identifiers matches the values in `LANGUAGE_REGISTRY` (see [LANGUAGE_SUPPORT.md](LANGUAGE_SUPPORT.md)).
+
+### Tools
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `disabled_tools` | list | `[]` | Tool names to remove from `list_tools()` schema. Project-level disabling also blocks execution via `call_tool()`. |
+| `descriptions` | dict | `{}` | Override tool and parameter descriptions. See [Descriptions](#descriptions) below. |
+
+**Example — disable tools you don't use:**
+
+```jsonc
+{
+  "disabled_tools": ["search_columns", "get_symbol_diff", "suggest_queries"]
+}
+```
+
+### Descriptions
+
+Customize tool descriptions to reduce schema tokens or tailor to your workflow. Two formats are supported:
+
+**Flat format** — override the tool description only:
+
+```jsonc
+{
+  "descriptions": {
+    "search_symbols": "Find code symbols in this Python project",
+    "get_file_tree": "Browse the directory structure"
+  }
+}
+```
+
+**Nested format** — override tool description and/or individual parameter descriptions:
+
+```jsonc
+{
+  "descriptions": {
+    "search_symbols": {
+      "_tool": "Find code symbols",
+      "query": "Symbol name to search for",
+      "language": "Filter by language"
+    },
+    // _shared applies to all tools that have these parameters
+    "_shared": {
+      "repo": "Repository name from list_repos"
+    }
+  }
+}
+```
+
+- `"_tool"` overrides the tool-level description
+- Named keys override individual parameter descriptions
+- `"_shared"` applies parameter overrides across all tools (tool-specific overrides take precedence)
+- Empty string `""` clears a description (useful for removing verbose defaults)
+
+### Meta response control
+
+Controls the `_meta` envelope included in tool responses. Reducing meta fields saves tokens per call.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `meta_fields` | list or null | `null` | `null` = all fields. `[]` = strip `_meta` entirely. List = include only named fields. |
+
+**Example — keep only timing and savings:**
+
+```jsonc
+{
+  "meta_fields": ["timing_ms", "tokens_saved"]
+}
+```
+
+**Example — strip all meta (maximum token savings):**
+
+```jsonc
+{
+  "meta_fields": []
+}
+```
+
+Available meta fields: `timing_ms`, `tokens_saved`, `total_tokens_saved`, `powered_by`, `index_stale`, `reindex_in_progress`, `stale_since_ms`, `files_searched`, `truncated`, `candidates_scored`.
+
+The legacy `suppress_meta` per-call parameter still works for backward compatibility.
+
+### Transport
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `transport` | str | `"stdio"` | Transport mode: `"stdio"`, `"sse"`, or `"streamable-http"`. |
+| `host` | str | `"127.0.0.1"` | Bind address for HTTP transports. |
+| `port` | int | `8901` | Port for HTTP transports. |
+| `rate_limit` | int | `0` | Max requests per minute per client IP in HTTP mode. `0` = disabled. |
+
+### Watcher
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `watch` | bool | `false` | Enable built-in file watcher alongside the MCP server. |
+| `watch_debounce_ms` | int | `2000` | Debounce interval for file change events. |
+| `freshness_mode` | str | `"relaxed"` | `"relaxed"` = serve stale results during reindex. `"strict"` = wait for fresh results (500ms timeout). |
+| `claude_poll_interval` | float | `5.0` | Poll interval (seconds) for Claude Code worktree discovery. |
+
+### Logging
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `log_level` | str | `"WARNING"` | Python log level: `"DEBUG"`, `"INFO"`, `"WARNING"`, `"ERROR"`. |
+| `log_file` | str or null | `null` | Path to log file. `null` = stderr only. |
+
+### Privacy and telemetry
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `redact_source_root` | bool | `false` | Replace absolute source paths with display names in responses. |
+| `stats_file_interval` | int | `3` | Calls between `session_stats.json` writes. `0` = disable (reduces NVMe writes). |
+| `share_savings` | bool | `true` | Send anonymous token savings telemetry to the community counter. |
+
+### Path remapping
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `path_map` | str | `""` | Cross-platform path prefix remapping. Format: `orig1=new1,orig2=new2`. |
+
+**Example — index on Linux, query from Windows (WSL):**
+
+```jsonc
+{
+  "path_map": "/home/user/project=D:\\Users\\user\\project"
+}
+```
+
+## Project-level overrides
+
+Place a `.jcodemunch.jsonc` file in your project root. It merges over the global config for that repo only.
+
+```jsonc
+// .jcodemunch.jsonc — committed to version control
+{
+  "languages": ["python"],
+  "max_folder_files": 5000,
+  "extra_ignore_patterns": ["*.generated.py", "migrations/"],
+  "disabled_tools": ["search_columns"],
+  "meta_fields": ["timing_ms", "tokens_saved"]
+}
+```
+
+Project config is loaded automatically when a repo is indexed. It uses hash-based caching — the file is only re-parsed when its content changes, not on every watcher cycle.
+
+## Migrating from environment variables
+
+Every `JCODEMUNCH_*` env var maps to a config key:
+
+| Environment variable | Config key |
+|---------------------|------------|
+| `JCODEMUNCH_USE_AI_SUMMARIES` | `use_ai_summaries` |
+| `JCODEMUNCH_MAX_FOLDER_FILES` | `max_folder_files` |
+| `JCODEMUNCH_MAX_INDEX_FILES` | `max_index_files` |
+| `JCODEMUNCH_STALENESS_DAYS` | `staleness_days` |
+| `JCODEMUNCH_MAX_RESULTS` | `max_results` |
+| `JCODEMUNCH_EXTRA_IGNORE_PATTERNS` | `extra_ignore_patterns` |
+| `JCODEMUNCH_EXTRA_EXTENSIONS` | `extra_extensions` |
+| `JCODEMUNCH_CONTEXT_PROVIDERS` | `context_providers` |
+| `JCODEMUNCH_REDACT_SOURCE_ROOT` | `redact_source_root` |
+| `JCODEMUNCH_STATS_FILE_INTERVAL` | `stats_file_interval` |
+| `JCODEMUNCH_SHARE_SAVINGS` | `share_savings` |
+| `JCODEMUNCH_SUMMARIZER_CONCURRENCY` | `summarizer_concurrency` |
+| `JCODEMUNCH_ALLOW_REMOTE_SUMMARIZER` | `allow_remote_summarizer` |
+| `JCODEMUNCH_RATE_LIMIT` | `rate_limit` |
+| `JCODEMUNCH_TRANSPORT` | `transport` |
+| `JCODEMUNCH_HOST` | `host` |
+| `JCODEMUNCH_PORT` | `port` |
+| `JCODEMUNCH_WATCH` | `watch` |
+| `JCODEMUNCH_WATCH_DEBOUNCE_MS` | `watch_debounce_ms` |
+| `JCODEMUNCH_FRESHNESS_MODE` | `freshness_mode` |
+| `JCODEMUNCH_CLAUDE_POLL_INTERVAL` | `claude_poll_interval` |
+| `JCODEMUNCH_LOG_LEVEL` | `log_level` |
+| `JCODEMUNCH_LOG_FILE` | `log_file` |
+| `JCODEMUNCH_PATH_MAP` | `path_map` |
+
+**Migration steps:**
+
+1. Run `jcodemunch-mcp config` to see your current effective configuration
+2. Run `jcodemunch-mcp config --init` to create a template
+3. Move env var values into the config file
+4. Remove the env vars from your shell profile
+5. Verify with `jcodemunch-mcp config` — source column should show "config" instead of "env"
+
+Env vars continue to work as fallback (they fill in keys not set in the config file) and emit a one-time deprecation warning per variable. They will be removed in v2.0.
+
+## Not in config
+
+These environment variables are **not** config keys and remain env-var only:
+
+| Variable | Reason |
+|----------|--------|
+| `CODE_INDEX_PATH` | Determines where the config file itself lives (circular dependency) |
+| `ANTHROPIC_API_KEY` | Secret — should not be in config files |
+| `GOOGLE_API_KEY` | Secret |
+| `OPENAI_API_KEY` / `OPENAI_API_BASE` | Secret / endpoint |
+| `GITHUB_TOKEN` | Secret |
+| `ANTHROPIC_MODEL` / `GOOGLE_MODEL` / `OPENAI_MODEL` | AI model selection — rarely changed, provider-specific |
+| `OPENAI_TIMEOUT` / `OPENAI_BATCH_SIZE` / `OPENAI_MAX_TOKENS` / `OPENAI_CONCURRENCY` | Local LLM tuning — see [USER_GUIDE.md](USER_GUIDE.md#11-local-llm-tuning-for-summaries) |

--- a/README.md
+++ b/README.md
@@ -213,31 +213,63 @@ Use jcodemunch-mcp for code lookup whenever available. Prefer symbol search, out
 
 ## Configuration
 
-All settings are controlled by environment variables. Defaults are chosen so that a fresh install works without touching any of them.
+Settings are controlled by a JSONC config file (`config.jsonc`) with env var fallbacks for backward compatibility. Defaults are chosen so that a fresh install works without any configuration.
 
-To see the current effective configuration:
+### Quick setup
 
 ```bash
-jcodemunch-mcp config           # show all settings
-jcodemunch-mcp config --check   # also verify prerequisites
+jcodemunch-mcp config --init       # create ~/.code-index/config.jsonc from template
+jcodemunch-mcp config              # show effective configuration
+jcodemunch-mcp config --check      # validate config + verify prerequisites
 ```
 
-`--check` validates that your AI provider package is installed, your index storage path is writable, and HTTP transport packages are present if you're using HTTP mode. Exits non-zero on any failure — useful for CI/CD or first-run scripts.
+`--check` validates that your config file is well-formed, your AI provider package is installed, your index storage path is writable, and HTTP transport packages are present. Exits non-zero on any failure — useful for CI/CD or first-run scripts.
 
-### Key variables
+### Config file locations
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `CODE_INDEX_PATH` | `~/.code-index/` | Where indexes are stored |
-| `JCODEMUNCH_USE_AI_SUMMARIES` | `true` | Set `false` to disable AI summaries globally |
-| `ANTHROPIC_API_KEY` | — | Enables Claude Haiku summaries (`pip install jcodemunch-mcp[anthropic]`) |
-| `GOOGLE_API_KEY` | — | Enables Gemini Flash summaries (`pip install jcodemunch-mcp[gemini]`) |
-| `OPENAI_API_BASE` | — | Local LLM endpoint (Ollama, LM Studio) |
-| `JCODEMUNCH_TRANSPORT` | `stdio` | Set `sse` or `streamable-http` for HTTP mode |
-| `JCODEMUNCH_HTTP_TOKEN` | — | Bearer token for HTTP transport auth |
-| `JCODEMUNCH_RATE_LIMIT` | `0` | Max requests/min per IP in HTTP mode (0 = off) |
-| `JCODEMUNCH_MAX_FOLDER_FILES` | 2,000 | File cap for `index_folder` |
-| `JCODEMUNCH_SHARE_SAVINGS` | `1` | Set `0` to disable anonymous token-savings telemetry |
+| Layer | Path | Purpose |
+|-------|------|---------|
+| Global | `~/.code-index/config.jsonc` | Server-wide defaults |
+| Project | `{project_root}/.jcodemunch.jsonc` | Per-project overrides |
+
+Project config merges over global config — closest to the work wins.
+
+### Token-control levers (reduce schema tokens per turn)
+
+| Config key | What it controls | Typical savings |
+|-----------|-----------------|----------------|
+| `disabled_tools` | Remove tools from schema entirely | ~100–400 tokens/tool |
+| `languages` | Shrink language enum + gate features | ~2–86 tokens/turn |
+| `meta_fields` | Filter `_meta` response fields | ~50–150 tokens/call |
+| `descriptions` | Control description verbosity | ~0–600 tokens/turn |
+
+See the full template for all available keys. Run `jcodemunch-mcp config --init` to generate one.
+
+### Deprecated env vars (v2.0 will remove)
+
+The following env vars still work but are deprecated. Config file values take priority:
+
+| Variable | Config key | Default |
+|----------|-----------|---------|
+| `JCODEMUNCH_USE_AI_SUMMARIES` | `use_ai_summaries` | `true` |
+| `JCODEMUNCH_MAX_FOLDER_FILES` | `max_folder_files` | `2000` |
+| `JCODEMUNCH_MAX_INDEX_FILES` | `max_index_files` | `10000` |
+| `JCODEMUNCH_STALENESS_DAYS` | `staleness_days` | `7` |
+| `JCODEMUNCH_MAX_RESULTS` | `max_results` | `500` |
+| `JCODEMUNCH_EXTRA_IGNORE_PATTERNS` | `extra_ignore_patterns` | `[]` |
+| `JCODEMUNCH_CONTEXT_PROVIDERS` | `context_providers` | `true` |
+| `JCODEMUNCH_REDACT_SOURCE_ROOT` | `redact_source_root` | `false` |
+| `JCODEMUNCH_STATS_FILE_INTERVAL` | `stats_file_interval` | `3` |
+| `JCODEMUNCH_SHARE_SAVINGS` | `share_savings` | `true` |
+| `JCODEMUNCH_SUMMARIZER_CONCURRENCY` | `summarizer_concurrency` | `4` |
+| `JCODEMUNCH_ALLOW_REMOTE_SUMMARIZER` | `allow_remote_summarizer` | `false` |
+| `JCODEMUNCH_RATE_LIMIT` | `rate_limit` | `0` |
+| `JCODEMUNCH_TRANSPORT` | `transport` | `stdio` |
+| `JCODEMUNCH_HOST` | `host` | `127.0.0.1` |
+| `JCODEMUNCH_PORT` | `port` | `8901` |
+| `JCODEMUNCH_LOG_LEVEL` | `log_level` | `WARNING` |
+
+AI provider keys (`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `OPENAI_API_BASE`, etc.) and `CODE_INDEX_PATH` are **always** read from env vars — they are never placed in config files.
 
 AI provider priority: Anthropic → Gemini → local LLM → signature fallback. The first key that is set wins. `jcodemunch-mcp config` shows which provider is active.
 

--- a/benchmarks/profile_config_regression.py
+++ b/benchmarks/profile_config_regression.py
@@ -1,0 +1,258 @@
+"""Benchmark all MCP tools against FlatCAM_EVO to detect config-change regressions.
+
+Measures both cold-index (first load from disk) and warm-index (LRU cache hit) performance.
+
+Usage:
+    python benchmarks/profile_config_regression.py [--iterations N] [--label LABEL]
+
+Writes JSON results to benchmarks/results_{label}.json
+"""
+
+import asyncio
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+# Ensure project root is on path
+PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+sys.path.insert(0, os.path.join(PROJECT_ROOT, "src"))
+
+REPO = "local/FlatCAM_EVO-abd24de5"
+ITERATIONS = 5
+
+
+async def setup():
+    """Initialize config and verify repo is indexed."""
+    # Load config if available (feature branch), otherwise skip (main)
+    try:
+        from jcodemunch_mcp import config as config_module
+        import tempfile
+        tmpdir = tempfile.mkdtemp(prefix="jcm_bench_")
+        config_module.load_config(tmpdir)
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    from jcodemunch_mcp.server import call_tool
+    result = await call_tool("list_repos", {})
+    repos = json.loads(result[0].text)
+    repo_names = [r["repo"] for r in repos.get("repos", [])]
+    if REPO not in repo_names:
+        print(f"ERROR: {REPO} not indexed. Available: {repo_names}")
+        sys.exit(1)
+    return call_tool
+
+
+async def discover_targets(call_tool):
+    """Discover file paths and symbols for benchmarking."""
+    outline_result = await call_tool("get_file_tree", {"repo": REPO})
+    tree = json.loads(outline_result[0].text)
+
+    files = []
+    for f in tree.get("files", []):
+        if f.endswith(".py") and len(files) < 3:
+            files.append(f)
+
+    if not files:
+        search_result = await call_tool("search_symbols", {"repo": REPO, "query": "App", "max_results": 5})
+        search_data = json.loads(search_result[0].text)
+        for sym in search_data.get("results", []):
+            files.append(sym["file"])
+            break
+
+    symbols = []
+    class_name = None
+    if files:
+        outline = await call_tool("get_file_outline", {"repo": REPO, "file_path": files[0]})
+        outline_data = json.loads(outline[0].text)
+        for sym in outline_data.get("symbols", [])[:3]:
+            symbols.append(sym["id"])
+            if sym.get("kind") == "class" and not class_name:
+                class_name = sym["name"]
+
+    if not class_name:
+        search_result = await call_tool("search_symbols", {"repo": REPO, "query": "App", "kind": "class", "max_results": 1})
+        search_data = json.loads(search_result[0].text)
+        for sym in search_data.get("results", []):
+            class_name = sym["name"]
+            if not symbols:
+                symbols.append(sym["id"])
+
+    return {
+        "files": files,
+        "symbols": symbols,
+        "class_name": class_name or "App",
+        "search_query": "parse",
+        "identifier": "self",
+    }
+
+
+def build_tool_calls(targets):
+    """Build the list of (tool_name, arguments) to benchmark."""
+    files = targets["files"]
+    symbols = targets["symbols"]
+    file0 = files[0] if files else "app_Main.py"
+    sym0 = symbols[0] if symbols else None
+
+    calls = [
+        ("list_repos", {}),
+        ("get_session_stats", {}),
+        ("get_repo_outline", {"repo": REPO}),
+        ("get_file_tree", {"repo": REPO}),
+    ]
+
+    if files:
+        calls.append(("get_file_outline", {"repo": REPO, "file_path": file0}))
+        calls.append(("get_file_content", {"repo": REPO, "file_path": file0, "start_line": 1, "end_line": 50}))
+        calls.append(("find_importers", {"repo": REPO, "file_path": file0, "max_results": 10}))
+
+    if sym0:
+        calls.append(("get_symbol", {"repo": REPO, "symbol_id": sym0}))
+        calls.append(("get_context_bundle", {"repo": REPO, "symbol_id": sym0}))
+        calls.append(("get_related_symbols", {"repo": REPO, "symbol_id": sym0, "max_results": 5}))
+
+    calls.extend([
+        ("search_symbols", {"repo": REPO, "query": targets["search_query"], "max_results": 20}),
+        ("search_text", {"repo": REPO, "query": targets["search_query"], "max_results": 20}),
+        ("find_references", {"repo": REPO, "identifier": targets["identifier"], "max_results": 10}),
+        ("get_dependency_graph", {"repo": REPO, "file": file0, "depth": 2}),
+        ("get_blast_radius", {"repo": REPO, "symbol": targets["search_query"], "depth": 2}),
+        ("get_class_hierarchy", {"repo": REPO, "class_name": targets["class_name"]}),
+    ])
+
+    return calls
+
+
+def _evict_lru_cache():
+    """Evict the in-memory LRU index cache to simulate cold reads."""
+    # Primary cache: sqlite_store._index_cache (OrderedDict, module-level)
+    try:
+        from jcodemunch_mcp.storage.sqlite_store import _index_cache, _cache_lock
+        with _cache_lock:
+            _index_cache.clear()
+    except (ImportError, AttributeError):
+        pass
+    # Legacy cache: index_store._load_index_json_cached (functools.lru_cache)
+    try:
+        from jcodemunch_mcp.storage.index_store import _load_index_json_cached
+        _load_index_json_cached.cache_clear()
+    except (ImportError, AttributeError):
+        pass
+    # resolve_repo bare-name cache
+    try:
+        from jcodemunch_mcp.tools._utils import _BARE_NAME_CACHE
+        _BARE_NAME_CACHE.clear()
+    except (ImportError, AttributeError):
+        pass
+
+
+async def benchmark(call_tool, tool_calls, iterations, cold=False):
+    """Run each tool call N times and collect timings.
+
+    Args:
+        cold: If True, evict LRU cache before each iteration to measure
+              cold-index (disk read) performance.
+    """
+    results = {}
+
+    if not cold:
+        # Warmup run (fills LRU cache)
+        for name, args in tool_calls:
+            try:
+                await call_tool(name, args)
+            except Exception:
+                pass
+
+    for name, args in tool_calls:
+        timings = []
+        errors = 0
+        for _ in range(iterations):
+            if cold:
+                _evict_lru_cache()
+            t0 = time.perf_counter()
+            try:
+                await call_tool(name, args)
+            except Exception:
+                errors += 1
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            timings.append(elapsed_ms)
+
+        results[name] = {
+            "mean_ms": round(statistics.mean(timings), 2),
+            "median_ms": round(statistics.median(timings), 2),
+            "stdev_ms": round(statistics.stdev(timings), 2) if len(timings) > 1 else 0,
+            "min_ms": round(min(timings), 2),
+            "max_ms": round(max(timings), 2),
+            "iterations": iterations,
+            "errors": errors,
+        }
+
+    return results
+
+
+def _print_table(results, header="Tool"):
+    print(f"{header:<25} {'Mean (ms)':>10} {'Median':>10} {'StDev':>10} {'Min':>10} {'Max':>10}")
+    print("-" * 77)
+    for name, data in results.items():
+        print(f"{name:<25} {data['mean_ms']:>10.2f} {data['median_ms']:>10.2f} "
+              f"{data['stdev_ms']:>10.2f} {data['min_ms']:>10.2f} {data['max_ms']:>10.2f}")
+
+
+async def main():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iterations", type=int, default=ITERATIONS)
+    parser.add_argument("--label", default="current")
+    args = parser.parse_args()
+
+    print(f"Setting up (label={args.label}, iterations={args.iterations})...")
+    call_tool = await setup()
+
+    print("Discovering benchmark targets...")
+    targets = await discover_targets(call_tool)
+    print(f"  Files: {targets['files']}")
+    print(f"  Symbols: {targets['symbols'][:2]}...")
+    print(f"  Class: {targets['class_name']}")
+
+    tool_calls = build_tool_calls(targets)
+
+    # --- Warm index benchmark (LRU cache hit) ---
+    print(f"\n=== WARM INDEX (LRU cache hit) ===")
+    print(f"Benchmarking {len(tool_calls)} tools x {args.iterations} iterations...\n")
+    warm_results = await benchmark(call_tool, tool_calls, args.iterations, cold=False)
+    _print_table(warm_results)
+
+    # --- Cold index benchmark (disk read per call) ---
+    print(f"\n=== COLD INDEX (cache evicted per call) ===")
+    print(f"Benchmarking {len(tool_calls)} tools x {args.iterations} iterations...\n")
+    cold_results = await benchmark(call_tool, tool_calls, args.iterations, cold=True)
+    _print_table(cold_results)
+
+    # --- Cold vs Warm comparison ---
+    print(f"\n=== COLD vs WARM COMPARISON ===")
+    print(f"{'Tool':<25} {'Warm (ms)':>10} {'Cold (ms)':>10} {'Overhead':>10} {'Factor':>8}")
+    print("-" * 65)
+    for tool in warm_results:
+        w = warm_results[tool]["median_ms"]
+        c = cold_results[tool]["median_ms"]
+        overhead = c - w
+        factor = c / w if w > 0 else float("inf")
+        print(f"{tool:<25} {w:>10.2f} {c:>10.2f} {overhead:>+10.2f} {factor:>7.1f}x")
+
+    # Save to JSON
+    out_path = Path(__file__).parent / f"results_{args.label}.json"
+    out_path.write_text(json.dumps({
+        "label": args.label,
+        "repo": REPO,
+        "iterations": args.iterations,
+        "targets": {k: v for k, v in targets.items() if k != "symbols" or len(v) <= 3},
+        "warm": warm_results,
+        "cold": cold_results,
+    }, indent=2))
+    print(f"\nResults saved to {out_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/benchmarks/profile_language_filter.py
+++ b/benchmarks/profile_language_filter.py
@@ -1,0 +1,317 @@
+"""Benchmark: languages=["python"] config vs no config (all languages).
+
+Tests:
+  1. Query tools on FlatCAM_EVO with python-only config
+  2. Indexing a mixed-language folder to verify SQL/dbt gating
+  3. Tool availability (search_columns, language enum)
+
+Usage:
+    python benchmarks/profile_language_filter.py [--iterations N] [--label LABEL]
+"""
+
+import asyncio
+import json
+import os
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+sys.path.insert(0, os.path.join(PROJECT_ROOT, "src"))
+
+REPO = "local/FlatCAM_EVO-abd24de5"
+ITERATIONS = 5
+
+
+def _create_mixed_language_folder(base_dir):
+    """Create a small folder with Python, JS, SQL, and dbt files for indexing."""
+    folder = Path(base_dir) / "mixed_lang_project"
+    folder.mkdir(parents=True, exist_ok=True)
+
+    # Python file
+    (folder / "app.py").write_text(
+        'class UserService:\n'
+        '    """Handles user operations."""\n'
+        '    def get_user(self, user_id: int) -> dict:\n'
+        '        return {"id": user_id, "name": "test"}\n'
+        '\n'
+        '    def list_users(self) -> list:\n'
+        '        return []\n'
+        '\n'
+        'def main():\n'
+        '    svc = UserService()\n'
+        '    print(svc.get_user(1))\n',
+        encoding="utf-8",
+    )
+
+    # JavaScript file
+    (folder / "utils.js").write_text(
+        'function formatDate(date) {\n'
+        '  return date.toISOString();\n'
+        '}\n'
+        '\n'
+        'class Logger {\n'
+        '  log(msg) { console.log(msg); }\n'
+        '}\n'
+        '\n'
+        'module.exports = { formatDate, Logger };\n',
+        encoding="utf-8",
+    )
+
+    # SQL file (plain DDL)
+    (folder / "schema.sql").write_text(
+        'CREATE TABLE users (\n'
+        '    id INTEGER PRIMARY KEY,\n'
+        '    name VARCHAR(255) NOT NULL,\n'
+        '    email VARCHAR(255) UNIQUE\n'
+        ');\n'
+        '\n'
+        'CREATE TABLE orders (\n'
+        '    id INTEGER PRIMARY KEY,\n'
+        '    user_id INTEGER REFERENCES users(id),\n'
+        '    total DECIMAL(10, 2)\n'
+        ');\n',
+        encoding="utf-8",
+    )
+
+    # dbt model (SQL with Jinja)
+    models_dir = folder / "models"
+    models_dir.mkdir(exist_ok=True)
+    (models_dir / "stg_users.sql").write_text(
+        '{{ config(materialized="view") }}\n'
+        '\n'
+        'SELECT\n'
+        '    id,\n'
+        '    name,\n'
+        '    email,\n'
+        '    created_at\n'
+        'FROM {{ source("raw", "users") }}\n'
+        'WHERE email IS NOT NULL\n',
+        encoding="utf-8",
+    )
+
+    # dbt project file (triggers dbt provider detection)
+    (folder / "dbt_project.yml").write_text(
+        'name: test_project\n'
+        'version: "1.0.0"\n'
+        'profile: test\n'
+        'model-paths: ["models"]\n',
+        encoding="utf-8",
+    )
+
+    # TypeScript file
+    (folder / "api.ts").write_text(
+        'interface User {\n'
+        '  id: number;\n'
+        '  name: string;\n'
+        '}\n'
+        '\n'
+        'export function fetchUser(id: number): Promise<User> {\n'
+        '  return fetch(`/api/users/${id}`).then(r => r.json());\n'
+        '}\n',
+        encoding="utf-8",
+    )
+
+    return str(folder)
+
+
+async def setup(languages_config=None):
+    """Initialize config and return call_tool."""
+    tmpdir = tempfile.mkdtemp(prefix="jcm_langbench_")
+
+    try:
+        from jcodemunch_mcp import config as config_module
+
+        if languages_config is not None:
+            config_path = os.path.join(tmpdir, "config.jsonc")
+            with open(config_path, "w") as f:
+                json.dump({"languages": languages_config}, f)
+            config_module.load_config(tmpdir)
+            print(f"  Config: languages={config_module.get('languages')}")
+        else:
+            config_module.load_config(tmpdir)
+            print(f"  Config: languages={config_module.get('languages')} (all)")
+    except (ImportError, ModuleNotFoundError):
+        print("  Config: N/A (main branch, all languages)")
+
+    from jcodemunch_mcp.server import call_tool, list_tools
+    return call_tool, list_tools, tmpdir
+
+
+async def check_tool_gating(list_tools):
+    """Verify tool availability and schema based on config."""
+    tools = await list_tools()
+    tool_names = [t.name for t in tools]
+
+    has_search_columns = "search_columns" in tool_names
+
+    lang_enum = []
+    for t in tools:
+        if t.name == "search_symbols":
+            lang_enum = t.inputSchema.get("properties", {}).get("language", {}).get("enum", [])
+            break
+
+    return {
+        "total_tools": len(tool_names),
+        "search_columns_available": has_search_columns,
+        "search_symbols_languages": lang_enum,
+    }
+
+
+async def benchmark_query_tools(call_tool, iterations):
+    """Benchmark query tools against FlatCAM_EVO."""
+    tool_calls = [
+        ("list_repos", {}),
+        ("get_repo_outline", {"repo": REPO}),
+        ("get_file_tree", {"repo": REPO}),
+        ("get_file_outline", {"repo": REPO, "file_path": "appMain.py"}),
+        ("get_file_content", {"repo": REPO, "file_path": "appMain.py", "start_line": 1, "end_line": 50}),
+        ("get_symbol", {"repo": REPO, "symbol_id": "appMain.py::App#class"}),
+        ("search_symbols", {"repo": REPO, "query": "parse", "max_results": 20}),
+        ("search_text", {"repo": REPO, "query": "parse", "max_results": 20}),
+        ("find_references", {"repo": REPO, "identifier": "self", "max_results": 10}),
+        ("find_importers", {"repo": REPO, "file_path": "appMain.py", "max_results": 10}),
+        ("get_dependency_graph", {"repo": REPO, "file": "appMain.py", "depth": 2}),
+        ("get_class_hierarchy", {"repo": REPO, "class_name": "App"}),
+    ]
+
+    # Warmup
+    for name, args in tool_calls:
+        try:
+            await call_tool(name, args)
+        except Exception:
+            pass
+
+    results = {}
+    for name, args in tool_calls:
+        timings = []
+        for _ in range(iterations):
+            t0 = time.perf_counter()
+            try:
+                await call_tool(name, args)
+            except Exception:
+                pass
+            timings.append((time.perf_counter() - t0) * 1000)
+
+        results[name] = {
+            "median_ms": round(statistics.median(timings), 2),
+            "mean_ms": round(statistics.mean(timings), 2),
+            "stdev_ms": round(statistics.stdev(timings), 2) if len(timings) > 1 else 0,
+        }
+
+    return results
+
+
+async def benchmark_indexing(call_tool, tmpdir, iterations):
+    """Index a mixed-language folder and measure timing + symbol counts."""
+    folder = _create_mixed_language_folder(tmpdir)
+    storage_path = os.environ.get("CODE_INDEX_PATH")
+
+    results = {"timings_ms": [], "symbols_by_language": {}, "files_by_language": {}}
+
+    for i in range(iterations):
+        # Invalidate previous index
+        try:
+            await call_tool("invalidate_cache", {"repo": Path(folder).name})
+        except Exception:
+            pass
+
+        t0 = time.perf_counter()
+        result = await call_tool("index_folder", {
+            "path": folder,
+            "use_ai_summaries": False,
+        })
+        elapsed = (time.perf_counter() - t0) * 1000
+        results["timings_ms"].append(elapsed)
+
+        data = json.loads(result[0].text)
+        if i == 0:
+            # Capture language breakdown from first run
+            results["file_count"] = data.get("file_count", 0)
+            results["symbol_count"] = data.get("symbol_count", 0)
+            results["languages"] = data.get("languages", {})
+            results["duration_seconds"] = data.get("duration_seconds", 0)
+
+    results["median_ms"] = round(statistics.median(results["timings_ms"]), 2)
+    results["mean_ms"] = round(statistics.mean(results["timings_ms"]), 2)
+
+    # Check dbt provider detection
+    dbt_detected = False
+    try:
+        outline_result = await call_tool("get_repo_outline", {"repo": Path(folder).name})
+        outline = json.loads(outline_result[0].text)
+        # dbt provider would add dbt-specific symbols
+        dbt_detected = "dbt" in str(outline).lower()
+    except Exception:
+        pass
+    results["dbt_detected"] = dbt_detected
+
+    # Cleanup
+    try:
+        await call_tool("invalidate_cache", {"repo": Path(folder).name})
+    except Exception:
+        pass
+
+    return results
+
+
+async def main():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iterations", type=int, default=ITERATIONS)
+    parser.add_argument("--label", default="current")
+    parser.add_argument("--languages", nargs="*", default=None,
+                        help="Language filter (e.g. --languages python). Omit for all.")
+    args = parser.parse_args()
+
+    lang_config = args.languages  # None = all, ["python"] = python only
+    label = args.label
+
+    print(f"=== Language Filter Benchmark (label={label}) ===")
+    call_tool, list_tools_fn, tmpdir = await setup(lang_config)
+
+    # 1. Tool gating
+    print("\n--- Tool Gating ---")
+    gating = await check_tool_gating(list_tools_fn)
+    print(f"  Total tools: {gating['total_tools']}")
+    print(f"  search_columns available: {gating['search_columns_available']}")
+    print(f"  search_symbols languages: {gating['search_symbols_languages']}")
+
+    # 2. Query tools
+    print(f"\n--- Query Tools ({args.iterations} iterations) ---")
+    query_results = await benchmark_query_tools(call_tool, args.iterations)
+    print(f"  {'Tool':<25} {'Median (ms)':>12} {'Mean (ms)':>12}")
+    print(f"  {'-'*51}")
+    total = 0
+    for name, data in query_results.items():
+        print(f"  {name:<25} {data['median_ms']:>12.2f} {data['mean_ms']:>12.2f}")
+        total += data["median_ms"]
+    print(f"  {'-'*51}")
+    print(f"  {'TOTAL':<25} {total:>12.2f}")
+
+    # 3. Indexing
+    print(f"\n--- Indexing Mixed-Language Folder ({args.iterations} iterations) ---")
+    index_results = await benchmark_indexing(call_tool, tmpdir, args.iterations)
+    print(f"  Index time (median): {index_results['median_ms']:.1f} ms")
+    print(f"  Files indexed: {index_results.get('file_count', '?')}")
+    print(f"  Symbols found: {index_results.get('symbol_count', '?')}")
+    print(f"  Languages parsed: {index_results.get('languages', {})}")
+    print(f"  dbt detected: {index_results.get('dbt_detected', '?')}")
+
+    # Save
+    out_path = Path(__file__).parent / f"results_lang_{label}.json"
+    out_path.write_text(json.dumps({
+        "label": label,
+        "languages_config": lang_config,
+        "gating": gating,
+        "query": query_results,
+        "indexing": index_results,
+    }, indent=2))
+    print(f"\nResults saved to {out_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -186,3 +186,17 @@ def load_project_config(source_root: str) -> None:
             _PROJECT_CONFIGS[repo_key] = _GLOBAL_CONFIG.copy()
     else:
         _PROJECT_CONFIGS[repo_key] = _GLOBAL_CONFIG.copy()
+
+
+def is_tool_disabled(tool_name: str, repo: str | None = None) -> bool:
+    """Check if a tool is in disabled_tools."""
+    disabled = get("disabled_tools", [], repo=repo)
+    return tool_name in disabled
+
+
+def is_language_enabled(language: str, repo: str | None = None) -> bool:
+    """Check if a language is in the languages list."""
+    languages = get("languages", None, repo=repo)
+    if languages is None:  # None = all enabled
+        return True
+    return language in languages

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -1,0 +1,42 @@
+"""Centralized JSONC config for jcodemunch-mcp."""
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _strip_jsonc(text: str) -> str:
+    """Strip // and /* */ comments from JSONC, respecting quoted strings."""
+    result, i, n = [], 0, len(text)
+    in_str = False
+    while i < n:
+        ch = text[i]
+        if in_str:
+            result.append(ch)
+            if ch == '\\' and i + 1 < n:
+                result.append(text[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                in_str = False
+            i += 1
+        elif ch == '"':
+            in_str = True
+            result.append(ch)
+            i += 1
+        elif ch == '/' and i + 1 < n and text[i + 1] == '/':
+            # Line comment — skip to end of line
+            end = text.find('\n', i)
+            i = n if end == -1 else end
+        elif ch == '/' and i + 1 < n and text[i + 1] == '*':
+            # Block comment — skip to */
+            end = text.find('*/', i + 2)
+            i = n if end == -1 else end + 2
+        else:
+            result.append(ch)
+            i += 1
+    return ''.join(result)

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -223,6 +223,11 @@ def is_language_enabled(language: str, repo: str | None = None) -> bool:
     return language in languages
 
 
+def get_descriptions() -> dict:
+    """Get the nested descriptions dict."""
+    return _GLOBAL_CONFIG.get("descriptions", {})
+
+
 # Lazy import to avoid circular dependency
 def generate_template() -> str:
     """Return default config.jsonc content."""

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -93,13 +93,34 @@ def _strip_jsonc(text: str) -> str:
             result.append(ch)
             i += 1
         elif ch == '/' and i + 1 < n and text[i + 1] == '/':
-            # Line comment — skip to end of line
+            # Line comment — strip trailing comma and spaces from previous content
+            if result and result[-1] == ',':
+                result.pop()
+                while result and result[-1] in (' ', '\t'):
+                    result.pop()
             end = text.find('\n', i)
             i = n if end == -1 else end
         elif ch == '/' and i + 1 < n and text[i + 1] == '*':
             # Block comment — skip to */
             end = text.find('*/', i + 2)
-            i = n if end == -1 else end + 2
+            if end == -1:
+                i = n
+            else:
+                end_i = end + 2
+                if end_i < n and text[end_i] == ',':
+                    # Comma immediately after */ — strip it
+                    i = end_i + 1
+                elif end_i < n and text[end_i] == '\n':
+                    # Newline after */ — strip trailing comma only
+                    # Walk back to find the last non-whitespace character
+                    j = len(result) - 1
+                    while j >= 0 and result[j] in (' ', '\t'):
+                        j -= 1
+                    if j >= 0 and result[j] == ',':
+                        result.pop()  # pop comma only
+                    i = end_i
+                else:
+                    i = end_i
         else:
             result.append(ch)
             i += 1
@@ -200,3 +221,66 @@ def is_language_enabled(language: str, repo: str | None = None) -> bool:
     if languages is None:  # None = all enabled
         return True
     return language in languages
+
+
+# Lazy import to avoid circular dependency
+def generate_template() -> str:
+    """Return default config.jsonc content."""
+    from .parser.languages import LANGUAGE_REGISTRY
+
+    languages_list = list(LANGUAGE_REGISTRY.keys())
+    lang_str = ", ".join(f'"{lang}"' for lang in languages_list)
+
+    return f'''// jcodemunch-mcp configuration
+// Global: ~/.code-index/config.jsonc
+// Project: {{project_root}}/.jcodemunch.jsonc (optional, overrides global)
+//
+// All values below show defaults. Uncomment to override.
+// Env vars still work as fallback but are deprecated.
+{{
+  // === Indexing ===
+  "use_ai_summaries": true,
+  "max_folder_files": 2000,
+  "max_index_files": 10000,
+  "staleness_days": 7,
+  "max_results": 500,
+  "extra_ignore_patterns": [],
+  "extra_extensions": {{}},
+  "context_providers": true,
+
+  // === Meta Response Control ===
+  "meta_fields": null,
+
+  // === Languages ===
+  "languages": [{lang_str}],
+
+  // === Disabled Tools ===
+  "disabled_tools": [],
+
+  // === Descriptions ===
+  "descriptions": {{}},
+
+  // === Transport ===
+  "transport": "stdio",
+  "host": "127.0.0.1",
+  "port": 8901,
+  "rate_limit": 0,
+
+  // === Watcher ===
+  "watch": false,
+  "watch_debounce_ms": 2000,
+  "freshness_mode": "relaxed",
+  "claude_poll_interval": 5.0,
+
+  // === Logging ===
+  "log_level": "WARNING",
+  "log_file": null,
+
+  // === Privacy & Telemetry ===
+  "redact_source_root": false,
+  "stats_file_interval": 3,
+  "share_savings": true,
+  "summarizer_concurrency": 4,
+  "allow_remote_summarizer": false
+}}
+'''

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -157,3 +157,32 @@ def get(key: str, default: Any = None, repo: str | None = None) -> Any:
     if repo and repo in _PROJECT_CONFIGS:
         return _PROJECT_CONFIGS[repo].get(key, default)
     return _GLOBAL_CONFIG.get(key, default)
+
+
+def load_project_config(source_root: str) -> None:
+    """Load and cache .jcodemunch.jsonc for a project. Called on first index."""
+    project_config_path = Path(source_root) / ".jcodemunch.jsonc"
+    repo_key = str(Path(source_root).resolve())
+
+    if project_config_path.exists():
+        try:
+            content = project_config_path.read_text(encoding="utf-8")
+            stripped = _strip_jsonc(content)
+            project_config = json.loads(stripped)
+
+            # Merge over global
+            merged = {**_GLOBAL_CONFIG}
+            for key, value in project_config.items():
+                if key in CONFIG_TYPES:
+                    if _validate_type(key, value, CONFIG_TYPES[key]):
+                        merged[key] = value
+                    else:
+                        logger.warning(
+                            f"Project config key '{key}' has invalid type. Using global default."
+                        )
+            _PROJECT_CONFIGS[repo_key] = merged
+        except Exception as e:
+            logger.warning(f"Failed to load project config: {e}")
+            _PROJECT_CONFIGS[repo_key] = _GLOBAL_CONFIG.copy()
+    else:
+        _PROJECT_CONFIGS[repo_key] = _GLOBAL_CONFIG.copy()

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 # Global config storage
 _GLOBAL_CONFIG: dict[str, Any] = {}
 _PROJECT_CONFIGS: dict[str, dict[str, Any]] = {}  # repo -> merged config
+_PROJECT_CONFIG_HASHES: dict[str, str] = {}  # repo -> content hash of .jcodemunch.jsonc
 _DEPRECATED_ENV_VARS_LOGGED: set[str] = set()  # Track warned vars
 
 ENV_VAR_MAPPING = {
@@ -101,7 +102,10 @@ CONFIG_TYPES = {
 
 
 def _strip_jsonc(text: str) -> str:
-    """Strip // and /* */ comments from JSONC, respecting quoted strings."""
+    """Strip // and /* */ comments from JSONC, respecting quoted strings.
+    
+    Also strips trailing commas (common in JSONC but invalid in JSON).
+    """
     result, i, n = [], 0, len(text)
     in_str = False
     while i < n:
@@ -151,7 +155,39 @@ def _strip_jsonc(text: str) -> str:
         else:
             result.append(ch)
             i += 1
-    return ''.join(result)
+    
+    # Post-process: strip trailing commas before } and ]
+    # This handles JSONC's allowance of trailing commas
+    output = ''.join(result)
+    # Use a simple state machine to strip trailing commas
+    final = []
+    j = 0
+    m = len(output)
+    while j < m:
+        ch = output[j]
+        if ch == '"' and (j == 0 or output[j-1] != '\\'):
+            # Find end of string
+            final.append(ch)
+            j += 1
+            while j < m:
+                final.append(output[j])
+                if output[j] == '"' and output[j-1] != '\\':
+                    j += 1
+                    break
+                j += 1
+        elif ch in ('}', ']'):
+            # Strip trailing whitespace and comma before this
+            while final and final[-1] in (' ', '\t', '\n', '\r'):
+                final.pop()
+            if final and final[-1] == ',':
+                final.pop()
+            final.append(ch)
+            j += 1
+        else:
+            final.append(ch)
+            j += 1
+    
+    return ''.join(final)
 
 
 def _validate_type(key: str, value: Any, expected_type: type | tuple) -> bool:
@@ -173,24 +209,48 @@ def load_config(storage_path: str | None = None) -> None:
         index_path = os.environ.get("CODE_INDEX_PATH", str(Path.home() / ".code-index"))
         config_path = Path(index_path) / "config.jsonc"
 
-    # Load config if exists
+    # Auto-create default config if missing
+    if not config_path.exists():
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        template = generate_template()
+        config_path.write_text(template, encoding="utf-8")
+        logger.info("Created default config at %s", config_path)
+
+    # Load config
+    _explicit_keys: set[str] = set()  # Track keys explicitly set in config file
     if config_path.exists():
         try:
-            content = config_path.read_text(encoding="utf-8")
+            content = config_path.read_text(encoding="utf-8-sig")  # utf-8-sig handles BOM
             stripped = _strip_jsonc(content)
             loaded = json.loads(stripped)
 
-            # Type validation
+            # Start with defaults, then overlay valid config values
+            _GLOBAL_CONFIG = DEFAULTS.copy()
             for key, value in loaded.items():
                 if key in CONFIG_TYPES:
                     if _validate_type(key, value, CONFIG_TYPES[key]):
-                        _GLOBAL_CONFIG[key] = value
+                        # Special validation for languages list
+                        if key == "languages" and isinstance(value, list):
+                            from .parser.languages import LANGUAGE_REGISTRY
+                            valid_langs = []
+                            for lang in value:
+                                if lang in LANGUAGE_REGISTRY:
+                                    valid_langs.append(lang)
+                                else:
+                                    logger.warning(
+                                        "Config key 'languages' contains unknown language '%s'. "
+                                        "Known languages: %s...",
+                                        lang, list(LANGUAGE_REGISTRY.keys())[:5]
+                                    )
+                            _GLOBAL_CONFIG[key] = valid_langs
+                        else:
+                            _GLOBAL_CONFIG[key] = value
+                        _explicit_keys.add(key)  # Track explicitly set keys
                     else:
                         logger.warning(
                             f"Config key '{key}' has invalid type. "
                             f"Expected {CONFIG_TYPES[key]}, got {type(value).__name__}. Using default."
                         )
-                        _GLOBAL_CONFIG[key] = DEFAULTS.get(key)
                 # Ignore unknown keys silently
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse config.jsonc: {e}")
@@ -201,8 +261,8 @@ def load_config(storage_path: str | None = None) -> None:
     else:
         _GLOBAL_CONFIG = DEFAULTS.copy()
 
-    # Apply env var fallback for keys not set in config
-    _apply_env_var_fallback()
+    # Apply env var fallback for keys not explicitly set in config
+    _apply_env_var_fallback(_explicit_keys)
 
 
 def _parse_env_value(value: str, expected_type: type | tuple) -> Any:
@@ -217,22 +277,53 @@ def _parse_env_value(value: str, expected_type: type | tuple) -> Any:
         elif expected_type == str:
             return value
         elif expected_type == list:
-            return json.loads(value)
+            # Try JSON array first (["*.log", "*.tmp"])
+            try:
+                return json.loads(value)
+            except (ValueError, json.JSONDecodeError):
+                # Fall back to legacy comma-separated format (*.log,*.tmp)
+                result = []
+                for token in value.split(","):
+                    token = token.strip()
+                    if token:
+                        result.append(token)
+                return result if result else None
         elif expected_type == dict:
-            return json.loads(value)
+            # Try JSON first (new format: {"ext": "lang", ...})
+            try:
+                return json.loads(value)
+            except (ValueError, json.JSONDecodeError):
+                # Fall back to legacy comma-separated format (.ext:lang,.ext:lang)
+                result = {}
+                for token in value.split(","):
+                    token = token.strip()
+                    if not token or ":" not in token:
+                        continue
+                    ext, _, lang = token.partition(":")
+                    ext = ext.strip()
+                    lang = lang.strip()
+                    if ext and lang:
+                        result[ext] = lang
+                return result if result else None
+        else:
+            logger.warning(f"Unknown config type %s for env var value: %s", expected_type, value)
+            return None
     except (ValueError, json.JSONDecodeError):
         logger.warning(f"Failed to parse env var value: {value}")
         return None
     return value
 
 
-def _apply_env_var_fallback() -> None:
-    """Apply deprecated env var fallback for keys not in config."""
+def _apply_env_var_fallback(explicit_keys: set[str] | None = None) -> None:
+    """Apply deprecated env var fallback for keys not explicitly set in config."""
     global _GLOBAL_CONFIG
 
+    if explicit_keys is None:
+        explicit_keys = set()
+
     for env_var, config_key in ENV_VAR_MAPPING.items():
-        # Skip if config key already set
-        if config_key in _GLOBAL_CONFIG:
+        # Skip if config key was explicitly set in config file
+        if config_key in explicit_keys:
             continue
 
         env_value = os.environ.get(env_var)
@@ -261,14 +352,36 @@ def get(key: str, default: Any = None, repo: str | None = None) -> Any:
     return _GLOBAL_CONFIG.get(key, default)
 
 
+def _content_hash(content: str) -> str:
+    """Compute SHA-256 hash of content (first 12 hex chars)."""
+    import hashlib
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()[:12]
+
+
 def load_project_config(source_root: str) -> None:
-    """Load and cache .jcodemunch.jsonc for a project. Called on first index."""
+    """Load and cache .jcodemunch.jsonc for a project.
+    
+    Uses hash-based caching: if the config file content hasn't changed,
+    the cached config is reused. This handles:
+    - First-time indexing (no cache)
+    - Incremental reindexes (cache hit, no parse)
+    - Config file edited (hash changed, reload)
+    - File touched but unchanged (hash same, no reload)
+    - Index dropped and recreated (cache still valid if file unchanged)
+    """
     project_config_path = Path(source_root) / ".jcodemunch.jsonc"
     repo_key = str(Path(source_root).resolve())
 
     if project_config_path.exists():
         try:
-            content = project_config_path.read_text(encoding="utf-8")
+            content = project_config_path.read_text(encoding="utf-8-sig")
+            content_hash = _content_hash(content)
+            
+            # Check if content unchanged (handles touch, mtime-only changes)
+            if repo_key in _PROJECT_CONFIGS:
+                if _PROJECT_CONFIG_HASHES.get(repo_key) == content_hash:
+                    return  # Cache is fresh
+            
             stripped = _strip_jsonc(content)
             project_config = json.loads(stripped)
 
@@ -283,11 +396,50 @@ def load_project_config(source_root: str) -> None:
                             f"Project config key '{key}' has invalid type. Using global default."
                         )
             _PROJECT_CONFIGS[repo_key] = merged
+            _PROJECT_CONFIG_HASHES[repo_key] = content_hash
         except Exception as e:
             logger.warning(f"Failed to load project config: {e}")
             _PROJECT_CONFIGS[repo_key] = _GLOBAL_CONFIG.copy()
     else:
-        _PROJECT_CONFIGS[repo_key] = _GLOBAL_CONFIG.copy()
+        # No config file - use global defaults
+        # Only cache if not already cached (avoids overwriting valid config)
+        if repo_key not in _PROJECT_CONFIGS:
+            _PROJECT_CONFIGS[repo_key] = _GLOBAL_CONFIG.copy()
+        _PROJECT_CONFIG_HASHES.pop(repo_key, None)
+
+
+def _list_repos_for_config() -> list[dict]:
+    """Get list of indexed repos for project config loading.
+    
+    Deferred import to avoid circular dependency at module load time.
+    """
+    from .storage.index_store import IndexStore
+    storage_path = os.environ.get("CODE_INDEX_PATH", str(Path.home() / ".code-index"))
+    store = IndexStore(base_path=storage_path)
+    return store.list_repos()
+
+
+def load_all_project_configs() -> None:
+    """Load project configs for all already-indexed local repos.
+    
+    Called once at server startup after load_config(). Discovers all indexed
+    local repos via list_repos() and loads their .jcodemunch.jsonc files.
+    Remote repos (empty source_root) are skipped.
+    """
+    if not _GLOBAL_CONFIG:
+        return
+    
+    try:
+        repos = _list_repos_for_config()
+        for repo_entry in repos:
+            source_root = repo_entry.get("source_root", "")
+            if not source_root:
+                continue
+            repo_key = str(Path(source_root).resolve())
+            if repo_key not in _PROJECT_CONFIGS:
+                load_project_config(source_root)
+    except Exception as e:
+        logger.warning("Failed to load project configs at startup: %s", e)
 
 
 def is_tool_disabled(tool_name: str, repo: str | None = None) -> bool:
@@ -309,14 +461,6 @@ def get_descriptions() -> dict:
     return _GLOBAL_CONFIG.get("descriptions", {})
 
 
-# Lazy import to avoid circular dependency
-def generate_template() -> str:
-    """Return default config.jsonc content."""
-    from .parser.languages import LANGUAGE_REGISTRY
-
-    languages_list = list(LANGUAGE_REGISTRY.keys())
-    lang_str = ", ".join(f'"{lang}"' for lang in languages_list)
-
 def validate_config(config_path: str) -> list[str]:
     """Validate a config.jsonc file and return a list of issue messages.
 
@@ -334,7 +478,7 @@ def validate_config(config_path: str) -> list[str]:
         return [f"Config file not found: {config_path}"]
 
     try:
-        content = path.read_text(encoding="utf-8")
+        content = path.read_text(encoding="utf-8-sig")  # utf-8-sig handles BOM
         stripped = _strip_jsonc(content)
         loaded = json.loads(stripped)
     except json.JSONDecodeError as e:
@@ -344,9 +488,11 @@ def validate_config(config_path: str) -> list[str]:
     for key, value in loaded.items():
         if key in CONFIG_TYPES:
             if not _validate_type(key, value, CONFIG_TYPES[key]):
+                expected = CONFIG_TYPES[key]
+                type_name = getattr(expected, "__name__", str(expected))
                 issues.append(
                     f"Config key '{key}' has invalid type: "
-                    f"expected {CONFIG_TYPES[key].__name__}, got {type(value).__name__}"
+                    f"expected {type_name}, got {type(value).__name__}"
                 )
         else:
             issues.append(f"Config key '{key}' is not recognized (unknown key)")
@@ -361,6 +507,28 @@ def generate_template() -> str:
     languages_list = list(LANGUAGE_REGISTRY.keys())
     lang_str = ", ".join(f'"{lang}"' for lang in languages_list)
 
+    # All available tools (for disabled_tools reference)
+    all_tools = [
+        "index_repo", "index_folder", "index_file", "list_repos",
+        "get_file_tree", "get_file_outline", "get_symbol", "get_file_content",
+        "get_symbols", "search_symbols", "search_text", "search_columns",
+        "get_repo_outline", "get_context_bundle", "get_session_stats",
+        "get_dependency_graph", "get_symbol_diff", "get_class_hierarchy",
+        "get_related_symbols", "get_blast_radius", "suggest_queries",
+        "find_importers", "find_references", "check_references",
+        "invalidate_cache", "wait_for_fresh",
+    ]
+    tools_str = "\n    //   ".join(f'"{t}",' for t in all_tools)
+
+    # All available meta_fields (for template documentation)
+    meta_fields_list = [
+        "timing_ms", "powered_by", "index_stale", "reindex_in_progress",
+        "stale_since_ms", "reindex_error", "reindex_failures",
+        "candidates_scored", "token_budget", "tokens_used", "tokens_remaining",
+    ]
+    # Commented-out example for meta_fields section in template (each field on its own line)
+    meta_str = "\n  //   ".join(f'"{mf}",' for mf in meta_fields_list)
+
     return f'''// jcodemunch-mcp configuration
 // Global: ~/.code-index/config.jsonc
 // Project: {{project_root}}/.jcodemunch.jsonc (optional, overrides global)
@@ -369,48 +537,84 @@ def generate_template() -> str:
 // Env vars still work as fallback but are deprecated.
 {{
   // === Indexing ===
-  "use_ai_summaries": true,
-  "max_folder_files": 2000,
-  "max_index_files": 10000,
-  "staleness_days": 7,
-  "max_results": 500,
-  "extra_ignore_patterns": [],
-  "extra_extensions": {{}},
-  "context_providers": true,
+  // "use_ai_summaries": true,
+  // "max_folder_files": 2000,
+  // "max_index_files": 10000,
+  // "staleness_days": 7,
+  // "max_results": 500,
+  // "extra_ignore_patterns": [],
+  // "extra_extensions": {{}},
+  // "context_providers": true,
 
   // === Meta Response Control ===
+  // Allowlist of _meta fields to include in responses.
+  // Empty list = no _meta at all (maximum token savings).
+  // Absent/null = all fields included (backward compatible default).
+  // Uncomment and set to a list of field names to include only those fields.
+  // Available fields:{meta_str}
+  // "meta_fields": [
+  //   "timing_ms",
+  //   "powered_by"
+  // ],
   "meta_fields": null,
 
   // === Languages ===
+  // All supported languages. Comment out to disable a language
+  // and its dependent features (e.g. "sql" disables dbt parsing
+  // and search_columns tool).
   "languages": [{lang_str}],
 
   // === Disabled Tools ===
+  // Global: tools listed here are removed from the schema entirely.
+  // Project: tools listed here are rejected at call_tool() with an
+  //   explanatory error (schema is global, can't be changed per-project).
+  // Default: empty (all tools enabled). Uncomment to disable specific tools.
+  // Available tools: {tools_str}
   "disabled_tools": [],
 
   // === Descriptions ===
-  "descriptions": {{}},
+  // Append text to shortened tool/param descriptions.
+  // Empty string = use hardcoded minimal base only.
+  // _tool = tool-level description, other keys = param names.
+  // _shared applies across all tools (tool-specific overrides _shared).
+  // Tools not listed here keep their full current descriptions unchanged.
+  "descriptions": {{
+    // === Example: Uncomment to enable ===
+    // "search_symbols": {{
+    //   "_tool": "",
+    //   "debug": "",
+    //   "detail_level": "",
+    //   "language": ""
+    // }},
+    // "find_importers": {{ "_tool": "" }},
+    // "find_references": {{ "_tool": "" }},
+    // "get_blast_radius": {{ "_tool": "" }},
+    // "get_context_bundle": {{ "_tool": "" }},
+    // "suggest_queries": {{ "_tool": "" }},
+    // "_shared": {{ "repo": "" }}
+  }}
 
   // === Transport ===
-  "transport": "stdio",
-  "host": "127.0.0.1",
-  "port": 8901,
-  "rate_limit": 0,
+  // "transport": "stdio",
+  // "host": "127.0.0.1",
+  // "port": 8901,
+  // "rate_limit": 0,
 
   // === Watcher ===
-  "watch": false,
-  "watch_debounce_ms": 2000,
-  "freshness_mode": "relaxed",
-  "claude_poll_interval": 5.0,
+  // "watch": false,
+  // "watch_debounce_ms": 2000,
+  // "freshness_mode": "relaxed",
+  // "claude_poll_interval": 5.0,
 
   // === Logging ===
-  "log_level": "WARNING",
-  "log_file": null,
+  // "log_level": "WARNING",
+  // "log_file": null,
 
   // === Privacy & Telemetry ===
-  "redact_source_root": false,
-  "stats_file_interval": 3,
-  "share_savings": true,
-  "summarizer_concurrency": 4,
-  "allow_remote_summarizer": false
+  // "redact_source_root": false,
+  // "stats_file_interval": 3,
+  // "share_savings": true,
+  // "summarizer_concurrency": 4,
+  // "allow_remote_summarizer": false
 }}
 '''

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -11,6 +11,33 @@ logger = logging.getLogger(__name__)
 # Global config storage
 _GLOBAL_CONFIG: dict[str, Any] = {}
 _PROJECT_CONFIGS: dict[str, dict[str, Any]] = {}  # repo -> merged config
+_DEPRECATED_ENV_VARS_LOGGED: set[str] = set()  # Track warned vars
+
+ENV_VAR_MAPPING = {
+    "JCODEMUNCH_USE_AI_SUMMARIES": "use_ai_summaries",
+    "JCODEMUNCH_MAX_FOLDER_FILES": "max_folder_files",
+    "JCODEMUNCH_MAX_INDEX_FILES": "max_index_files",
+    "JCODEMUNCH_STALENESS_DAYS": "staleness_days",
+    "JCODEMUNCH_MAX_RESULTS": "max_results",
+    "JCODEMUNCH_EXTRA_IGNORE_PATTERNS": "extra_ignore_patterns",
+    "JCODEMUNCH_EXTRA_EXTENSIONS": "extra_extensions",
+    "JCODEMUNCH_CONTEXT_PROVIDERS": "context_providers",
+    "JCODEMUNCH_REDACT_SOURCE_ROOT": "redact_source_root",
+    "JCODEMUNCH_STATS_FILE_INTERVAL": "stats_file_interval",
+    "JCODEMUNCH_SHARE_SAVINGS": "share_savings",
+    "JCODEMUNCH_SUMMARIZER_CONCURRENCY": "summarizer_concurrency",
+    "JCODEMUNCH_ALLOW_REMOTE_SUMMARIZER": "allow_remote_summarizer",
+    "JCODEMUNCH_RATE_LIMIT": "rate_limit",
+    "JCODEMUNCH_TRANSPORT": "transport",
+    "JCODEMUNCH_HOST": "host",
+    "JCODEMUNCH_PORT": "port",
+    "JCODEMUNCH_WATCH": "watch",
+    "JCODEMUNCH_WATCH_DEBOUNCE_MS": "watch_debounce_ms",
+    "JCODEMUNCH_FRESHNESS_MODE": "freshness_mode",
+    "JCODEMUNCH_CLAUDE_POLL_INTERVAL": "claude_poll_interval",
+    "JCODEMUNCH_LOG_LEVEL": "log_level",
+    "JCODEMUNCH_LOG_FILE": "log_file",
+}
 
 DEFAULTS = {
     "use_ai_summaries": True,
@@ -171,6 +198,58 @@ def load_config(storage_path: str | None = None) -> None:
             _GLOBAL_CONFIG = DEFAULTS.copy()
     else:
         _GLOBAL_CONFIG = DEFAULTS.copy()
+
+    # Apply env var fallback for keys not set in config
+    _apply_env_var_fallback()
+
+
+def _parse_env_value(value: str, expected_type: type | tuple) -> Any:
+    """Parse env var string to expected type."""
+    try:
+        if expected_type == bool:
+            return value.lower() in ("true", "1", "yes", "on")
+        elif expected_type == int:
+            return int(value)
+        elif expected_type == float:
+            return float(value)
+        elif expected_type == str:
+            return value
+        elif expected_type == list:
+            return json.loads(value)
+        elif expected_type == dict:
+            return json.loads(value)
+    except (ValueError, json.JSONDecodeError):
+        logger.warning(f"Failed to parse env var value: {value}")
+        return None
+    return value
+
+
+def _apply_env_var_fallback() -> None:
+    """Apply deprecated env var fallback for keys not in config."""
+    global _GLOBAL_CONFIG
+
+    for env_var, config_key in ENV_VAR_MAPPING.items():
+        # Skip if config key already set
+        if config_key in _GLOBAL_CONFIG:
+            continue
+
+        env_value = os.environ.get(env_var)
+        if env_value is not None:
+            # Log warning once per var
+            if env_var not in _DEPRECATED_ENV_VARS_LOGGED:
+                logger.warning(
+                    f"Deprecated: Using {env_var} environment variable. "
+                    f"This will be removed in v2.0. Use config.jsonc instead."
+                )
+                _DEPRECATED_ENV_VARS_LOGGED.add(env_var)
+
+            # Parse and apply value
+            expected_type = CONFIG_TYPES.get(config_key)
+            if expected_type is None:
+                continue
+            parsed = _parse_env_value(env_value, expected_type)  # type: ignore[arg-type]
+            if parsed is not None:
+                _GLOBAL_CONFIG[config_key] = parsed
 
 
 def get(key: str, default: Any = None, repo: str | None = None) -> Any:

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -169,7 +169,9 @@ def load_config(storage_path: str | None = None) -> None:
     if storage_path:
         config_path = Path(storage_path) / "config.jsonc"
     else:
-        config_path = Path.home() / ".code-index" / "config.jsonc"
+        # Respect CODE_INDEX_PATH env var for config file location
+        index_path = os.environ.get("CODE_INDEX_PATH", str(Path.home() / ".code-index"))
+        config_path = Path(index_path) / "config.jsonc"
 
     # Load config if exists
     if config_path.exists():
@@ -308,6 +310,50 @@ def get_descriptions() -> dict:
 
 
 # Lazy import to avoid circular dependency
+def generate_template() -> str:
+    """Return default config.jsonc content."""
+    from .parser.languages import LANGUAGE_REGISTRY
+
+    languages_list = list(LANGUAGE_REGISTRY.keys())
+    lang_str = ", ".join(f'"{lang}"' for lang in languages_list)
+
+def validate_config(config_path: str) -> list[str]:
+    """Validate a config.jsonc file and return a list of issue messages.
+
+    Returns an empty list if the config is valid.
+    Checks:
+    - File exists
+    - JSONC parses to valid JSON
+    - All keys have correct types
+    - Unknown keys are flagged (warning, not error)
+    """
+    issues: list[str] = []
+    path = Path(config_path)
+
+    if not path.exists():
+        return [f"Config file not found: {config_path}"]
+
+    try:
+        content = path.read_text(encoding="utf-8")
+        stripped = _strip_jsonc(content)
+        loaded = json.loads(stripped)
+    except json.JSONDecodeError as e:
+        return [f"Config parse error: {e}"]
+
+    # Validate types
+    for key, value in loaded.items():
+        if key in CONFIG_TYPES:
+            if not _validate_type(key, value, CONFIG_TYPES[key]):
+                issues.append(
+                    f"Config key '{key}' has invalid type: "
+                    f"expected {CONFIG_TYPES[key].__name__}, got {type(value).__name__}"
+                )
+        else:
+            issues.append(f"Config key '{key}' is not recognized (unknown key)")
+
+    return issues
+
+
 def generate_template() -> str:
     """Return default config.jsonc content."""
     from .parser.languages import LANGUAGE_REGISTRY

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -104,3 +104,56 @@ def _strip_jsonc(text: str) -> str:
             result.append(ch)
             i += 1
     return ''.join(result)
+
+
+def _validate_type(key: str, value: Any, expected_type: type | tuple) -> bool:
+    """Validate value against expected type."""
+    if isinstance(expected_type, tuple):
+        return isinstance(value, expected_type)
+    return isinstance(value, expected_type)
+
+
+def load_config(storage_path: str | None = None) -> None:
+    """Load global config.jsonc. Called once from main()."""
+    global _GLOBAL_CONFIG
+
+    # Determine config path
+    if storage_path:
+        config_path = Path(storage_path) / "config.jsonc"
+    else:
+        config_path = Path.home() / ".code-index" / "config.jsonc"
+
+    # Load config if exists
+    if config_path.exists():
+        try:
+            content = config_path.read_text(encoding="utf-8")
+            stripped = _strip_jsonc(content)
+            loaded = json.loads(stripped)
+
+            # Type validation
+            for key, value in loaded.items():
+                if key in CONFIG_TYPES:
+                    if _validate_type(key, value, CONFIG_TYPES[key]):
+                        _GLOBAL_CONFIG[key] = value
+                    else:
+                        logger.warning(
+                            f"Config key '{key}' has invalid type. "
+                            f"Expected {CONFIG_TYPES[key]}, got {type(value).__name__}. Using default."
+                        )
+                        _GLOBAL_CONFIG[key] = DEFAULTS.get(key)
+                # Ignore unknown keys silently
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse config.jsonc: {e}")
+            _GLOBAL_CONFIG = DEFAULTS.copy()
+        except Exception as e:
+            logger.error(f"Failed to load config.jsonc: {e}")
+            _GLOBAL_CONFIG = DEFAULTS.copy()
+    else:
+        _GLOBAL_CONFIG = DEFAULTS.copy()
+
+
+def get(key: str, default: Any = None, repo: str | None = None) -> Any:
+    """Get config value. If repo is given, uses merged project config."""
+    if repo and repo in _PROJECT_CONFIGS:
+        return _PROJECT_CONFIGS[repo].get(key, default)
+    return _GLOBAL_CONFIG.get(key, default)

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -1,18 +1,22 @@
 """Centralized JSONC config for jcodemunch-mcp."""
 
+import hashlib
 import json
 import logging
 import os
+import threading
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# Global config storage
 _GLOBAL_CONFIG: dict[str, Any] = {}
-_PROJECT_CONFIGS: dict[str, dict[str, Any]] = {}  # repo -> merged config
-_PROJECT_CONFIG_HASHES: dict[str, str] = {}  # repo -> content hash of .jcodemunch.jsonc
-_DEPRECATED_ENV_VARS_LOGGED: set[str] = set()  # Track warned vars
+_PROJECT_CONFIGS: dict[str, dict[str, Any]] = {}
+_PROJECT_CONFIG_HASHES: dict[str, str] = {}
+_DEPRECATED_ENV_VARS_LOGGED: set[str] = set()
+_CONFIG_LOCK = threading.Lock()
+_REPO_PATH_CACHE: dict[str, str] = {}
 
 ENV_VAR_MAPPING = {
     "JCODEMUNCH_USE_AI_SUMMARIES": "use_ai_summaries",
@@ -156,24 +160,35 @@ def _strip_jsonc(text: str) -> str:
             result.append(ch)
             i += 1
     
-    # Post-process: strip trailing commas before } and ]
-    # This handles JSONC's allowance of trailing commas
     output = ''.join(result)
-    # Use a simple state machine to strip trailing commas
     final = []
     j = 0
     m = len(output)
     while j < m:
         ch = output[j]
-        if ch == '"' and (j == 0 or output[j-1] != '\\'):
-            # Find end of string
+        if ch == '"':
+            backslash_count = 0
+            k = j - 1
+            while k >= 0 and output[k] == '\\':
+                backslash_count += 1
+                k -= 1
+            if backslash_count % 2 == 1:
+                final.append(ch)
+                j += 1
+                continue
             final.append(ch)
             j += 1
             while j < m:
                 final.append(output[j])
-                if output[j] == '"' and output[j-1] != '\\':
-                    j += 1
-                    break
+                if output[j] == '"':
+                    backslash_count = 0
+                    k = j - 1
+                    while k >= 0 and output[k] == '\\':
+                        backslash_count += 1
+                        k -= 1
+                    if backslash_count % 2 == 0:
+                        j += 1
+                        break
                 j += 1
         elif ch in ('}', ']'):
             # Strip trailing whitespace and comma before this
@@ -248,15 +263,16 @@ def load_config(storage_path: str | None = None) -> None:
                         _explicit_keys.add(key)  # Track explicitly set keys
                     else:
                         logger.warning(
-                            f"Config key '{key}' has invalid type. "
-                            f"Expected {CONFIG_TYPES[key]}, got {type(value).__name__}. Using default."
+                            "Config key '%s' has invalid type. "
+                            "Expected %s, got %s. Using default.",
+                            key, CONFIG_TYPES[key], type(value).__name__
                         )
-                # Ignore unknown keys silently
+                    # Ignore unknown keys silently
         except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse config.jsonc: {e}")
+            logger.error("Failed to parse config.jsonc: %s", e)
             _GLOBAL_CONFIG = DEFAULTS.copy()
         except Exception as e:
-            logger.error(f"Failed to load config.jsonc: {e}")
+            logger.error("Failed to load config.jsonc: %s", e)
             _GLOBAL_CONFIG = DEFAULTS.copy()
     else:
         _GLOBAL_CONFIG = DEFAULTS.copy()
@@ -268,6 +284,14 @@ def load_config(storage_path: str | None = None) -> None:
 def _parse_env_value(value: str, expected_type: type | tuple) -> Any:
     """Parse env var string to expected type."""
     try:
+        if isinstance(expected_type, tuple):
+            for t in expected_type:
+                if t == type(None):
+                    continue
+                parsed = _parse_env_value(value, t)
+                if parsed is not None:
+                    return parsed
+            return None
         if expected_type == bool:
             return value.lower() in ("true", "1", "yes", "on")
         elif expected_type == int:
@@ -277,23 +301,19 @@ def _parse_env_value(value: str, expected_type: type | tuple) -> Any:
         elif expected_type == str:
             return value
         elif expected_type == list:
-            # Try JSON array first (["*.log", "*.tmp"])
             try:
                 return json.loads(value)
             except (ValueError, json.JSONDecodeError):
-                # Fall back to legacy comma-separated format (*.log,*.tmp)
                 result = []
                 for token in value.split(","):
                     token = token.strip()
                     if token:
                         result.append(token)
-                return result if result else None
+                return result
         elif expected_type == dict:
-            # Try JSON first (new format: {"ext": "lang", ...})
             try:
                 return json.loads(value)
             except (ValueError, json.JSONDecodeError):
-                # Fall back to legacy comma-separated format (.ext:lang,.ext:lang)
                 result = {}
                 for token in value.split(","):
                     token = token.strip()
@@ -304,14 +324,13 @@ def _parse_env_value(value: str, expected_type: type | tuple) -> Any:
                     lang = lang.strip()
                     if ext and lang:
                         result[ext] = lang
-                return result if result else None
+                return result
         else:
             logger.warning(f"Unknown config type %s for env var value: %s", expected_type, value)
             return None
     except (ValueError, json.JSONDecodeError):
         logger.warning(f"Failed to parse env var value: {value}")
         return None
-    return value
 
 
 def _apply_env_var_fallback(explicit_keys: set[str] | None = None) -> None:
@@ -345,16 +364,56 @@ def _apply_env_var_fallback(explicit_keys: set[str] | None = None) -> None:
                 _GLOBAL_CONFIG[config_key] = parsed
 
 
+def _resolve_repo_key(repo: str) -> str | None:
+    """Resolve a repo identifier to the absolute path key used in _PROJECT_CONFIGS.
+    
+    _PROJECT_CONFIGS is keyed by resolved absolute paths (e.g. "D:\\...\\project").
+    The 'repo' argument from tool calls may be:
+    - An absolute path (already a valid key)
+    - A repo identifier like "jcodemunch-mcp" or "local/jcodemunch-mcp-384d867b"
+    
+    Returns the resolved key if found, None otherwise.
+    """
+    if repo in _PROJECT_CONFIGS:
+        return repo
+    if repo in _REPO_PATH_CACHE:
+        cached = _REPO_PATH_CACHE[repo]
+        if cached in _PROJECT_CONFIGS:
+            return cached
+    try:
+        from .storage.index_store import IndexStore
+        storage_path = os.environ.get("CODE_INDEX_PATH", str(Path.home() / ".code-index"))
+        store = IndexStore(base_path=storage_path)
+        repos = store.list_repos()
+        for entry in repos:
+            source_root = entry.get("source_root", "")
+            if not source_root:
+                continue
+            resolved = str(Path(source_root).resolve())
+            display_name = entry.get("display_name", "")
+            repo_name = entry.get("repo", "")
+            if display_name:
+                _REPO_PATH_CACHE[display_name] = resolved
+            if repo_name:
+                _REPO_PATH_CACHE[repo_name] = resolved
+            if repo == display_name or repo == repo_name or repo == resolved:
+                return resolved
+    except Exception:
+        pass
+    return None
+
+
 def get(key: str, default: Any = None, repo: str | None = None) -> Any:
     """Get config value. If repo is given, uses merged project config."""
-    if repo and repo in _PROJECT_CONFIGS:
-        return _PROJECT_CONFIGS[repo].get(key, default)
+    if repo:
+        resolved = _resolve_repo_key(repo)
+        if resolved and resolved in _PROJECT_CONFIGS:
+            return _PROJECT_CONFIGS[resolved].get(key, default)
     return _GLOBAL_CONFIG.get(key, default)
 
 
 def _content_hash(content: str) -> str:
     """Compute SHA-256 hash of content (first 12 hex chars)."""
-    import hashlib
     return hashlib.sha256(content.encode("utf-8")).hexdigest()[:12]
 
 
@@ -368,6 +427,8 @@ def load_project_config(source_root: str) -> None:
     - Config file edited (hash changed, reload)
     - File touched but unchanged (hash same, no reload)
     - Index dropped and recreated (cache still valid if file unchanged)
+    
+    Thread-safe: uses _CONFIG_LOCK to protect global dict mutations.
     """
     project_config_path = Path(source_root) / ".jcodemunch.jsonc"
     repo_key = str(Path(source_root).resolve())
@@ -377,35 +438,36 @@ def load_project_config(source_root: str) -> None:
             content = project_config_path.read_text(encoding="utf-8-sig")
             content_hash = _content_hash(content)
             
-            # Check if content unchanged (handles touch, mtime-only changes)
-            if repo_key in _PROJECT_CONFIGS:
-                if _PROJECT_CONFIG_HASHES.get(repo_key) == content_hash:
-                    return  # Cache is fresh
+            with _CONFIG_LOCK:
+                if repo_key in _PROJECT_CONFIGS:
+                    if _PROJECT_CONFIG_HASHES.get(repo_key) == content_hash:
+                        return
             
             stripped = _strip_jsonc(content)
             project_config = json.loads(stripped)
 
-            # Merge over global
-            merged = {**_GLOBAL_CONFIG}
-            for key, value in project_config.items():
-                if key in CONFIG_TYPES:
-                    if _validate_type(key, value, CONFIG_TYPES[key]):
-                        merged[key] = value
-                    else:
-                        logger.warning(
-                            f"Project config key '{key}' has invalid type. Using global default."
-                        )
-            _PROJECT_CONFIGS[repo_key] = merged
-            _PROJECT_CONFIG_HASHES[repo_key] = content_hash
+            with _CONFIG_LOCK:
+                merged = deepcopy(_GLOBAL_CONFIG)
+                for key, value in project_config.items():
+                    if key in CONFIG_TYPES:
+                        if _validate_type(key, value, CONFIG_TYPES[key]):
+                            merged[key] = value
+                        else:
+                            logger.warning(
+                                "Project config key '%s' has invalid type. Using global default.",
+                                key
+                            )
+                _PROJECT_CONFIGS[repo_key] = merged
+                _PROJECT_CONFIG_HASHES[repo_key] = content_hash
         except Exception as e:
-            logger.warning(f"Failed to load project config: {e}")
-            _PROJECT_CONFIGS[repo_key] = _GLOBAL_CONFIG.copy()
+            logger.warning("Failed to load project config: %s", e)
+            with _CONFIG_LOCK:
+                _PROJECT_CONFIGS[repo_key] = deepcopy(_GLOBAL_CONFIG)
     else:
-        # No config file - use global defaults
-        # Only cache if not already cached (avoids overwriting valid config)
-        if repo_key not in _PROJECT_CONFIGS:
-            _PROJECT_CONFIGS[repo_key] = _GLOBAL_CONFIG.copy()
-        _PROJECT_CONFIG_HASHES.pop(repo_key, None)
+        with _CONFIG_LOCK:
+            if repo_key not in _PROJECT_CONFIGS:
+                _PROJECT_CONFIGS[repo_key] = deepcopy(_GLOBAL_CONFIG)
+            _PROJECT_CONFIG_HASHES.pop(repo_key, None)
 
 
 def _list_repos_for_config() -> list[dict]:

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -240,7 +240,7 @@ def load_config(storage_path: str | None = None) -> None:
             loaded = json.loads(stripped)
 
             # Start with defaults, then overlay valid config values
-            _GLOBAL_CONFIG = DEFAULTS.copy()
+            _GLOBAL_CONFIG = deepcopy(DEFAULTS)
             for key, value in loaded.items():
                 if key in CONFIG_TYPES:
                     if _validate_type(key, value, CONFIG_TYPES[key]):
@@ -270,10 +270,10 @@ def load_config(storage_path: str | None = None) -> None:
                     # Ignore unknown keys silently
         except json.JSONDecodeError as e:
             logger.error("Failed to parse config.jsonc: %s", e)
-            _GLOBAL_CONFIG = DEFAULTS.copy()
+            _GLOBAL_CONFIG = deepcopy(DEFAULTS)
         except Exception as e:
             logger.error("Failed to load config.jsonc: %s", e)
-            _GLOBAL_CONFIG = DEFAULTS.copy()
+            _GLOBAL_CONFIG = deepcopy(DEFAULTS)
     else:
         _GLOBAL_CONFIG = DEFAULTS.copy()
 
@@ -326,10 +326,10 @@ def _parse_env_value(value: str, expected_type: type | tuple) -> Any:
                         result[ext] = lang
                 return result
         else:
-            logger.warning(f"Unknown config type %s for env var value: %s", expected_type, value)
+            logger.warning("Unknown config type %s for env var value: %s", expected_type, value)
             return None
     except (ValueError, json.JSONDecodeError):
-        logger.warning(f"Failed to parse env var value: {value}")
+        logger.warning("Failed to parse env var value: %s", value)
         return None
 
 
@@ -378,8 +378,8 @@ def _resolve_repo_key(repo: str) -> str | None:
         return repo
     if repo in _REPO_PATH_CACHE:
         cached = _REPO_PATH_CACHE[repo]
-        if cached in _PROJECT_CONFIGS:
-            return cached
+        # None = negative cache (unknown repo), str = resolved path
+        return cached
     try:
         from .storage.index_store import IndexStore
         storage_path = os.environ.get("CODE_INDEX_PATH", str(Path.home() / ".code-index"))
@@ -400,6 +400,8 @@ def _resolve_repo_key(repo: str) -> str | None:
                 return resolved
     except Exception:
         pass
+    # Negative cache: avoids repeated IndexStore scans for unknown identifiers
+    _REPO_PATH_CACHE[repo] = None  # type: ignore[assignment]
     return None
 
 

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -8,6 +8,70 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Global config storage
+_GLOBAL_CONFIG: dict[str, Any] = {}
+_PROJECT_CONFIGS: dict[str, dict[str, Any]] = {}  # repo -> merged config
+
+DEFAULTS = {
+    "use_ai_summaries": True,
+    "max_folder_files": 2000,
+    "max_index_files": 10000,
+    "staleness_days": 7,
+    "max_results": 500,
+    "extra_ignore_patterns": [],
+    "extra_extensions": {},
+    "context_providers": True,
+    "meta_fields": None,  # None = all fields
+    "languages": None,  # None = all languages
+    "disabled_tools": [],
+    "descriptions": {},
+    "transport": "stdio",
+    "host": "127.0.0.1",
+    "port": 8901,
+    "rate_limit": 0,
+    "watch": False,
+    "watch_debounce_ms": 2000,
+    "freshness_mode": "relaxed",
+    "claude_poll_interval": 5.0,
+    "log_level": "WARNING",
+    "log_file": None,
+    "redact_source_root": False,
+    "stats_file_interval": 3,
+    "share_savings": True,
+    "summarizer_concurrency": 4,
+    "allow_remote_summarizer": False,
+}
+
+CONFIG_TYPES = {
+    "use_ai_summaries": bool,
+    "max_folder_files": int,
+    "max_index_files": int,
+    "staleness_days": int,
+    "max_results": int,
+    "extra_ignore_patterns": list,
+    "extra_extensions": dict,
+    "context_providers": bool,
+    "meta_fields": (list, type(None)),
+    "languages": (list, type(None)),
+    "disabled_tools": list,
+    "descriptions": dict,
+    "transport": str,
+    "host": str,
+    "port": int,
+    "rate_limit": int,
+    "watch": bool,
+    "watch_debounce_ms": int,
+    "freshness_mode": str,
+    "claude_poll_interval": float,
+    "log_level": str,
+    "log_file": (str, type(None)),
+    "redact_source_root": bool,
+    "stats_file_interval": int,
+    "share_savings": bool,
+    "summarizer_concurrency": int,
+    "allow_remote_summarizer": bool,
+}
+
 
 def _strip_jsonc(text: str) -> str:
     """Strip // and /* */ comments from JSONC, respecting quoted strings."""

--- a/src/jcodemunch_mcp/parser/context/__init__.py
+++ b/src/jcodemunch_mcp/parser/context/__init__.py
@@ -8,7 +8,11 @@ from .base import ContextProvider, FileContext, discover_providers, enrich_symbo
 
 # Import provider modules so @register_provider decorators execute.
 # Each module registers itself on import — add new providers here.
-from . import dbt  # noqa: F401
+# Gate dbt provider: it depends on SQL language (dbt models are SQL files with Jinja).
+# The dbt provider is only loaded when SQL is enabled in config.languages.
+from ...config import is_language_enabled as _is_lang_enabled
+if _is_lang_enabled("sql"):
+    from . import dbt  # noqa: F401
 from . import git_blame  # noqa: F401
 
 __all__ = [

--- a/src/jcodemunch_mcp/parser/context/__init__.py
+++ b/src/jcodemunch_mcp/parser/context/__init__.py
@@ -6,13 +6,7 @@ and inject business context into symbols and file summaries during indexing.
 
 from .base import ContextProvider, FileContext, discover_providers, enrich_symbols, collect_metadata
 
-# Import provider modules so @register_provider decorators execute.
-# Each module registers itself on import — add new providers here.
-# Gate dbt provider: it depends on SQL language (dbt models are SQL files with Jinja).
-# The dbt provider is only loaded when SQL is enabled in config.languages.
-from ...config import is_language_enabled as _is_lang_enabled
-if _is_lang_enabled("sql"):
-    from . import dbt  # noqa: F401
+from . import dbt  # noqa: F401
 from . import git_blame  # noqa: F401
 
 __all__ = [

--- a/src/jcodemunch_mcp/parser/extractor.py
+++ b/src/jcodemunch_mcp/parser/extractor.py
@@ -22,6 +22,15 @@ def parse_file(content: str, filename: str, language: str) -> list[Symbol]:
     if language not in LANGUAGE_REGISTRY:
         return []
     
+    # Gate SQL-dependent features: when SQL is removed from languages config,
+    # skip parsing SQL files entirely. This prevents dbt context provider overhead
+    # and sql_preprocessor imports for users who don't need SQL support.
+    if language == "sql":
+        # Defer import to avoid circular dependency at module load time
+        from ..config import is_language_enabled as _is_lang_enabled
+        if not _is_lang_enabled("sql"):
+            return []
+    
     source_bytes = content.encode("utf-8")
 
     if language == "cpp":

--- a/src/jcodemunch_mcp/parser/extractor.py
+++ b/src/jcodemunch_mcp/parser/extractor.py
@@ -21,15 +21,15 @@ def parse_file(content: str, filename: str, language: str) -> list[Symbol]:
     """
     if language not in LANGUAGE_REGISTRY:
         return []
-    
-    # Gate SQL-dependent features: when SQL is removed from languages config,
-    # skip parsing SQL files entirely. This prevents dbt context provider overhead
-    # and sql_preprocessor imports for users who don't need SQL support.
-    if language == "sql":
-        # Defer import to avoid circular dependency at module load time
+
+    # Skip parsing if the language is not in the configured languages list.
+    # When languages config is None (default), all languages are enabled.
+    try:
         from ..config import is_language_enabled as _is_lang_enabled
-        if not _is_lang_enabled("sql"):
+        if not _is_lang_enabled(language):
             return []
+    except ImportError:
+        pass  # config module not available (e.g. standalone use)
     
     source_bytes = content.encode("utf-8")
 

--- a/src/jcodemunch_mcp/parser/languages.py
+++ b/src/jcodemunch_mcp/parser/languages.py
@@ -1370,7 +1370,9 @@ LANGUAGE_REGISTRY = {
 
 logger = logging.getLogger(__name__)
 
-# Well-known OpenAPI/Swagger basenames (no compound extension, just the filename)
+_APPLIED_EXTENSIONS = False
+
+
 _OPENAPI_BASENAMES = frozenset({
     "openapi.yaml", "openapi.yml", "openapi.json",
     "swagger.yaml", "swagger.yml", "swagger.json",
@@ -1378,30 +1380,36 @@ _OPENAPI_BASENAMES = frozenset({
 
 
 def _apply_extra_extensions() -> None:
-    """Apply JCODEMUNCH_EXTRA_EXTENSIONS env var to LANGUAGE_EXTENSIONS at import time."""
-    raw = os.environ.get("JCODEMUNCH_EXTRA_EXTENSIONS", "").strip()
-    if not raw:
+    """Apply extra_extensions from config to LANGUAGE_EXTENSIONS.
+
+    Respects config.get("extra_extensions") which includes env var fallback
+    (both JSON and legacy comma-separated formats) applied at startup.
+
+    Lazy — runs once on first access (cached via _APPLIED_EXTENSIONS flag).
+    """
+    global _APPLIED_EXTENSIONS
+    if _APPLIED_EXTENSIONS:
         return
-    for token in raw.split(","):
-        token = token.strip()
-        if not token:
-            continue
-        if ":" not in token:
-            logger.warning("JCODEMUNCH_EXTRA_EXTENSIONS: malformed entry %r (expected .ext:lang) — skipped", token)
-            continue
-        ext, _, lang = token.partition(":")
-        ext = ext.strip()
-        lang = lang.strip()
+
+    from .. import config as _cfg
+
+    extra_extensions = _cfg.get("extra_extensions", {})
+    for ext, lang in extra_extensions.items():
         if not ext or not lang:
-            logger.warning("JCODEMUNCH_EXTRA_EXTENSIONS: malformed entry %r (empty ext or lang) — skipped", token)
+            logger.warning("extra_extensions: empty extension or language %r:%r — skipped", ext, lang)
             continue
         if lang not in LANGUAGE_REGISTRY:
-            logger.warning("JCODEMUNCH_EXTRA_EXTENSIONS: unknown language %r in entry %r — skipped", lang, token)
+            logger.warning("extra_extensions: unknown language %r for extension %r — skipped", lang, ext)
             continue
         LANGUAGE_EXTENSIONS[ext] = lang
 
+    _APPLIED_EXTENSIONS = True
 
-_apply_extra_extensions()
+
+def get_language_extensions() -> dict[str, str]:
+    """Return LANGUAGE_EXTENSIONS with extra_extensions applied (lazy, cached)."""
+    _apply_extra_extensions()
+    return LANGUAGE_EXTENSIONS
 
 
 def get_language_for_path(path: str) -> "Optional[str]":

--- a/src/jcodemunch_mcp/parser/languages.py
+++ b/src/jcodemunch_mcp/parser/languages.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import threading
 from dataclasses import dataclass
 from typing import Optional
 
@@ -1371,6 +1372,7 @@ LANGUAGE_REGISTRY = {
 logger = logging.getLogger(__name__)
 
 _APPLIED_EXTENSIONS = False
+_EXTENSIONS_LOCK = threading.Lock()
 
 
 _OPENAPI_BASENAMES = frozenset({
@@ -1386,24 +1388,26 @@ def _apply_extra_extensions() -> None:
     (both JSON and legacy comma-separated formats) applied at startup.
 
     Lazy — runs once on first access (cached via _APPLIED_EXTENSIONS flag).
+    Thread-safe via _EXTENSIONS_LOCK.
     """
     global _APPLIED_EXTENSIONS
-    if _APPLIED_EXTENSIONS:
-        return
+    with _EXTENSIONS_LOCK:
+        if _APPLIED_EXTENSIONS:
+            return
 
-    from .. import config as _cfg
+        from .. import config as _cfg
 
-    extra_extensions = _cfg.get("extra_extensions", {})
-    for ext, lang in extra_extensions.items():
-        if not ext or not lang:
-            logger.warning("extra_extensions: empty extension or language %r:%r — skipped", ext, lang)
-            continue
-        if lang not in LANGUAGE_REGISTRY:
-            logger.warning("extra_extensions: unknown language %r for extension %r — skipped", lang, ext)
-            continue
-        LANGUAGE_EXTENSIONS[ext] = lang
+        extra_extensions = _cfg.get("extra_extensions", {})
+        for ext, lang in extra_extensions.items():
+            if not ext or not lang:
+                logger.warning("extra_extensions: empty extension or language %r:%r — skipped", ext, lang)
+                continue
+            if lang not in LANGUAGE_REGISTRY:
+                logger.warning("extra_extensions: unknown language %r for extension %r — skipped", lang, ext)
+                continue
+            LANGUAGE_EXTENSIONS[ext] = lang
 
-    _APPLIED_EXTENSIONS = True
+        _APPLIED_EXTENSIONS = True
 
 
 def get_language_extensions() -> dict[str, str]:
@@ -1420,6 +1424,7 @@ def get_language_for_path(path: str) -> "Optional[str]":
     2. Compound suffixes (e.g. ``.blade.php``, ``.openapi.yaml``).
     3. Last extension (e.g. ``.php``).
     """
+    _apply_extra_extensions()
     import os as _os
     lower = path.lower()
     base = _os.path.basename(lower)

--- a/src/jcodemunch_mcp/security.py
+++ b/src/jcodemunch_mcp/security.py
@@ -4,6 +4,8 @@ import os
 from pathlib import Path
 from typing import Optional
 
+from . import config as _config
+
 
 # --- Package Integrity Check ---
 
@@ -307,10 +309,7 @@ EXTRA_IGNORE_PATTERNS_ENV_VAR = "JCODEMUNCH_EXTRA_IGNORE_PATTERNS"
 
 
 def get_extra_ignore_patterns(call_patterns: Optional[list] = None) -> list:
-    """Return merged extra ignore patterns from env var and per-call list.
-
-    Reads ``JCODEMUNCH_EXTRA_IGNORE_PATTERNS`` (comma-separated string or
-    JSON array), then appends any per-call ``extra_ignore_patterns``.
+    """Return merged extra ignore patterns from config and per-call list.
 
     Args:
         call_patterns: Patterns supplied by the caller (per-call override).
@@ -318,19 +317,11 @@ def get_extra_ignore_patterns(call_patterns: Optional[list] = None) -> list:
     Returns:
         Combined list of gitignore-style pattern strings. Empty list if none.
     """
-    import json as _json
-
-    env_val = os.environ.get(EXTRA_IGNORE_PATTERNS_ENV_VAR, "").strip()
-    env_patterns: list = []
-    if env_val:
-        try:
-            parsed = _json.loads(env_val)
-            if isinstance(parsed, list):
-                env_patterns = [str(p) for p in parsed if p]
-        except (_json.JSONDecodeError, ValueError):
-            env_patterns = [p.strip() for p in env_val.split(",") if p.strip()]
-
-    combined = env_patterns[:]
+    config_patterns = _config.get("extra_ignore_patterns", [])
+    if isinstance(config_patterns, list):
+        combined = config_patterns[:]
+    else:
+        combined = []
     if call_patterns:
         combined.extend(call_patterns)
     return combined
@@ -351,41 +342,30 @@ MAX_FOLDER_FILES_ENV_VAR = "JCODEMUNCH_MAX_FOLDER_FILES"
 
 
 def get_max_index_files(max_files: Optional[int] = None) -> int:
-    """Resolve the maximum indexed file count from arg or environment.
+    """Resolve the maximum indexed file count from arg or config.
 
     Args:
         max_files: Explicit override. Must be a positive integer when provided.
 
     Returns:
-        Positive file-count limit. Falls back to the default if the environment
-        variable is unset or invalid.
+        Positive file-count limit. Falls back to the default if config
+        is unset or invalid.
     """
     if max_files is not None:
         if max_files <= 0:
             raise ValueError("max_files must be a positive integer")
         return max_files
 
-    value = os.environ.get(MAX_INDEX_FILES_ENV_VAR)
-    if value is None:
-        return DEFAULT_MAX_INDEX_FILES
-
-    try:
-        parsed = int(value)
-    except ValueError:
-        return DEFAULT_MAX_INDEX_FILES
-
-    if parsed <= 0:
-        return DEFAULT_MAX_INDEX_FILES
-
-    return parsed
+    value = _config.get("max_index_files", DEFAULT_MAX_INDEX_FILES)
+    if isinstance(value, int) and value > 0:
+        return value
+    return DEFAULT_MAX_INDEX_FILES
 
 
 def get_max_folder_files(max_files: Optional[int] = None) -> int:
     """Resolve the maximum indexed file count for local folder indexing.
 
-    Checks JCODEMUNCH_MAX_FOLDER_FILES first, then falls back to
-    JCODEMUNCH_MAX_INDEX_FILES for backward compatibility.  The default
-    (2,000) is intentionally lower than the GitHub repo default (10,000)
+    The default (2,000) is intentionally lower than the GitHub repo default (10,000)
     because local indexing runs synchronously inside an MCP tool call and
     must complete within the client's timeout window.
 
@@ -400,17 +380,9 @@ def get_max_folder_files(max_files: Optional[int] = None) -> int:
             raise ValueError("max_files must be a positive integer")
         return max_files
 
-    # Check folder-specific env var first, then legacy shared var.
-    for env_var in (MAX_FOLDER_FILES_ENV_VAR, MAX_INDEX_FILES_ENV_VAR):
-        value = os.environ.get(env_var)
-        if value is not None:
-            try:
-                parsed = int(value)
-            except ValueError:
-                continue
-            if parsed > 0:
-                return parsed
-
+    value = _config.get("max_folder_files", DEFAULT_MAX_FOLDER_FILES)
+    if isinstance(value, int) and value > 0:
+        return value
     return DEFAULT_MAX_FOLDER_FILES
 
 

--- a/src/jcodemunch_mcp/security.py
+++ b/src/jcodemunch_mcp/security.py
@@ -380,7 +380,10 @@ def get_max_folder_files(max_files: Optional[int] = None) -> int:
             raise ValueError("max_files must be a positive integer")
         return max_files
 
-    value = _config.get("max_folder_files", DEFAULT_MAX_FOLDER_FILES)
+    value = _config.get("max_folder_files")
+    if isinstance(value, int) and value > 0:
+        return value
+    value = _config.get("max_index_files")
     if isinstance(value, int) and value > 0:
         return value
     return DEFAULT_MAX_FOLDER_FILES

--- a/src/jcodemunch_mcp/security.py
+++ b/src/jcodemunch_mcp/security.py
@@ -383,9 +383,6 @@ def get_max_folder_files(max_files: Optional[int] = None) -> int:
     value = _config.get("max_folder_files")
     if isinstance(value, int) and value > 0:
         return value
-    value = _config.get("max_index_files")
-    if isinstance(value, int) and value > 0:
-        return value
     return DEFAULT_MAX_FOLDER_FILES
 
 

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -747,6 +747,11 @@ async def list_tools() -> list[Tool]:
     if disabled:
         tools = [t for t in tools if t.name not in disabled]
 
+    # SQL gating: auto-disable search_columns when SQL not in languages
+    languages = config_module.get("languages")
+    if languages is not None and "sql" not in languages:
+        tools = [t for t in tools if t.name != "search_columns"]
+
     # Merge descriptions from config (runs after disabled_tools filter)
     _apply_description_overrides(tools)
 

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -165,14 +165,6 @@ async def _ensure_tool_schemas() -> dict[str, dict]:
 server = Server("jcodemunch-mcp")
 
 
-_SUPPRESS_META_PROP = {
-    "suppress_meta": {
-        "type": "boolean",
-        "description": "When true, omit the _meta envelope from the response (saves ~100-200 tokens per call)."
-    }
-}
-
-
 @server.list_tools()
 async def list_tools() -> list[Tool]:
     """List all available tools."""
@@ -750,11 +742,6 @@ async def list_tools() -> list[Tool]:
             }
         ),
     ]
-    # Inject suppress_meta into every tool's properties without touching each schema individually.
-    for tool in tools:
-        if isinstance(tool.inputSchema, dict):
-            tool.inputSchema.setdefault("properties", {}).update(_SUPPRESS_META_PROP)
-
     # Filter out disabled tools
     disabled = config_module.get("disabled_tools", [])
     if disabled:
@@ -1067,9 +1054,10 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             result = {"error": f"Unknown tool: {name}"}
         
         if isinstance(result, dict):
-            if arguments.get("suppress_meta"):
+            meta_fields = config_module.get("meta_fields")
+            if meta_fields == []:
                 result.pop("_meta", None)
-            else:
+            elif meta_fields is None:
                 _meta = result.setdefault("_meta", {})
                 _meta["powered_by"] = "jcodemunch-mcp by jgravelle · https://github.com/jgravelle/jcodemunch-mcp"
                 # Inject staleness fields for per-repo tools
@@ -1085,6 +1073,28 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                     _meta["index_stale"] = any_in_progress
                     _meta["reindex_in_progress"] = any_in_progress
                     _meta["stale_since_ms"] = None
+            elif isinstance(meta_fields, list):
+                # Partial field inclusion - build _meta with only specified fields
+                result.pop("_meta", None)  # Clear existing _meta
+                _meta: dict[str, Any] = {}
+                _meta["powered_by"] = "jcodemunch-mcp by jgravelle · https://github.com/jgravelle/jcodemunch-mcp"
+                repo_arg = arguments.get("repo")
+                if repo_arg:
+                    status = get_reindex_status(repo_arg)
+                    for field in meta_fields:
+                        if field in status:
+                            _meta[field] = status[field]
+                elif name not in ("list_repos", "get_session_stats", "index_repo", "index_folder"):
+                    from .reindex_state import is_any_reindex_in_progress
+                    any_in_progress = is_any_reindex_in_progress()
+                    if "index_stale" in meta_fields:
+                        _meta["index_stale"] = any_in_progress
+                    if "reindex_in_progress" in meta_fields:
+                        _meta["reindex_in_progress"] = any_in_progress
+                    if "stale_since_ms" in meta_fields:
+                        _meta["stale_since_ms"] = None
+                if _meta:
+                    result["_meta"] = _meta
         return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
     except KeyError as e:

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -139,6 +139,15 @@ def _coerce_arguments(arguments: dict, schema: dict) -> dict:
 _TOOL_SCHEMAS: dict[str, dict] | None = None
 
 
+def _build_language_enum() -> list[str]:
+    """Build language enum from config, falling back to all registry languages."""
+    languages = config_module.get("languages")
+    if languages is None:
+        from .parser.languages import LANGUAGE_REGISTRY
+        return sorted(LANGUAGE_REGISTRY.keys())
+    return languages
+
+
 async def _ensure_tool_schemas() -> dict[str, dict]:
     """Lazy-initialize the tool name → inputSchema lookup for type coercion.
 
@@ -409,7 +418,7 @@ async def list_tools() -> list[Tool]:
                     "language": {
                         "type": "string",
                         "description": "Optional filter by language",
-                        "enum": ["python", "javascript", "typescript", "tsx", "go", "rust", "java", "php", "dart", "csharp", "razor", "c", "cpp", "swift", "elixir", "ruby", "perl", "gdscript", "blade", "kotlin", "scala", "haskell", "julia", "r", "lua", "bash", "css", "sql", "toml", "erlang", "fortran", "gleam", "nix", "vue", "ejs", "verse", "groovy", "objc", "proto", "hcl", "graphql", "autohotkey", "asm", "xml", "openapi", "al"]
+                        "enum": _build_language_enum()
                     },
                     "max_results": {
                         "type": "integer",

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -67,11 +67,8 @@ logger = logging.getLogger(__name__)
 
 
 def _default_use_ai_summaries() -> bool:
-    """Return the default for use_ai_summaries, respecting JCODEMUNCH_USE_AI_SUMMARIES env var."""
-    val = os.environ.get("JCODEMUNCH_USE_AI_SUMMARIES", "").strip().lower()
-    if val in ("0", "false", "no", "off"):
-        return False
-    return True  # default on
+    """Return the default for use_ai_summaries, respecting config (including env var fallback)."""
+    return config_module.get("use_ai_summaries", True)
 
 
 def _parse_watcher_flag(value: Optional[str]) -> bool:
@@ -770,7 +767,8 @@ def _apply_description_overrides(tools: list) -> None:
         tool_desc = descriptions.get(tool.name, {})
 
         # Override tool-level description
-        if tool_desc.get("_tool"):
+        # "_tool": "" means "use hardcoded minimal base only" (empty string override)
+        if "_tool" in tool_desc:
             tool.description = tool_desc["_tool"]
 
         # Override parameter descriptions (applies even if only _shared is set)
@@ -780,8 +778,11 @@ def _apply_description_overrides(tools: list) -> None:
                 if not isinstance(param_schema, dict):
                     continue
                 # Tool-specific override takes precedence over _shared
-                desc_override = tool_desc.get(param_name) or shared.get(param_name)
-                if desc_override:
+                # Empty string means "use hardcoded minimal base only"
+                desc_override = tool_desc.get(param_name)
+                if desc_override is None:
+                    desc_override = shared.get(param_name)
+                if desc_override is not None:
                     props[param_name] = {**param_schema, "description": desc_override}
 
 
@@ -821,6 +822,18 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         repo_arg = arguments.get("repo")
         if (name not in _EXCLUDED_FROM_STRICT and repo_arg):
             await asyncio.to_thread(await_freshness_if_strict, repo_arg, timeout_ms=500)
+
+        # Project-level tool disabling: check if tool is disabled for this project
+        # Global disabled tools are filtered out in list_tools() schema; project-level
+        # rejection happens here since schema is global (can't be changed per-project).
+        if config_module.is_tool_disabled(name, repo=repo_arg):
+            return [TextContent(type="text", text=json.dumps({
+                "error": (
+                    f"Tool '{name}' is disabled in this project's configuration. "
+                    f"Project-level tool disabling is set via the 'disabled_tools' key "
+                    f"in the .jcodemunch.jsonc file. Remove '{name}' from 'disabled_tools' to re-enable."
+                )
+            }, indent=2))]
 
         if name == "index_repo":
             result = await index_repo(
@@ -1110,15 +1123,19 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                     _meta["stale_since_ms"] = None
             elif isinstance(meta_fields, list):
                 # Partial field inclusion - build _meta with only specified fields
-                result.pop("_meta", None)  # Clear existing _meta
+                # Save existing _meta (may contain tool-generated fields like timing_ms, tokens_saved)
+                existing_meta = result.pop("_meta", {})
                 _meta: dict[str, Any] = {}
-                _meta["powered_by"] = "jcodemunch-mcp by jgravelle · https://github.com/jgravelle/jcodemunch-mcp"
+                if "powered_by" in meta_fields:
+                    _meta["powered_by"] = "jcodemunch-mcp by jgravelle · https://github.com/jgravelle/jcodemunch-mcp"
                 repo_arg = arguments.get("repo")
                 if repo_arg:
                     status = get_reindex_status(repo_arg)
                     for field in meta_fields:
                         if field in status:
                             _meta[field] = status[field]
+                        elif field in existing_meta:
+                            _meta[field] = existing_meta[field]
                 elif name not in ("list_repos", "get_session_stats", "index_repo", "index_folder"):
                     from .reindex_state import is_any_reindex_in_progress
                     any_in_progress = is_any_reindex_in_progress()
@@ -1128,6 +1145,11 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                         _meta["reindex_in_progress"] = any_in_progress
                     if "stale_since_ms" in meta_fields:
                         _meta["stale_since_ms"] = None
+                # Preserve tool-generated fields (timing_ms, tokens_saved, candidates_scored)
+                # This runs for ALL tools, including list_repos, get_session_stats, etc.
+                for field in meta_fields:
+                    if field not in _meta and field in existing_meta:
+                        _meta[field] = existing_meta[field]
                 if _meta:
                     result["_meta"] = _meta
         return [TextContent(type="text", text=json.dumps(result, indent=2))]
@@ -1451,10 +1473,10 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
 
 def _run_config(check: bool = False, init: bool = False) -> None:
     """Print the current effective configuration to stdout, or initialize config file."""
+    from . import config as _cfg
+
     # Handle --init
     if init:
-        from . import config as _cfg
-
         storage_path = os.environ.get("CODE_INDEX_PATH", str(Path.home() / ".code-index"))
         config_path = Path(storage_path) / "config.jsonc"
 
@@ -1469,6 +1491,10 @@ def _run_config(check: bool = False, init: bool = False) -> None:
         print(f"Created config template: {config_path}")
         print("Edit it to customize jcodemunch-mcp settings.")
         return
+
+    # Load config to get effective values
+    _cfg.load_config()
+
     tty = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
     enc = getattr(sys.stdout, "encoding", "ascii") or "ascii"
 
@@ -1491,8 +1517,8 @@ def _run_config(check: bool = False, init: bool = False) -> None:
 
     COL = 36
 
-    def row(name, value, is_default=False):
-        tag = dim(" (default)") if is_default else ""
+    def row(name, value, source="default"):
+        tag = dim(f" [{source}]") if source != "default" else dim(" (default)")
         print(f"  {name:<{COL}} {value}{tag}")
 
     def env(var, default=""):
@@ -1502,28 +1528,97 @@ def _run_config(check: bool = False, init: bool = False) -> None:
     def section(title):
         print(f"\n{bold(title)}")
 
+    def cfg_row(name, key, default, source=None, fmt=None):
+        """Display a config value with source indicator."""
+        val = _cfg.get(key, default)
+        if fmt:
+            val = fmt(val)
+        effective_source = source or "default"
+        print(f"  {name:<{COL}} {val}{dim(f' [{effective_source}]')}")
+
     print(bold(f"jcodemunch-mcp {__version__} — configuration"))
 
-    # ── Core ──────────────────────────────────────────────────────────────
-    section("Core")
-    v, d = env("CODE_INDEX_PATH", str(Path.home() / ".code-index"))
-    row("CODE_INDEX_PATH", v, d)
-    v, d = env("JCODEMUNCH_MAX_FOLDER_FILES", "2000")
-    row("JCODEMUNCH_MAX_FOLDER_FILES", v, d)
-    v, d = env("JCODEMUNCH_MAX_INDEX_FILES", "10000")
-    row("JCODEMUNCH_MAX_INDEX_FILES", v, d)
-    v, d = env("JCODEMUNCH_STALENESS_DAYS", "7")
-    row("JCODEMUNCH_STALENESS_DAYS", v, d)
-    v, d = env("JCODEMUNCH_MAX_RESULTS", "500")
-    row("JCODEMUNCH_MAX_RESULTS", v, d)
-    extra = os.environ.get("JCODEMUNCH_EXTRA_IGNORE_PATTERNS", "")
-    row("JCODEMUNCH_EXTRA_IGNORE_PATTERNS", extra if extra else dim("(none)"), not extra)
+    # ── Config File ───────────────────────────────────────────────────────
+    section("Config File")
+    storage_path = os.environ.get("CODE_INDEX_PATH", str(Path.home() / ".code-index"))
+    config_path = Path(storage_path) / "config.jsonc"
+    if config_path.exists():
+        print(f"  {green(CHECK)} config.jsonc found: {config_path}")
+    else:
+        print(f"  {yellow(WARN)} config.jsonc not found: {config_path}")
+        print(f"  {dim('  Using defaults + env var fallbacks. Run `config --init` to create a config file.')}")
+
+    # ── Indexing ──────────────────────────────────────────────────────────
+    section("Indexing")
+    # Detect source for each config key
+    # Check the actual config file content (if exists) to determine if a key was
+    # explicitly set in config vs defaulted
+    _loaded_keys: set = set()
+    if config_path.exists():
+        try:
+            content = config_path.read_text(encoding="utf-8")
+            stripped = _cfg._strip_jsonc(content)
+            import json as _json
+            _loaded_keys = set(_json.loads(stripped).keys())
+        except Exception:
+            pass
+
+    def _detect_source(key, default):
+        if key in _loaded_keys:
+            return "config"
+        env_var = next((e for e, c in _cfg.ENV_VAR_MAPPING.items() if c == key), None)
+        if env_var and os.environ.get(env_var) is not None:
+            return "env"
+        return "default"
+
+    def _fmt_list(v):
+        if isinstance(v, list):
+            return f"[{len(v)} items]" if len(v) > 3 else str(v)
+        return str(v)
+
+    row("max_folder_files", _cfg.get("max_folder_files", 2000), _detect_source("max_folder_files", 2000))
+    row("max_index_files", _cfg.get("max_index_files", 10000), _detect_source("max_index_files", 10000))
+    row("staleness_days", _cfg.get("staleness_days", 7), _detect_source("staleness_days", 7))
+    row("max_results", _cfg.get("max_results", 500), _detect_source("max_results", 500))
+    patterns = _cfg.get("extra_ignore_patterns", [])
+    row("extra_ignore_patterns", _fmt_list(patterns) if patterns else dim("(none)"), _detect_source("extra_ignore_patterns", []))
+    exts = _cfg.get("extra_extensions", {})
+    row("extra_extensions", _fmt_list(exts) if exts else dim("(none)"), _detect_source("extra_extensions", {}))
+    row("context_providers", str(_cfg.get("context_providers", True)).lower(), _detect_source("context_providers", True))
+
+    # ── Meta Response Control ─────────────────────────────────────────────
+    section("Meta Response Control")
+    meta_fields = _cfg.get("meta_fields")
+    if meta_fields is None:
+        row("meta_fields", dim("(all fields)"), "default")
+    elif meta_fields == []:
+        row("meta_fields", dim("(none)"), "config")
+    else:
+        row("meta_fields", _fmt_list(meta_fields), _detect_source("meta_fields", None))
+
+    # ── Languages ─────────────────────────────────────────────────────────
+    section("Languages")
+    languages = _cfg.get("languages")
+    if languages is None:
+        row("languages", dim("(all languages)"), "default")
+    else:
+        row("languages", _fmt_list(languages), _detect_source("languages", None))
+
+    # ── Disabled Tools ────────────────────────────────────────────────────
+    section("Disabled Tools")
+    disabled = _cfg.get("disabled_tools", [])
+    row("disabled_tools", _fmt_list(disabled) if disabled else dim("(none)"), _detect_source("disabled_tools", []))
+
+    # ── Descriptions ──────────────────────────────────────────────────────
+    section("Descriptions")
+    descs = _cfg.get("descriptions", {})
+    row("descriptions", _fmt_list(descs) if descs else dim("(none)"), _detect_source("descriptions", {}))
 
     # ── AI Summarizer ─────────────────────────────────────────────────────
     section("AI Summarizer")
     use_ai_raw, use_ai_d = env("JCODEMUNCH_USE_AI_SUMMARIES", "true")
     use_ai = use_ai_raw.lower() not in ("false", "0", "no", "off")
-    row("JCODEMUNCH_USE_AI_SUMMARIES", str(use_ai).lower(), use_ai_d)
+    row("use_ai_summaries", str(use_ai).lower(), "env" if not use_ai_d else _detect_source("use_ai_summaries", True))
 
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY", "")
     google_key    = os.environ.get("GOOGLE_API_KEY", "")
@@ -1534,53 +1629,65 @@ def _run_config(check: bool = False, init: bool = False) -> None:
     elif anthropic_key:
         print(f"  Active provider:  {green('Anthropic')}  (ANTHROPIC_API_KEY set)")
         model, d = env("ANTHROPIC_MODEL", "claude-haiku-*")
-        row("  ANTHROPIC_MODEL", model, d)
+        row("  ANTHROPIC_MODEL", model, "env" if not d else "default")
     elif google_key:
         print(f"  Active provider:  {green('Google Gemini')}  (GOOGLE_API_KEY set)")
         model, d = env("GOOGLE_MODEL", "gemini-flash-*")
-        row("  GOOGLE_MODEL", model, d)
+        row("  GOOGLE_MODEL", model, "env" if not d else "default")
     elif openai_base:
         print(f"  Active provider:  {green('Local LLM')}  (OPENAI_API_BASE set)")
-        row("  OPENAI_API_BASE", openai_base, False)
+        row("  OPENAI_API_BASE", openai_base, "env")
         model, d = env("OPENAI_MODEL", "qwen3-coder")
-        row("  OPENAI_MODEL", model, d)
+        row("  OPENAI_MODEL", model, "env" if not d else "default")
         v, d = env("OPENAI_TIMEOUT", "60.0")
-        row("  OPENAI_TIMEOUT", v, d)
+        row("  OPENAI_TIMEOUT", v, "env" if not d else "default")
         v, d = env("OPENAI_BATCH_SIZE", "10")
-        row("  OPENAI_BATCH_SIZE", v, d)
+        row("  OPENAI_BATCH_SIZE", v, "env" if not d else "default")
         v, d = env("OPENAI_CONCURRENCY", "1")
-        row("  OPENAI_CONCURRENCY", v, d)
+        row("  OPENAI_CONCURRENCY", v, "env" if not d else "default")
         v, d = env("OPENAI_MAX_TOKENS", "500")
-        row("  OPENAI_MAX_TOKENS", v, d)
+        row("  OPENAI_MAX_TOKENS", v, "env" if not d else "default")
     else:
         print(f"  Active provider:  {yellow('none')} — no API key set, signature fallback active")
         print(f"  {dim('Set ANTHROPIC_API_KEY, GOOGLE_API_KEY, or OPENAI_API_BASE to enable')}")
 
-    # ── HTTP Transport ────────────────────────────────────────────────────
-    section("HTTP Transport")
-    transport, d = env("JCODEMUNCH_TRANSPORT", "stdio")
-    row("JCODEMUNCH_TRANSPORT", transport, d)
+    # ── Transport ──────────────────────────────────────────────────────────
+    section("Transport")
+    transport = _cfg.get("transport", "stdio")
+    row("transport", transport, _detect_source("transport", "stdio"))
     if transport != "stdio":
-        host, d = env("JCODEMUNCH_HOST", "127.0.0.1")
-        row("JCODEMUNCH_HOST", host, d)
-        port, d = env("JCODEMUNCH_PORT", "8901")
-        row("JCODEMUNCH_PORT", port, d)
+        row("host", _cfg.get("host", "127.0.0.1"), _detect_source("host", "127.0.0.1"))
+        row("port", _cfg.get("port", 8901), _detect_source("port", 8901))
         token = os.environ.get("JCODEMUNCH_HTTP_TOKEN", "")
-        row("JCODEMUNCH_HTTP_TOKEN", green("set") if token else yellow("not set"), not token)
-        rate, d = env("JCODEMUNCH_RATE_LIMIT", "0")
-        rate_label = f"{rate}/min per IP" if rate != "0" else "disabled"
-        row("JCODEMUNCH_RATE_LIMIT", rate_label, d)
+        row("JCODEMUNCH_HTTP_TOKEN", green("set") if token else yellow("not set"), "env")
+        rate = _cfg.get("rate_limit", 0)
+        rate_label = f"{rate}/min per IP" if rate != 0 else "disabled"
+        row("rate_limit", rate_label, _detect_source("rate_limit", 0))
     else:
         print(f"  {dim('stdio mode — HTTP transport vars ignored')}")
 
-    # ── Performance & Privacy ─────────────────────────────────────────────
-    section("Performance & Privacy")
-    v, d = env("JCODEMUNCH_STATS_FILE_INTERVAL", "3")
-    row("JCODEMUNCH_STATS_FILE_INTERVAL", "disabled" if v == "0" else f"every {v} calls", d)
-    v, d = env("JCODEMUNCH_SHARE_SAVINGS", "1")
-    row("JCODEMUNCH_SHARE_SAVINGS", green("enabled") if v != "0" else yellow("disabled"), d)
-    v, d = env("JCODEMUNCH_REDACT_SOURCE_ROOT", "0")
-    row("JCODEMUNCH_REDACT_SOURCE_ROOT", "enabled" if v == "1" else "disabled", d)
+    # ── Watcher ───────────────────────────────────────────────────────────
+    section("Watcher")
+    row("watch", str(_cfg.get("watch", False)).lower(), _detect_source("watch", False))
+    row("watch_debounce_ms", _cfg.get("watch_debounce_ms", 2000), _detect_source("watch_debounce_ms", 2000))
+    row("freshness_mode", _cfg.get("freshness_mode", "relaxed"), _detect_source("freshness_mode", "relaxed"))
+    row("claude_poll_interval", _cfg.get("claude_poll_interval", 5.0), _detect_source("claude_poll_interval", 5.0))
+
+    # ── Logging ──────────────────────────────────────────────────────────
+    section("Logging")
+    row("log_level", _cfg.get("log_level", "WARNING"), _detect_source("log_level", "WARNING"))
+    log_file = _cfg.get("log_file")
+    row("log_file", log_file if log_file else dim("(stderr)"), _detect_source("log_file", None))
+
+    # ── Privacy & Telemetry ───────────────────────────────────────────────
+    section("Privacy & Telemetry")
+    row("redact_source_root", str(_cfg.get("redact_source_root", False)).lower(), _detect_source("redact_source_root", False))
+    stats_int = _cfg.get("stats_file_interval", 3)
+    row("stats_file_interval", "disabled" if stats_int == 0 else f"every {stats_int} calls", _detect_source("stats_file_interval", 3))
+    share = _cfg.get("share_savings", True)
+    row("share_savings", green("enabled") if share else yellow("disabled"), _detect_source("share_savings", True))
+    row("summarizer_concurrency", _cfg.get("summarizer_concurrency", 4), _detect_source("summarizer_concurrency", 4))
+    row("allow_remote_summarizer", str(_cfg.get("allow_remote_summarizer", False)).lower(), _detect_source("allow_remote_summarizer", False))
 
     # ── --check ───────────────────────────────────────────────────────────
     if check:
@@ -1588,9 +1695,6 @@ def _run_config(check: bool = False, init: bool = False) -> None:
         issues: list[str] = []
 
         # Validate config.jsonc
-        from . import config as _cfg
-        storage_path = os.environ.get("CODE_INDEX_PATH", str(Path.home() / ".code-index"))
-        config_path = Path(storage_path) / "config.jsonc"
         config_issues = _cfg.validate_config(str(config_path))
         if config_issues:
             for issue in config_issues:
@@ -1600,7 +1704,7 @@ def _run_config(check: bool = False, init: bool = False) -> None:
             print(f"  {green(CHECK)} config.jsonc valid: {config_path}")
 
         # Storage writable?
-        storage = Path(os.environ.get("CODE_INDEX_PATH", Path.home() / ".code-index"))
+        storage = Path(storage_path)
         try:
             storage.mkdir(parents=True, exist_ok=True)
             probe = storage / ".jcm_probe"
@@ -1720,8 +1824,9 @@ def main(argv: Optional[list[str]] = None):
     serve_parser.add_argument(
         "--watcher-debounce",
         type=int,
-        default=int(os.environ.get("JCODEMUNCH_WATCH_DEBOUNCE_MS", "2000")),
-        help="Watcher debounce interval in ms (default: 2000, also via JCODEMUNCH_WATCH_DEBOUNCE_MS)",
+        default=None,
+        metavar="MS",
+        help="Watcher debounce interval in ms (default: from config, also via JCODEMUNCH_WATCH_DEBOUNCE_MS)",
     )
     serve_parser.add_argument(
         "--watcher-idle-timeout",
@@ -1756,7 +1861,7 @@ def main(argv: Optional[list[str]] = None):
     )
     serve_parser.add_argument(
         "--freshness-mode",
-        default=os.environ.get("JCODEMUNCH_FRESHNESS_MODE", "relaxed"),
+        default=None,
         choices=["relaxed", "strict"],
         help="Freshness mode: 'relaxed' (default) or 'strict' (block queries until watcher reindex finishes)",
     )
@@ -1774,8 +1879,9 @@ def main(argv: Optional[list[str]] = None):
     watch_parser.add_argument(
         "--debounce",
         type=int,
-        default=int(os.environ.get("JCODEMUNCH_WATCH_DEBOUNCE_MS", "2000")),
-        help="Debounce interval in milliseconds (default: 2000, also via JCODEMUNCH_WATCH_DEBOUNCE_MS)",
+        default=None,
+        metavar="MS",
+        help="Debounce interval in ms (default: from config, also via JCODEMUNCH_WATCH_DEBOUNCE_MS)",
     )
     watch_parser.add_argument(
         "--no-ai-summaries",
@@ -1858,14 +1964,16 @@ def main(argv: Optional[list[str]] = None):
     wc_parser.add_argument(
         "--poll-interval",
         type=float,
-        default=float(os.environ.get("JCODEMUNCH_CLAUDE_POLL_INTERVAL", "5")),
-        help="How often (in seconds) to poll git for worktrees (default: 5, only with --repos)",
+        default=None,
+        metavar="SECONDS",
+        help="Poll interval in seconds (default: from config, also via JCODEMUNCH_CLAUDE_POLL_INTERVAL)",
     )
     wc_parser.add_argument(
         "--debounce",
         type=int,
-        default=int(os.environ.get("JCODEMUNCH_WATCH_DEBOUNCE_MS", "2000")),
-        help="Debounce interval in milliseconds for file watching (default: 2000)",
+        default=None,
+        metavar="MS",
+        help="Debounce interval in ms for file watching (default: from config, also via JCODEMUNCH_WATCH_DEBOUNCE_MS)",
     )
     wc_parser.add_argument(
         "--no-ai-summaries",
@@ -1904,6 +2012,26 @@ def main(argv: Optional[list[str]] = None):
             init=getattr(args, "init", False),
         )
         return
+
+    # Apply config defaults for watcher keys: CLI args > config > env vars.
+    # config.load_config() is called inside each subcommand handler, but we need
+    # the values here to fill in None defaults from argparse.
+    # load_config() is idempotent so calling it early is safe.
+    config_module.load_config()
+
+    # --watcher-debounce (serve subcommand) / --debounce (watch, watch-claude)
+    # Only set if the attr exists on args and is None (not explicitly provided on CLI)
+    _debounce = config_module.get("watch_debounce_ms", 2000)
+    if getattr(args, "watcher_debounce", None) is None:
+        args.watcher_debounce = _debounce
+    if getattr(args, "debounce", None) is None:
+        args.debounce = _debounce
+
+    # --poll-interval (watch-claude subcommand)
+    if getattr(args, "poll_interval", None) is None:
+        args.poll_interval = config_module.get("claude_poll_interval", 5.0)
+
+    # --freshness-mode is only relevant for serve subcommand; handled there
 
     _setup_logging(args)
 
@@ -1944,6 +2072,7 @@ def main(argv: Optional[list[str]] = None):
             )
         )
     elif args.command == "index-file":
+        config_module.load_config()
         from .tools.index_file import index_file as _index_file
         import json as _json
 
@@ -1960,7 +2089,11 @@ def main(argv: Optional[list[str]] = None):
          # serve (default)
         # Load config at startup so config values are available to all tools
         config_module.load_config()
+        config_module.load_all_project_configs()
         from .reindex_state import set_freshness_mode
+        # Apply config default if --freshness-mode was not explicitly provided
+        if args.freshness_mode is None:
+            args.freshness_mode = config_module.get("freshness_mode", "relaxed")
         set_freshness_mode(args.freshness_mode)
         watcher_enabled = _get_watcher_enabled(args)
 

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -1444,8 +1444,26 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _run_config(check: bool = False) -> None:
-    """Print the current effective configuration to stdout."""
+def _run_config(check: bool = False, init: bool = False) -> None:
+    """Print the current effective configuration to stdout, or initialize config file."""
+    # Handle --init
+    if init:
+        from . import config as _cfg
+
+        storage_path = os.environ.get("CODE_INDEX_PATH", str(Path.home() / ".code-index"))
+        config_path = Path(storage_path) / "config.jsonc"
+
+        if config_path.exists():
+            print(f"Config file already exists: {config_path}")
+            print("Refusing to overwrite. Remove it first or use --check to validate it.")
+            return
+
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        template = _cfg.generate_template()
+        config_path.write_text(template, encoding="utf-8")
+        print(f"Created config template: {config_path}")
+        print("Edit it to customize jcodemunch-mcp settings.")
+        return
     tty = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
     enc = getattr(sys.stdout, "encoding", "ascii") or "ascii"
 
@@ -1776,6 +1794,11 @@ def main(argv: Optional[list[str]] = None):
         action="store_true",
         help="Also verify prerequisites (storage writable, AI packages installed, HTTP packages present)",
     )
+    config_parser.add_argument(
+        "--init",
+        action="store_true",
+        help="Generate a template config.jsonc file in CODE_INDEX_PATH",
+    )
 
     # --- hook-event ---
     hook_parser = subparsers.add_parser(
@@ -1843,7 +1866,10 @@ def main(argv: Optional[list[str]] = None):
         args = parser.parse_args(raw_argv)
 
     if args.command == "config":
-        _run_config(check=getattr(args, "check", False))
+        _run_config(
+            check=getattr(args, "check", False),
+            init=getattr(args, "init", False),
+        )
         return
 
     _setup_logging(args)

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -1587,6 +1587,18 @@ def _run_config(check: bool = False, init: bool = False) -> None:
         section("Checks")
         issues: list[str] = []
 
+        # Validate config.jsonc
+        from . import config as _cfg
+        storage_path = os.environ.get("CODE_INDEX_PATH", str(Path.home() / ".code-index"))
+        config_path = Path(storage_path) / "config.jsonc"
+        config_issues = _cfg.validate_config(str(config_path))
+        if config_issues:
+            for issue in config_issues:
+                print(f"  {red(CROSS)} config.jsonc: {issue}")
+            issues.append("config")
+        else:
+            print(f"  {green(CHECK)} config.jsonc valid: {config_path}")
+
         # Storage writable?
         storage = Path(os.environ.get("CODE_INDEX_PATH", Path.home() / ".code-index"))
         try:
@@ -1896,6 +1908,7 @@ def main(argv: Optional[list[str]] = None):
     _setup_logging(args)
 
     if args.command == "watch":
+        config_module.load_config()
         from .watcher import watch_folders
 
         use_ai = not args.no_ai_summaries and _default_use_ai_summaries()
@@ -1915,6 +1928,7 @@ def main(argv: Optional[list[str]] = None):
 
         handle_hook_event(event_type=args.event_type)
     elif args.command == "watch-claude":
+        config_module.load_config()
         from .watcher import watch_claude_worktrees
 
         use_ai = not args.no_ai_summaries and _default_use_ai_summaries()
@@ -1943,7 +1957,9 @@ def main(argv: Optional[list[str]] = None):
         if not result.get("success"):
             sys.exit(1)
     else:
-        # serve (default)
+         # serve (default)
+        # Load config at startup so config values are available to all tools
+        config_module.load_config()
         from .reindex_state import set_freshness_mode
         set_freshness_mode(args.freshness_mode)
         watcher_enabled = _get_watcher_enabled(args)

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -2086,7 +2086,7 @@ def main(argv: Optional[list[str]] = None):
         if not result.get("success"):
             sys.exit(1)
     else:
-         # serve (default)
+        # serve (default)
         # Load config at startup so config values are available to all tools
         config_module.load_config()
         config_module.load_all_project_configs()

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -16,6 +16,7 @@ from mcp.server import Server
 from mcp.types import Tool, TextContent, Resource
 
 from . import __version__
+from . import config as config_module
 from .tools.index_repo import index_repo
 from .tools.index_folder import index_folder
 from .tools.index_file import index_file
@@ -744,6 +745,12 @@ async def list_tools() -> list[Tool]:
     for tool in tools:
         if isinstance(tool.inputSchema, dict):
             tool.inputSchema.setdefault("properties", {}).update(_SUPPRESS_META_PROP)
+
+    # Filter out disabled tools
+    disabled = config_module.get("disabled_tools", [])
+    if disabled:
+        tools = [t for t in tools if t.name not in disabled]
+
     return tools
 
 

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -762,15 +762,13 @@ def _apply_description_overrides(tools: list) -> None:
     shared = descriptions.get("_shared", {})
 
     for tool in tools:
-        tool_desc = descriptions.get(tool.name)
-        if not tool_desc:
-            continue
+        tool_desc = descriptions.get(tool.name, {})
 
         # Override tool-level description
-        if "_tool" in tool_desc and tool_desc["_tool"]:
+        if tool_desc.get("_tool"):
             tool.description = tool_desc["_tool"]
 
-        # Override parameter descriptions
+        # Override parameter descriptions (applies even if only _shared is set)
         if isinstance(tool.inputSchema, dict):
             props = tool.inputSchema.get("properties", {})
             for param_name, param_schema in props.items():

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -1103,7 +1103,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         
         if isinstance(result, dict):
             meta_fields = config_module.get("meta_fields")
-            if meta_fields == []:
+            if meta_fields == [] or arguments.get("suppress_meta"):
                 result.pop("_meta", None)
             elif meta_fields is None:
                 _meta = result.setdefault("_meta", {})
@@ -2036,7 +2036,6 @@ def main(argv: Optional[list[str]] = None):
     _setup_logging(args)
 
     if args.command == "watch":
-        config_module.load_config()
         from .watcher import watch_folders
 
         use_ai = not args.no_ai_summaries and _default_use_ai_summaries()
@@ -2056,7 +2055,6 @@ def main(argv: Optional[list[str]] = None):
 
         handle_hook_event(event_type=args.event_type)
     elif args.command == "watch-claude":
-        config_module.load_config()
         from .watcher import watch_claude_worktrees
 
         use_ai = not args.no_ai_summaries and _default_use_ai_summaries()
@@ -2072,7 +2070,6 @@ def main(argv: Optional[list[str]] = None):
             )
         )
     elif args.command == "index-file":
-        config_module.load_config()
         from .tools.index_file import index_file as _index_file
         import json as _json
 
@@ -2087,7 +2084,8 @@ def main(argv: Optional[list[str]] = None):
             sys.exit(1)
     else:
         # serve (default)
-        # Load config at startup so config values are available to all tools
+        # Re-run load_config() after _setup_logging() so config warnings/errors
+        # go to the configured log destination (the early call at startup ran before logging was set up)
         config_module.load_config()
         config_module.load_all_project_configs()
         from .reindex_state import set_freshness_mode

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -781,9 +781,17 @@ def _apply_description_overrides(tools: list) -> None:
     shared = descriptions.get("_shared", {})
 
     for tool in tools:
-        tool_desc = descriptions.get(tool.name, {})
+        raw = descriptions.get(tool.name)
+        if raw is None:
+            tool_desc: dict = {}
+        elif isinstance(raw, str):
+            # Flat format: "tool_name": "description" → override tool description only
+            tool.description = raw
+            tool_desc = {}
+        else:
+            tool_desc = raw
 
-        # Override tool-level description
+        # Nested format: override tool-level description via "_tool" key
         # "_tool": "" means "use hardcoded minimal base only" (empty string override)
         if "_tool" in tool_desc:
             tool.description = tool_desc["_tool"]

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -747,7 +747,39 @@ async def list_tools() -> list[Tool]:
     if disabled:
         tools = [t for t in tools if t.name not in disabled]
 
+    # Merge descriptions from config (runs after disabled_tools filter)
+    _apply_description_overrides(tools)
+
     return tools
+
+
+def _apply_description_overrides(tools: list) -> None:
+    """Apply description overrides from config to tool schemas."""
+    descriptions = config_module.get_descriptions()
+    if not descriptions:
+        return
+
+    shared = descriptions.get("_shared", {})
+
+    for tool in tools:
+        tool_desc = descriptions.get(tool.name)
+        if not tool_desc:
+            continue
+
+        # Override tool-level description
+        if "_tool" in tool_desc and tool_desc["_tool"]:
+            tool.description = tool_desc["_tool"]
+
+        # Override parameter descriptions
+        if isinstance(tool.inputSchema, dict):
+            props = tool.inputSchema.get("properties", {})
+            for param_name, param_schema in props.items():
+                if not isinstance(param_schema, dict):
+                    continue
+                # Tool-specific override takes precedence over _shared
+                desc_override = tool_desc.get(param_name) or shared.get(param_name)
+                if desc_override:
+                    props[param_name] = {**param_schema, "description": desc_override}
 
 
 @server.list_resources()

--- a/src/jcodemunch_mcp/storage/index_store.py
+++ b/src/jcodemunch_mcp/storage/index_store.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Callable, Optional
 
+from .. import config as _config
 from ..parser.symbols import Symbol
 from .sqlite_store import SQLiteIndexStore
 
@@ -638,7 +639,7 @@ class IndexStore:
         if data.get("display_name"):
             repo_entry["display_name"] = data["display_name"]
         if data.get("source_root"):
-            if os.environ.get("JCODEMUNCH_REDACT_SOURCE_ROOT", "") == "1":
+            if _config.get("redact_source_root", False):
                 repo_entry["source_root"] = data.get("display_name", "") or ""
             else:
                 repo_entry["source_root"] = data["source_root"]

--- a/src/jcodemunch_mcp/storage/token_tracker.py
+++ b/src/jcodemunch_mcp/storage/token_tracker.py
@@ -30,6 +30,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from .. import config as _config
+
 logger = logging.getLogger(__name__)
 
 _SAVINGS_FILE = "_savings.json"
@@ -38,14 +40,9 @@ _BYTES_PER_TOKEN = 4  # ~4 bytes per token (rough but consistent)
 _TELEMETRY_URL = "https://j.gravelle.us/APIs/savings/post.php"
 _FLUSH_INTERVAL = 3  # flush to disk every N calls
 
-def _read_stats_file_interval() -> int:
-    """Read JCODEMUNCH_STATS_FILE_INTERVAL env var. 0 = disabled, default 3."""
-    try:
-        return max(0, int(os.environ.get("JCODEMUNCH_STATS_FILE_INTERVAL", _FLUSH_INTERVAL)))
-    except (ValueError, TypeError):
-        return _FLUSH_INTERVAL
-
-_STATS_FILE_INTERVAL: int = _read_stats_file_interval()
+def _get_stats_file_interval() -> int:
+    """Read stats_file_interval from config. 0 = disabled, default 3."""
+    return max(0, _config.get("stats_file_interval", _FLUSH_INTERVAL))
 
 # Input token pricing ($ per token). Update as models reprice.
 # Source: https://claude.com/pricing#api (last verified 2026-03-09)
@@ -135,14 +132,15 @@ class _State:
     def _write_session_stats_locked(self, stats: dict, force: bool = False) -> None:
         """Write session stats to ~/.code-index/session_stats.json. Must be called with _lock held.
 
-        Writes are gated by JCODEMUNCH_STATS_FILE_INTERVAL (default 3 calls).
-        Set the env var to 0 to disable all session_stats.json writes.
+        Writes are gated by stats_file_interval config (default 3 calls).
+        Set to 0 to disable all session_stats.json writes.
         Pass force=True to bypass the interval check (e.g. explicit get_session_stats call).
         """
-        if _STATS_FILE_INTERVAL == 0 and not force:
+        stats_file_interval = _get_stats_file_interval()
+        if stats_file_interval == 0 and not force:
             return
         self._stats_call_count += 1
-        if not force and self._stats_call_count < _STATS_FILE_INTERVAL:
+        if not force and self._stats_call_count < stats_file_interval:
             return
         self._stats_call_count = 0
         path = _session_stats_path(self._base_path)
@@ -182,7 +180,7 @@ class _State:
             logger.debug("Failed to write savings data to %s", path, exc_info=True)
 
         # Send batched telemetry
-        if self._pending_telemetry > 0 and os.environ.get("JCODEMUNCH_SHARE_SAVINGS", "1") != "0":
+        if self._pending_telemetry > 0 and _config.get("share_savings", True):
             _share_savings(self._pending_telemetry, self._anon_id)
             self._pending_telemetry = 0
 

--- a/src/jcodemunch_mcp/summarizer/batch_summarize.py
+++ b/src/jcodemunch_mcp/summarizer/batch_summarize.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Optional
 from urllib.parse import urlparse
 
+from .. import config as _config
 from ..parser.symbols import Symbol
 
 logger = logging.getLogger(__name__)
@@ -88,7 +89,7 @@ class BaseSummarizer:
         if not to_summarize:
             return symbols
 
-        max_workers = int(os.environ.get("JCODEMUNCH_SUMMARIZER_CONCURRENCY", "4"))
+        max_workers = _config.get("summarizer_concurrency", 4)
         batches = [to_summarize[i:i + batch_size] for i in range(0, len(to_summarize), batch_size)]
 
         if max_workers <= 1 or len(batches) <= 1:
@@ -182,7 +183,7 @@ class BatchSummarizer(BaseSummarizer):
                 base_url = os.environ.get("ANTHROPIC_BASE_URL")
                 kwargs = {"api_key": api_key}
                 if base_url:
-                    allow_remote = os.environ.get("JCODEMUNCH_ALLOW_REMOTE_SUMMARIZER", "0") == "1"
+                    allow_remote = _config.get("allow_remote_summarizer", False)
                     if _is_localhost_url(base_url) or allow_remote:
                         kwargs["base_url"] = base_url
                     else:
@@ -295,7 +296,7 @@ class OpenAIBatchSummarizer(BaseSummarizer):
             # Strip trailing slash if present
             self.api_base = self.api_base.rstrip("/")
             # Security: restrict to localhost unless explicitly overridden
-            allow_remote = os.environ.get("JCODEMUNCH_ALLOW_REMOTE_SUMMARIZER", "0") == "1"
+            allow_remote = _config.get("allow_remote_summarizer", False)
             if not _is_localhost_url(self.api_base) and not allow_remote:
                 logger.warning(
                     "OPENAI_API_BASE points to non-localhost URL (%s). "

--- a/src/jcodemunch_mcp/tools/get_repo_outline.py
+++ b/src/jcodemunch_mcp/tools/get_repo_outline.py
@@ -7,6 +7,7 @@ from collections import Counter
 from datetime import datetime, timezone
 from typing import Optional
 
+from .. import config as _config
 from ..storage import IndexStore, record_savings, estimate_savings, cost_avoided
 from ..parser.imports import resolve_specifier
 from ._utils import resolve_repo
@@ -99,7 +100,7 @@ def get_repo_outline(
     # Staleness warning
     staleness_warning = None
     try:
-        staleness_days = int(os.environ.get("JCODEMUNCH_STALENESS_DAYS", "7"))
+        staleness_days = _config.get("staleness_days", 7)
         indexed_dt = datetime.fromisoformat(index.indexed_at)
         if indexed_dt.tzinfo is None:
             indexed_dt = indexed_dt.replace(tzinfo=timezone.utc)

--- a/src/jcodemunch_mcp/tools/index_file.py
+++ b/src/jcodemunch_mcp/tools/index_file.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
+from .. import config as _config
 from ..parser import LANGUAGE_EXTENSIONS, get_language_for_path
 from ..parser.context import discover_providers, collect_metadata
 from ..security import validate_path
@@ -129,8 +130,12 @@ def index_file(
         }
 
     # Discover context providers (same env var check as index_folder)
-    _providers_enabled = context_providers and os.environ.get("JCODEMUNCH_CONTEXT_PROVIDERS", "1") != "0"
+    _providers_enabled = context_providers and _config.get("context_providers", True)
     active_providers = discover_providers(source_root) if _providers_enabled else []
+    # Gate SQL-dependent providers: when SQL is removed from languages config,
+    # filter out the dbt provider to avoid unnecessary detection overhead.
+    if active_providers and not _config.is_language_enabled("sql"):
+        active_providers = [p for p in active_providers if p.name != "dbt"]
 
     # Shared pipeline: parse, enrich, summarize, extract metadata
     warnings: list[str] = []

--- a/src/jcodemunch_mcp/tools/index_folder.py
+++ b/src/jcodemunch_mcp/tools/index_folder.py
@@ -15,6 +15,7 @@ import pathspec
 
 logger = logging.getLogger(__name__)
 
+from .. import config as _config
 from ..parser import parse_file, LANGUAGE_EXTENSIONS, get_language_for_path
 from ..parser.context import discover_providers, enrich_symbols, collect_metadata
 from ..parser.imports import extract_imports
@@ -363,6 +364,11 @@ def index_folder(
     if not folder_path.is_dir():
         return {"success": False, "error": f"Path is not a directory: {path}"}
 
+    # Load and cache project-level config (.jcodemunch.jsonc) so subsequent
+    # config.get() calls within this indexing run use project overrides.
+    # This handles both first-time indexing and re-indexing of existing projects.
+    _config.load_project_config(str(folder_path))
+
     # Guard against dangerously broad roots.  A relative path like "." resolves
     # against the MCP server's CWD (not the caller's project directory), which
     # can be "/" or "~" when the server is launched by a system launcher.
@@ -391,8 +397,8 @@ def index_folder(
             "Prefer passing an absolute path to avoid unexpected behaviour."
         )
 
-    # Redact absolute path from responses when JCODEMUNCH_REDACT_SOURCE_ROOT=1
-    _redact = os.environ.get("JCODEMUNCH_REDACT_SOURCE_ROOT", "") == "1"
+    # Redact absolute path from responses when redact_source_root is enabled
+    _redact = _config.get("redact_source_root", False)
     _folder_display = folder_path.name if _redact else str(folder_path)
 
     max_files = get_max_folder_files()
@@ -688,9 +694,18 @@ def index_folder(
             return {"success": False, "error": "No source files found"}
 
         # Discover context providers (dbt, terraform, etc.)
-        _providers_enabled = context_providers and os.environ.get("JCODEMUNCH_CONTEXT_PROVIDERS", "1") != "0"
+        _providers_enabled = context_providers and _config.get("context_providers", True)
         active_providers = discover_providers(folder_path) if _providers_enabled else []
-        if active_providers:
+        # Gate SQL-dependent providers: when SQL is removed from languages config,
+        # filter out the dbt provider to avoid unnecessary detection overhead.
+        if active_providers and not _config.is_language_enabled("sql"):
+            active_providers = [p for p in active_providers if p.name != "dbt"]
+            if active_providers:
+                names = ", ".join(p.name for p in active_providers)
+                logger.info("Active context providers (SQL disabled): %s", names)
+            else:
+                logger.info("Active context providers: none (SQL disabled)")
+        elif active_providers:
             names = ", ".join(p.name for p in active_providers)
             logger.info("Active context providers: %s", names)
 

--- a/src/jcodemunch_mcp/tools/search_columns.py
+++ b/src/jcodemunch_mcp/tools/search_columns.py
@@ -1,10 +1,10 @@
 """Search column metadata across indexed models."""
 
 import fnmatch
-import os
 import time
 from typing import Optional
 
+from .. import config as _config
 from ._utils import resolve_repo
 from ..storage.index_store import IndexStore
 from ..storage.token_tracker import estimate_savings, record_savings, cost_avoided
@@ -50,7 +50,7 @@ def search_columns(
         Dict with matching columns and _meta envelope.
     """
     start = time.perf_counter()
-    hard_cap = int(os.environ.get("JCODEMUNCH_MAX_RESULTS", "500"))
+    hard_cap = _config.get("max_results", 500)
     max_results = max(1, min(max_results, hard_cap))
 
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,49 @@ import pytest
 from jcodemunch_mcp.server import main
 
 
+def test_config_init_creates_template(monkeypatch, tmp_path, capsys):
+    """config --init should create a template config.jsonc file."""
+    from jcodemunch_mcp import config as config_module
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    config_path = config_dir / "config.jsonc"
+
+    monkeypatch.setenv("CODE_INDEX_PATH", str(config_dir))
+    monkeypatch.setattr("sys.argv", ["jcodemunch-mcp", "config", "--init"])
+
+    main(["config", "--init"])
+
+    assert config_path.exists()
+
+    # Should be valid JSONC (parseable after stripping comments)
+    content = config_path.read_text()
+    assert "// jcodemunch-mcp configuration" in content
+    from jcodemunch_mcp.config import _strip_jsonc
+    import json
+    stripped = _strip_jsonc(content)
+    parsed = json.loads(stripped)  # Should not raise
+    assert "languages" in parsed
+    assert "disabled_tools" in parsed
+
+
+def test_config_init_refuses_overwrite(monkeypatch, tmp_path, capsys):
+    """config --init should refuse to overwrite existing config."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    config_path = config_dir / "config.jsonc"
+    config_path.write_text('{"already": "exists"}')
+
+    monkeypatch.setenv("CODE_INDEX_PATH", str(config_dir))
+    monkeypatch.setattr("sys.argv", ["jcodemunch-mcp", "config", "--init"])
+
+    main(["config", "--init"])
+
+    out = capsys.readouterr().out
+    # Should refuse to overwrite
+    assert "already exists" in out.lower() or "exists" in out.lower()
+
+
 def test_main_help_exits_without_starting_server(capsys):
     """`--help` should print usage and exit cleanly."""
     with pytest.raises(SystemExit) as exc:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -289,3 +289,80 @@ class TestGetDescriptions:
 
         result = get_descriptions()
         assert result == {}
+
+
+class TestEnvVarFallback:
+    """Test deprecated env var fallback with warnings."""
+
+    def test_env_var_used_when_config_key_absent(self, monkeypatch, caplog):
+        """Should use env var value when config key not set."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG, _DEPRECATED_ENV_VARS_LOGGED
+        import logging
+
+        _GLOBAL_CONFIG.clear()
+        _DEPRECATED_ENV_VARS_LOGGED.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Config without max_folder_files
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"use_ai_summaries": false}')
+
+            # Env var set for max_folder_files
+            monkeypatch.setenv("JCODEMUNCH_MAX_FOLDER_FILES", "5000")
+
+            with caplog.at_level(logging.WARNING):
+                load_config(tmpdir)
+
+            # Should use env var value
+            assert get("max_folder_files") == 5000
+
+    def test_warning_logged_once_per_deprecated_var(self, monkeypatch, caplog):
+        """Should log one warning per deprecated env var found."""
+        from src.jcodemunch_mcp.config import load_config, _GLOBAL_CONFIG, _DEPRECATED_ENV_VARS_LOGGED
+        import logging
+
+        _GLOBAL_CONFIG.clear()
+        _DEPRECATED_ENV_VARS_LOGGED.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{}')  # Empty config
+
+            monkeypatch.setenv("JCODEMUNCH_MAX_FOLDER_FILES", "5000")
+            monkeypatch.setenv("JCODEMUNCH_MAX_INDEX_FILES", "15000")
+
+            with caplog.at_level(logging.WARNING):
+                load_config(tmpdir)
+
+            # Should have warnings (one per env var)
+            warning_count = sum(1 for rec in caplog.records if rec.levelname == "WARNING")
+            assert warning_count >= 2
+
+            # Each warning should mention v2.0 removal
+            for rec in caplog.records:
+                if "deprecated" in rec.message.lower():
+                    assert "v2.0" in rec.message
+
+    def test_no_warning_when_config_key_present(self, monkeypatch, caplog):
+        """Should NOT log warning when config key is present."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG, _DEPRECATED_ENV_VARS_LOGGED
+        import logging
+
+        _GLOBAL_CONFIG.clear()
+        _DEPRECATED_ENV_VARS_LOGGED.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"max_folder_files": 3000}')
+
+            # Env var set but should be ignored (config takes precedence)
+            monkeypatch.setenv("JCODEMUNCH_MAX_FOLDER_FILES", "5000")
+
+            with caplog.at_level(logging.WARNING):
+                load_config(tmpdir)
+
+            # Should NOT log deprecation warning (config key present)
+            assert "deprecated" not in caplog.text.lower()
+
+            # Config value should be used, not env var
+            assert get("max_folder_files") == 3000

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -164,3 +164,53 @@ class TestProjectConfig:
             assert get("max_folder_files", repo=repo_key) == 5000
             # Non-overridden values should come from global
             assert get("use_ai_summaries", repo=repo_key) is True
+
+
+class TestConfigGetters:
+    """Test config getter functions."""
+
+    def test_is_tool_disabled(self):
+        """Should return True if tool is in disabled_tools."""
+        from src.jcodemunch_mcp.config import (
+            load_config, is_tool_disabled, _GLOBAL_CONFIG
+        )
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"disabled_tools": ["index_repo", "search_columns"]}')
+
+            load_config(tmpdir)
+
+            assert is_tool_disabled("index_repo") is True
+            assert is_tool_disabled("search_columns") is True
+            assert is_tool_disabled("get_file_tree") is False
+
+    def test_is_language_enabled_all_enabled(self):
+        """Should return True for all languages when languages is None."""
+        from src.jcodemunch_mcp.config import (
+            load_config, is_language_enabled, _GLOBAL_CONFIG, DEFAULTS
+        )
+
+        _GLOBAL_CONFIG.clear()
+        _GLOBAL_CONFIG.update(DEFAULTS)  # languages = None
+
+        assert is_language_enabled("python") is True
+        assert is_language_enabled("sql") is True
+
+    def test_is_language_enabled_filtered(self):
+        """Should return False for disabled languages."""
+        from src.jcodemunch_mcp.config import load_config, is_language_enabled, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"languages": ["python", "javascript"]}')
+
+            load_config(tmpdir)
+
+            assert is_language_enabled("python") is True
+            assert is_language_enabled("javascript") is True
+            assert is_language_enabled("sql") is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,21 @@
+"""Tests for JSONC config parsing."""
+
+import pytest
+
+from src.jcodemunch_mcp.config import _strip_jsonc
+
+
+class TestJSONCParser:
+    """Test JSONC comment stripping."""
+
+    def test_strips_line_comments(self):
+        """Should strip // comments to end of line."""
+        text = '{"key": "value" // this is a comment\n}'
+        result = _strip_jsonc(text)
+        assert result == '{"key": "value" \n}'
+
+    def test_strips_line_comment_no_trailing_newline(self):
+        """Should strip // comment at end of file."""
+        text = '{"key": "value"} // comment'
+        result = _strip_jsonc(text)
+        assert result == '{"key": "value"} '

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -253,3 +253,39 @@ class TestTemplateGeneration:
         # All registry languages should be in template
         for lang in LANGUAGE_REGISTRY.keys():
             assert lang in parsed["languages"]
+
+
+class TestGetDescriptions:
+    """Test get_descriptions() function."""
+
+    def test_returns_descriptions_dict(self):
+        """Should return descriptions dict from config."""
+        from src.jcodemunch_mcp.config import load_config, get_descriptions, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('''{
+                "descriptions": {
+                    "search_symbols": {"_tool": "custom"},
+                    "_shared": {"repo": "shared desc"}
+                }
+            }''')
+
+            load_config(tmpdir)
+
+            result = get_descriptions()
+            assert isinstance(result, dict)
+            assert "search_symbols" in result
+            assert "_shared" in result
+
+    def test_returns_empty_dict_when_absent(self):
+        """Should return empty dict when descriptions key absent."""
+        from src.jcodemunch_mcp.config import load_config, get_descriptions, _GLOBAL_CONFIG, DEFAULTS
+
+        _GLOBAL_CONFIG.clear()
+        _GLOBAL_CONFIG.update(DEFAULTS)  # descriptions = {}
+
+        result = get_descriptions()
+        assert result == {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,25 +16,20 @@ class TestJSONCParser:
         """Should strip // comments to end of line."""
         text = '{"key": "value" // this is a comment\n}'
         result = _strip_jsonc(text)
-        # Space before // is preserved; valid JSON
-        assert result == '{"key": "value" \n}'
-        import json
+        # Result must be valid JSON
         json.loads(result)  # Must be valid JSON
 
     def test_strips_line_comment_no_trailing_newline(self):
         """Should strip // comment at end of file."""
         text = '{"key": "value"} // comment'
         result = _strip_jsonc(text)
-        # Space before // is preserved
-        assert result == '{"key": "value"} '
-        import json
         json.loads(result)  # Must be valid JSON
 
     def test_strips_block_comments(self):
         """Should strip /* */ block comments."""
         text = '{"key" /* comment */: "value"}'
         result = _strip_jsonc(text)
-        assert result == '{"key" : "value"}'
+        json.loads(result)  # Must be valid JSON
 
     def test_strips_multiline_block_comments(self):
         """Should strip multiline /* */ comments."""
@@ -46,12 +41,113 @@ class TestJSONCParser:
         result = _strip_jsonc(text)
         assert '"key"' in result
         assert 'this is' not in result
+        json.loads(result)  # Must be valid JSON
 
     def test_preserves_strings_with_comment_chars(self):
         """Should not strip // or /* inside quoted strings."""
         text = '{"url": "http://example.com", "note": "use /* here*/"}'
         result = _strip_jsonc(text)
-        assert result == text  # Should be unchanged
+        json.loads(result)  # Must be valid JSON
+        parsed = json.loads(result)
+        assert parsed["url"] == "http://example.com"
+        assert parsed["note"] == "use /* here*/"
+
+    def test_trailing_comma_in_object(self):
+        """Should strip trailing commas in objects (valid JSONC, invalid JSON)."""
+        text = '{"a": 1, "b": 2,}'
+        result = _strip_jsonc(text)
+        json.loads(result)  # Must be valid JSON
+        assert json.loads(result) == {"a": 1, "b": 2}
+
+    def test_trailing_comma_in_nested_object(self):
+        """Should strip trailing commas in nested objects."""
+        text = '{"a": {"b": 1,}, "c": 2,}'
+        result = _strip_jsonc(text)
+        json.loads(result)  # Must be valid JSON
+
+    def test_trailing_comma_in_array(self):
+        """Should strip trailing commas in arrays."""
+        text = '{"arr": [1, 2, 3,]}'
+        result = _strip_jsonc(text)
+        json.loads(result)  # Must be valid JSON
+        assert json.loads(result)["arr"] == [1, 2, 3]
+
+    def test_trailing_comma_with_comment(self):
+        """Should strip trailing commas when followed by line comment."""
+        text = '{\n  "key": "value", // comment\n}'
+        result = _strip_jsonc(text)
+        json.loads(result)  # Must be valid JSON
+
+    def test_comment_before_closing_brace_with_trailing_comma(self):
+        """Should handle comment before closing brace with trailing comma."""
+        text = '{"key": "value", // comment\n}'
+        result = _strip_jsonc(text)
+        json.loads(result)  # Must be valid JSON
+
+    def test_escaped_quotes_in_strings(self):
+        """Should preserve escaped quotes inside strings."""
+        text = r'{"key": "value with \"quote\""}'
+        result = _strip_jsonc(text)
+        json.loads(result)  # Must be valid JSON
+        assert json.loads(result)["key"] == 'value with "quote"'
+
+    def test_comment_like_content_in_string(self):
+        """Should preserve // and /* inside quoted strings."""
+        text = '{"url": "http://example.com", "regex": "/*.*?*/"}'
+        result = _strip_jsonc(text)
+        json.loads(result)  # Must be valid JSON
+        parsed = json.loads(result)
+        assert parsed["url"] == "http://example.com"
+        assert parsed["regex"] == "/*.*?*/"
+
+    def test_real_world_config(self):
+        """Should parse a real-world JSONC config file."""
+        text = '''
+{
+  // === Indexing ===
+  "use_ai_summaries": true,
+  "max_folder_files": 2000,
+  "max_index_files": 10000,
+  "staleness_days": 7,
+  "max_results": 500,
+  "extra_ignore_patterns": [],
+  "extra_extensions": {},
+  "context_providers": true,
+
+  // === Meta Response Control ===
+  "meta_fields": [
+    "timing_ms",
+    "powered_by",
+  ],
+
+  // === Languages ===
+  "languages": ["python", "javascript", "typescript"],
+
+  // === Disabled Tools ===
+  "disabled_tools": [],
+
+  // === Descriptions ===
+  "descriptions": {
+    "search_symbols": {
+      "_tool": "",
+      "debug": "",
+    },
+  },
+}
+'''
+        result = _strip_jsonc(text)
+        parsed = json.loads(result)  # Must be valid JSON
+        assert parsed["use_ai_summaries"] is True
+        assert parsed["max_folder_files"] == 2000
+        assert "python" in parsed["languages"]
+        assert parsed["disabled_tools"] == []
+        assert "search_symbols" in parsed["descriptions"]
+
+    def test_multiple_trailing_commas_nested(self):
+        """Should handle multiple trailing commas in deeply nested structures."""
+        text = '{"a": {"b": {"c": 1,},}, "d": [{"e": 2,},],}'
+        result = _strip_jsonc(text)
+        json.loads(result)  # Must be valid JSON
 
 
 class TestConfigDefaults:
@@ -80,6 +176,30 @@ class TestConfigDefaults:
 
 class TestConfigLoading:
     """Test config file loading."""
+
+    def test_auto_creates_default_config_if_missing(self, tmp_path):
+        """load_config() should create default config.jsonc if it doesn't exist."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+        storage_path = str(tmp_path)
+
+        # No config.jsonc exists yet
+        config_path = tmp_path / "config.jsonc"
+        assert not config_path.exists()
+
+        load_config(storage_path)
+
+        # Should have created the config file
+        assert config_path.exists()
+
+        # Config should have default values
+        content = config_path.read_text()
+        assert "languages" in content  # Template includes languages
+
+        # And defaults should be available
+        assert get("max_folder_files") == 2000
+        assert get("use_ai_summaries") is True
 
     def test_missing_file_uses_defaults(self, monkeypatch):
         """Should use defaults when config file doesn't exist."""
@@ -116,6 +236,63 @@ class TestConfigLoading:
             assert get("max_folder_files") == 5000
             assert get("use_ai_summaries") is False
 
+    def test_meta_fields_null_from_config(self):
+        """meta_fields: null means all fields included (backward compatible)."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"meta_fields": null}')
+
+            load_config(tmpdir)
+
+            assert get("meta_fields") is None
+
+    def test_meta_fields_empty_list_from_config(self):
+        """meta_fields: [] means no _meta (maximum token savings)."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"meta_fields": []}')
+
+            load_config(tmpdir)
+
+            assert get("meta_fields") == []
+
+    def test_meta_fields_partial_list_from_config(self):
+        """meta_fields: ["timing_ms", "powered_by"] means only those fields."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"meta_fields": ["timing_ms", "powered_by"]}')
+
+            load_config(tmpdir)
+
+            assert get("meta_fields") == ["timing_ms", "powered_by"]
+
+    def test_meta_fields_absent_uses_default(self):
+        """meta_fields absent from config uses default (None = all fields)."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG, DEFAULTS
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"max_folder_files": 5000}')
+
+            load_config(tmpdir)
+
+            # When not specified, should use DEFAULTS value
+            assert get("meta_fields") is None
+
     def test_type_mismatch_logs_warning_and_uses_default(self, monkeypatch, caplog):
         """Should log warning and use default on type mismatch."""
         from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
@@ -136,9 +313,70 @@ class TestConfigLoading:
             # Should use default
             assert get("max_folder_files") == 2000
 
+    def test_unknown_language_logs_warning(self, monkeypatch, caplog):
+        """Unknown language in config should log warning and be filtered."""
+        import logging
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        caplog.set_level(logging.WARNING)
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"languages": ["python", "pythno", "javascript"]}')
+
+            load_config(str(tmpdir))
+
+            assert any("pythno" in record.message for record in caplog.records)
+
+            langs = get("languages")
+            assert "python" in langs
+            assert "javascript" in langs
+            assert "pythno" not in langs
+
 
 class TestProjectConfig:
     """Test project-level config loading."""
+
+    def test_load_all_project_configs_at_startup(self, tmp_path, monkeypatch):
+        """load_all_project_configs() should load .jcodemunch.jsonc for all local repos."""
+        from src.jcodemunch_mcp.config import (
+            load_config, load_all_project_configs, get, _GLOBAL_CONFIG, _PROJECT_CONFIGS
+        )
+        import unittest.mock
+
+        # Create two project roots with different configs
+        project_a = tmp_path / "project_a"
+        project_b = tmp_path / "project_b"
+        project_a.mkdir()
+        project_b.mkdir()
+
+        (project_a / ".jcodemunch.jsonc").write_text('{"max_folder_files": 1000}')
+        (project_b / ".jcodemunch.jsonc").write_text('{"max_folder_files": 3000}')
+
+        # Mock list_repos to return our test repos
+        mock_repos = [
+            {"repo": "local/project-a-abc123", "source_root": str(project_a)},
+            {"repo": "local/project-b-def456", "source_root": str(project_b)},
+            {"repo": "github/owner/repo", "source_root": ""},  # Remote repo, no source_root
+        ]
+
+        _GLOBAL_CONFIG.clear()
+        _PROJECT_CONFIGS.clear()
+
+        load_config(str(tmp_path))
+
+        with unittest.mock.patch(
+            "src.jcodemunch_mcp.config._list_repos_for_config", return_value=mock_repos
+        ):
+            load_all_project_configs()
+
+        # Project A should have max_folder_files=1000
+        assert get("max_folder_files", repo=str(project_a.resolve())) == 1000
+        # Project B should have max_folder_files=3000
+        assert get("max_folder_files", repo=str(project_b.resolve())) == 3000
+        # Remote repo should use global default
+        assert get("max_folder_files") == 2000
 
     def test_project_config_merges_over_global(self):
         """Should merge project config over global config."""
@@ -500,12 +738,14 @@ class TestServerConfigCheck:
             assert "parse error" not in captured.lower()
 
 
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 class TestLoadConfigWiredIntoMain:
     """Test that load_config() is called during server startup."""
 
     @pytest.mark.asyncio
     async def test_main_calls_load_config_for_serve_command(self, monkeypatch, tmp_path):
-        """main() should call load_config() when serving."""
+        """load_config should be called when serve subcommand starts."""
         from src.jcodemunch_mcp.config import _GLOBAL_CONFIG, DEFAULTS
 
         _GLOBAL_CONFIG.clear()
@@ -534,9 +774,10 @@ class TestLoadConfigWiredIntoMain:
         monkeypatch.setattr("sys.exit", lambda code=0: None)
 
         # Patch asyncio.run to avoid starting the actual server
-        async def fake_asyncio_run(coro):
-            # Just run the coroutine briefly, don't actually start the server
-            pass
+        def fake_asyncio_run(coro):
+            # Server startup is blocked by fake_server_run patch below,
+            # so we just close the coroutine without awaiting
+            coro.close()
 
         monkeypatch.setattr("asyncio.run", fake_asyncio_run)
 
@@ -549,6 +790,8 @@ class TestLoadConfigWiredIntoMain:
         from src.jcodemunch_mcp.server import main
         main(["serve"])
 
+        # After main() runs, config should reflect the file (not just defaults)
+        assert cfg_module.get("max_folder_files") == 9999
         assert call_count >= 1, "load_config should have been called during serve"
 
     @pytest.mark.asyncio
@@ -565,8 +808,11 @@ class TestLoadConfigWiredIntoMain:
 
         monkeypatch.setattr("sys.exit", lambda code=0: None)
 
-        async def fake_asyncio_run(coro):
-            pass
+        # Patch asyncio.run to avoid starting the actual server
+        def fake_asyncio_run(coro):
+            # Server startup is blocked by fake_server_run patch below,
+            # so we just close the coroutine without awaiting
+            coro.close()
 
         monkeypatch.setattr("asyncio.run", fake_asyncio_run)
 
@@ -579,5 +825,603 @@ class TestLoadConfigWiredIntoMain:
         main(["serve"])
 
         # After main() runs, config should reflect the file (not just defaults)
-        # cfg_module is the same object that server.py's config_module references
         assert cfg_module.get("max_folder_files") == 7777
+
+    def test_load_all_project_configs_called_at_startup(self, monkeypatch, tmp_path):
+        """Server startup should call load_all_project_configs()."""
+        from src.jcodemunch_mcp import config as config_module
+
+        load_calls = []
+        load_all_calls = []
+
+        def tracked_load(*args, **kwargs):
+            load_calls.append((args, kwargs))
+            config_module._GLOBAL_CONFIG = config_module.DEFAULTS.copy()
+
+        def tracked_load_all(*args, **kwargs):
+            load_all_calls.append((args, kwargs))
+
+        monkeypatch.setattr(config_module, "load_config", tracked_load)
+        monkeypatch.setattr(config_module, "load_all_project_configs", tracked_load_all)
+
+        # Patch asyncio.run to close the coroutine without awaiting
+        def fake_asyncio_run(coro):
+            coro.close()
+
+        monkeypatch.setattr("asyncio.run", fake_asyncio_run)
+
+        import sys
+        old_argv = sys.argv
+        sys.argv = ["jcodemunch-mcp"]
+        try:
+            from src.jcodemunch_mcp.server import main
+            main([])
+        finally:
+            sys.argv = old_argv
+
+        assert len(load_calls) >= 1, "load_config should be called"
+        assert len(load_all_calls) >= 1, "load_all_project_configs should be called"
+
+
+# ── Env Var List Comma-Separated Fallback Test (E4) ───────────────────────────────
+
+
+def test_parse_env_value_list_comma_separated_fallback():
+    """_parse_env_value list type falls back to comma-separated on parse failure (E4)."""
+    from src.jcodemunch_mcp.config import _parse_env_value
+
+    # Legacy comma-separated format (*.log,*.tmp) should parse as list
+    result = _parse_env_value("*.log,*.tmp,*.cache", list)
+    assert result == ["*.log", "*.tmp", "*.cache"]
+
+    # Single value (no comma) should still work
+    result = _parse_env_value("*.log", list)
+    assert result == ["*.log"]
+
+    # JSON array format should still take priority
+    result = _parse_env_value('["*.log", "*.tmp"]', list)
+    assert result == ["*.log", "*.tmp"]
+
+    # Empty string should return None (no tokens)
+    result = _parse_env_value("", list)
+    assert result is None
+
+    # Whitespace-only tokens should be stripped
+    result = _parse_env_value("*.log,  ,*.tmp", list)
+    assert result == ["*.log", "*.tmp"]
+
+
+# ── Comprehensive Config File Edge Case Tests ────────────────────────────────────
+
+
+class TestJSONCSyntaxErrors:
+    """Test JSONC parser handles malformed syntax gracefully."""
+
+    def test_unclosed_string_returns_invalid_json(self):
+        """Unclosed string should produce invalid JSON (parser doesn't fix it)."""
+        text = '{"key": "unclosed string}'
+        result = _strip_jsonc(text)
+        # Should not crash, but result won't be valid JSON
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(result)
+
+    def test_unclosed_block_comment_stripped_to_end(self):
+        """Unclosed block comment should strip to end of file."""
+        text = '{"key": "value" /* this never ends'
+        result = _strip_jsonc(text)
+        # The block comment should be stripped
+        assert "/*" not in result
+        assert "this never ends" not in result
+        assert '"key"' in result
+
+    def test_missing_closing_brace(self):
+        """Missing closing brace should produce invalid JSON."""
+        text = '{"key": "value"'
+        result = _strip_jsonc(text)
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(result)
+
+    def test_missing_closing_bracket(self):
+        """Missing closing bracket should produce invalid JSON."""
+        text = '{"arr": [1, 2, 3'
+        result = _strip_jsonc(text)
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(result)
+
+    def test_trailing_comma_without_closing_brace(self):
+        """Trailing comma without closing brace is still invalid JSON."""
+        text = '{"key": "value",'
+        result = _strip_jsonc(text)
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(result)
+
+    def test_duplicate_keys_allowed(self):
+        """JSON allows duplicate keys (last wins) - verify our parser doesn't break."""
+        text = '{"key": "first", "key": "second"}'
+        result = _strip_jsonc(text)
+        parsed = json.loads(result)
+        assert parsed["key"] == "second"  # Last value wins
+
+
+class TestJSONCEdgeCases:
+    """Test JSONC parser handles edge cases correctly."""
+
+    def test_empty_file(self):
+        """Empty file should fail JSON parse."""
+        result = _strip_jsonc("")
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(result)
+
+    def test_only_comments_no_json(self):
+        """File with only comments should fail JSON parse."""
+        text = '''// This is just a comment
+/* and a block comment */
+// More comments'''
+        result = _strip_jsonc(text)
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(result)
+
+    def test_empty_object(self):
+        """Empty object should parse."""
+        text = '{}'
+        result = _strip_jsonc(text)
+        parsed = json.loads(result)
+        assert parsed == {}
+
+    def test_empty_object_with_comments(self):
+        """Empty object with comments should parse."""
+        text = '''{
+    // This is empty
+}'''
+        result = _strip_jsonc(text)
+        parsed = json.loads(result)
+        assert parsed == {}
+
+    def test_unicode_in_strings(self):
+        """Unicode characters in strings should be preserved."""
+        text = '{"greeting": "Hello 世界 🌍"}'
+        result = _strip_jsonc(text)
+        parsed = json.loads(result)
+        assert parsed["greeting"] == "Hello 世界 🌍"
+
+    def test_newlines_in_strings(self):
+        """Escaped newlines in strings should be preserved."""
+        text = '{"text": "line1\\nline2\\nline3"}'
+        result = _strip_jsonc(text)
+        parsed = json.loads(result)
+        assert parsed["text"] == "line1\nline2\nline3"
+
+    def test_backslash_in_strings(self):
+        """Backslashes in strings should be preserved correctly."""
+        text = r'{"path": "C:\\Users\\test\\file.txt"}'
+        result = _strip_jsonc(text)
+        parsed = json.loads(result)
+        assert parsed["path"] == "C:\\Users\\test\\file.txt"
+
+    def test_very_nested_structure(self):
+        """Deeply nested structures should parse correctly."""
+        text = '{"a": {"b": {"c": {"d": {"e": {"f": "deep"}}}}}}'
+        result = _strip_jsonc(text)
+        parsed = json.loads(result)
+        assert parsed["a"]["b"]["c"]["d"]["e"]["f"] == "deep"
+
+    def test_large_array(self):
+        """Large arrays should parse correctly."""
+        items = ", ".join(str(i) for i in range(100))
+        text = f'{{"arr": [{items}]}}'
+        result = _strip_jsonc(text)
+        parsed = json.loads(result)
+        assert len(parsed["arr"]) == 100
+
+    def test_special_characters_in_strings(self):
+        """Special characters in strings should be preserved."""
+        # Test tab character (escaped in JSON as \t)
+        text = '{"text": "line1\\tline2"}'
+        result = _strip_jsonc(text)
+        parsed = json.loads(result)
+        assert "\t" in parsed["text"]
+        
+        # Test quote character (escaped in JSON as \")
+        text = '{"text": "say \\"hello\\""}'
+        result = _strip_jsonc(text)
+        parsed = json.loads(result)
+        assert '"' in parsed["text"]
+        
+        # Test backslash character (escaped in JSON as \\)
+        text = '{"path": "C:\\\\Users\\\\test"}'
+        result = _strip_jsonc(text)
+        parsed = json.loads(result)
+        assert "\\" in parsed["path"]
+
+
+class TestConfigTypeValidation:
+    """Test config type validation for all config keys."""
+
+    def test_bool_type_mismatch_string_true(self):
+        """String 'true' should be rejected for bool type."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+        import logging
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"use_ai_summaries": "true"}')  # String, not bool
+
+            load_config(tmpdir)
+            # Should fall back to default (True)
+            assert get("use_ai_summaries") is True
+
+    def test_int_type_mismatch_float(self):
+        """Float should be rejected for int type."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"max_folder_files": 2000.5}')  # Float, not int
+
+            load_config(tmpdir)
+            # Should fall back to default
+            assert get("max_folder_files") == 2000
+
+    def test_int_type_mismatch_negative(self):
+        """Negative int should be accepted (no range validation)."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"max_folder_files": -1}')
+
+            load_config(tmpdir)
+            # Negative is still a valid int (range validation is elsewhere)
+            assert get("max_folder_files") == -1
+
+    def test_list_type_mismatch_object(self):
+        """Object should be rejected for list type."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"disabled_tools": {"tool": "name"}}')  # Object, not list
+
+            load_config(tmpdir)
+            # Should fall back to default
+            assert get("disabled_tools") == []
+
+    def test_dict_type_mismatch_list(self):
+        """List should be rejected for dict type."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"extra_extensions": [".lua"]}')  # List, not dict
+
+            load_config(tmpdir)
+            # Should fall back to default
+            assert get("extra_extensions") == {}
+
+    def test_null_for_optional_type(self):
+        """Null should be accepted for optional types (list | None)."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"languages": null}')
+
+            load_config(tmpdir)
+            assert get("languages") is None
+
+    def test_empty_string_for_string_type(self):
+        """Empty string should be accepted for string type."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"log_level": ""}')
+
+            load_config(tmpdir)
+            assert get("log_level") == ""
+
+    def test_meta_fields_dict_type_mismatch(self):
+        """meta_fields as dict should fall back to None (all fields)."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"meta_fields": {"invalid": "dict"}}')
+
+            load_config(tmpdir)
+
+            assert get("meta_fields") is None
+
+
+class TestProjectConfigEdgeCases:
+    """Test project-level config edge cases."""
+
+    def test_project_config_invalid_syntax(self):
+        """Invalid project config should fall back to global."""
+        from src.jcodemunch_mcp.config import (
+            load_config, load_project_config, get,
+            _GLOBAL_CONFIG, _PROJECT_CONFIGS
+        )
+
+        _GLOBAL_CONFIG.clear()
+        _PROJECT_CONFIGS.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Set up global config
+            global_config = Path(tmpdir) / "global" / "config.jsonc"
+            global_config.parent.mkdir()
+            global_config.write_text('{"max_folder_files": 2000}')
+
+            load_config(str(global_config.parent))
+
+            # Set up project config with invalid JSON
+            project_root = Path(tmpdir) / "project"
+            project_root.mkdir()
+            project_config = project_root / ".jcodemunch.jsonc"
+            project_config.write_text('{"max_folder_files": invalid}')
+
+            load_project_config(str(project_root))
+
+            # Should fall back to global config
+            repo_key = str(project_root.resolve())
+            assert get("max_folder_files", repo=repo_key) == 2000
+
+    def test_project_config_type_mismatch(self):
+        """Project config with type mismatch should use global value."""
+        from src.jcodemunch_mcp.config import (
+            load_config, load_project_config, get,
+            _GLOBAL_CONFIG, _PROJECT_CONFIGS
+        )
+
+        _GLOBAL_CONFIG.clear()
+        _PROJECT_CONFIGS.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Set up global config
+            global_config = Path(tmpdir) / "global" / "config.jsonc"
+            global_config.parent.mkdir()
+            global_config.write_text('{"max_folder_files": 2000}')
+
+            load_config(str(global_config.parent))
+
+            # Set up project config with type mismatch
+            project_root = Path(tmpdir) / "project"
+            project_root.mkdir()
+            project_config = project_root / ".jcodemunch.jsonc"
+            project_config.write_text('{"max_folder_files": "not_an_int"}')
+
+            load_project_config(str(project_root))
+
+            # Should use global value (type mismatch rejected)
+            repo_key = str(project_root.resolve())
+            assert get("max_folder_files", repo=repo_key) == 2000
+
+    def test_project_config_unknown_key_ignored(self):
+        """Project config with unknown key should ignore it."""
+        from src.jcodemunch_mcp.config import (
+            load_config, load_project_config, get,
+            _GLOBAL_CONFIG, _PROJECT_CONFIGS
+        )
+
+        _GLOBAL_CONFIG.clear()
+        _PROJECT_CONFIGS.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Set up global config
+            global_config = Path(tmpdir) / "global" / "config.jsonc"
+            global_config.parent.mkdir()
+            global_config.write_text('{"max_folder_files": 2000}')
+
+            load_config(str(global_config.parent))
+
+            # Set up project config with unknown key
+            project_root = Path(tmpdir) / "project"
+            project_root.mkdir()
+            project_config = project_root / ".jcodemunch.jsonc"
+            project_config.write_text('{"unknown_key": "value", "max_folder_files": 5000}')
+
+            load_project_config(str(project_root))
+
+            # Unknown key should be ignored, known key should work
+            repo_key = str(project_root.resolve())
+            assert get("max_folder_files", repo=repo_key) == 5000
+            assert get("unknown_key", repo=repo_key) is None
+
+
+class TestConfigFileEncoding:
+    """Test config file encoding edge cases."""
+
+    def test_utf8_bom_handled(self):
+        """UTF-8 BOM should be handled correctly."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            # Write UTF-8 BOM + JSON
+            config_path.write_bytes(b'\xef\xbb\xbf{"max_folder_files": 5000}')
+
+            load_config(tmpdir)
+            assert get("max_folder_files") == 5000
+
+    def test_utf8_with_bom_and_comments(self):
+        """UTF-8 BOM with comments should work."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            # Write UTF-8 BOM + JSONC with comments
+            config_path.write_bytes(b'\xef\xbb\xbf{"max_folder_files": 5000, // comment\n}')
+
+            load_config(tmpdir)
+            assert get("max_folder_files") == 5000
+
+
+class TestAllConfigKeys:
+    """Test that all config keys can be loaded correctly."""
+
+    def test_all_string_keys(self):
+        """Test all string-typed config keys."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        string_keys = ["transport", "host", "freshness_mode", "log_level"]
+
+        for key in string_keys:
+            _GLOBAL_CONFIG.clear()
+            with tempfile.TemporaryDirectory() as tmpdir:
+                config_path = Path(tmpdir) / "config.jsonc"
+                config_path.write_text(f'{{"{key}": "test_value"}}')
+                load_config(tmpdir)
+                assert get(key) == "test_value", f"Key {key} failed"
+
+    def test_all_int_keys(self):
+        """Test all int-typed config keys."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        int_keys = [
+            "max_folder_files", "max_index_files", "staleness_days",
+            "max_results", "port", "rate_limit", "watch_debounce_ms",
+            "stats_file_interval", "summarizer_concurrency"
+        ]
+
+        for key in int_keys:
+            _GLOBAL_CONFIG.clear()
+            with tempfile.TemporaryDirectory() as tmpdir:
+                config_path = Path(tmpdir) / "config.jsonc"
+                config_path.write_text(f'{{"{key}": 42}}')
+                load_config(tmpdir)
+                assert get(key) == 42, f"Key {key} failed"
+
+    def test_all_bool_keys(self):
+        """Test all bool-typed config keys."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        bool_keys = [
+            "use_ai_summaries", "context_providers", "redact_source_root",
+            "share_savings", "allow_remote_summarizer", "watch"
+        ]
+
+        for key in bool_keys:
+            _GLOBAL_CONFIG.clear()
+            with tempfile.TemporaryDirectory() as tmpdir:
+                config_path = Path(tmpdir) / "config.jsonc"
+                config_path.write_text(f'{{"{key}": false}}')
+                load_config(tmpdir)
+                assert get(key) is False, f"Key {key} failed"
+
+    def test_all_list_keys(self):
+        """Test all list-typed config keys."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        list_keys = ["disabled_tools", "extra_ignore_patterns", "meta_fields"]
+
+        for key in list_keys:
+            _GLOBAL_CONFIG.clear()
+            with tempfile.TemporaryDirectory() as tmpdir:
+                config_path = Path(tmpdir) / "config.jsonc"
+                config_path.write_text(f'{{"{key}": ["item1", "item2"]}}')
+                load_config(tmpdir)
+                assert get(key) == ["item1", "item2"], f"Key {key} failed"
+
+    def test_all_list_keys_languages(self):
+        """Test languages list-typed config key with valid language names."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"languages": ["python", "javascript"]}')
+            load_config(tmpdir)
+            assert get("languages") == ["python", "javascript"], "Key languages failed"
+
+    def test_all_dict_keys(self):
+        """Test all dict-typed config keys."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        dict_keys = ["extra_extensions", "descriptions"]
+
+        for key in dict_keys:
+            _GLOBAL_CONFIG.clear()
+            with tempfile.TemporaryDirectory() as tmpdir:
+                config_path = Path(tmpdir) / "config.jsonc"
+                config_path.write_text(f'{{"{key}": {{"nested": "value"}}}}')
+                load_config(tmpdir)
+                assert get(key) == {"nested": "value"}, f"Key {key} failed"
+
+    def test_all_nullable_keys(self):
+        """Test all nullable config keys accept null."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG, CONFIG_TYPES
+
+        # Find all keys with tuple types that include None
+        nullable_keys = [k for k, v in CONFIG_TYPES.items() 
+                        if isinstance(v, tuple) and type(None) in v]
+
+        for key in nullable_keys:
+            _GLOBAL_CONFIG.clear()
+            with tempfile.TemporaryDirectory() as tmpdir:
+                config_path = Path(tmpdir) / "config.jsonc"
+                config_path.write_text(f'{{"{key}": null}}')
+                load_config(tmpdir)
+                assert get(key) is None, f"Key {key} failed"
+
+
+class TestConfigInit:
+    """Test the config --init CLI subcommand."""
+
+    def test_config_init_creates_template(self, tmp_path, monkeypatch, capsys):
+        """config --init should create config.jsonc template."""
+        from src.jcodemunch_mcp.server import main
+
+        storage_path = str(tmp_path)
+        monkeypatch.setenv("CODE_INDEX_PATH", storage_path)
+
+        main(["config", "--init"])
+
+        captured = capsys.readouterr()
+        assert "Created config template" in captured.out
+
+        config_path = tmp_path / "config.jsonc"
+        assert config_path.exists()
+
+        content = config_path.read_text()
+        from src.jcodemunch_mcp.config import _strip_jsonc
+        stripped = _strip_jsonc(content)
+        parsed = json.loads(stripped)
+        assert "languages" in parsed
+
+    def test_config_init_refuses_overwrite(self, tmp_path, monkeypatch, capsys):
+        """config --init should refuse to overwrite existing file."""
+        from src.jcodemunch_mcp.server import main
+
+        storage_path = str(tmp_path)
+        monkeypatch.setenv("CODE_INDEX_PATH", storage_path)
+
+        config_path = tmp_path / "config.jsonc"
+        config_path.write_text('{"existing": true}')
+
+        main(["config", "--init"])
+
+        captured = capsys.readouterr()
+        assert "Config file already exists" in captured.out
+        assert "Refusing to overwrite" in captured.out
+
+        assert json.loads(config_path.read_text()) == {"existing": True}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -366,3 +366,218 @@ class TestEnvVarFallback:
 
             # Config value should be used, not env var
             assert get("max_folder_files") == 3000
+
+
+# ── Config file validation ────────────────────────────────────────────────────
+
+class TestConfigValidation:
+    """Test validate_config() function in config module."""
+
+    def test_validate_valid_config_returns_empty(self):
+        """Should return no issues for a valid config."""
+        from src.jcodemunch_mcp.config import validate_config, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"max_folder_files": 5000}')
+            issues = validate_config(str(config_path))
+            assert issues == []
+
+    def test_validate_invalid_json_returns_parse_error(self):
+        """Should report JSON parse errors."""
+        from src.jcodemunch_mcp.config import validate_config, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"max_folder_files": }')  # Invalid JSON
+            issues = validate_config(str(config_path))
+            assert any("parse" in i.lower() for i in issues)
+
+    def test_validate_type_mismatch_returns_warning(self):
+        """Should report type mismatches."""
+        from src.jcodemunch_mcp.config import validate_config, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"max_folder_files": "not_an_int"}')
+            issues = validate_config(str(config_path))
+            assert any("type" in i.lower() or "invalid" in i.lower() for i in issues)
+
+    def test_validate_unknown_key_returns_warning(self):
+        """Should warn about unknown config keys."""
+        from src.jcodemunch_mcp.config import validate_config, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"max_folder_files": 5000, "unknown_key": true}')
+            issues = validate_config(str(config_path))
+            assert any("unknown" in i.lower() for i in issues)
+
+    def test_validate_missing_file_returns_error(self):
+        """Should report when config file is missing."""
+        from src.jcodemunch_mcp.config import validate_config, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing = Path(tmpdir) / "nonexistent.jsonc"
+            issues = validate_config(str(missing))
+            assert any("not found" in i.lower() for i in issues)
+
+
+class TestServerConfigCheck:
+    """Test that `config --check` validates the config file."""
+
+    def test_run_config_check_reports_config_parse_error(self, capsys, monkeypatch):
+        """Should report config file parse errors in --check output."""
+        from src.jcodemunch_mcp.config import _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"max_folder_files": }')  # Invalid JSON
+
+            monkeypatch.setenv("CODE_INDEX_PATH", tmpdir)
+
+            from src.jcodemunch_mcp.server import _run_config
+            with pytest.raises(SystemExit) as exc_info:
+                _run_config(check=True)
+            assert exc_info.value.code == 1
+
+            captured = capsys.readouterr().out
+            # Should mention config.jsonc and parse error
+            assert "config" in captured.lower()
+            assert "parse" in captured.lower()
+
+    def test_run_config_check_reports_type_error(self, capsys, monkeypatch):
+        """Should report config type errors in --check output."""
+        from src.jcodemunch_mcp.config import _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"max_folder_files": "wrong_type"}')
+
+            monkeypatch.setenv("CODE_INDEX_PATH", tmpdir)
+
+            from src.jcodemunch_mcp.server import _run_config
+            with pytest.raises(SystemExit) as exc_info:
+                _run_config(check=True)
+            assert exc_info.value.code == 1
+
+            captured = capsys.readouterr().out
+            assert "max_folder_files" in captured.lower()
+            assert "type" in captured.lower()
+
+    def test_run_config_check_passes_for_valid_config(self, capsys, monkeypatch):
+        """Should pass checks when config is valid."""
+        from src.jcodemunch_mcp.config import _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"max_folder_files": 5000}')
+
+            monkeypatch.setenv("CODE_INDEX_PATH", tmpdir)
+
+            from src.jcodemunch_mcp.server import _run_config
+            _run_config(check=True)
+
+            captured = capsys.readouterr().out
+            # Should NOT mention config errors
+            assert "config error" not in captured.lower()
+            assert "parse error" not in captured.lower()
+
+
+class TestLoadConfigWiredIntoMain:
+    """Test that load_config() is called during server startup."""
+
+    @pytest.mark.asyncio
+    async def test_main_calls_load_config_for_serve_command(self, monkeypatch, tmp_path):
+        """main() should call load_config() when serving."""
+        from src.jcodemunch_mcp.config import _GLOBAL_CONFIG, DEFAULTS
+
+        _GLOBAL_CONFIG.clear()
+        _GLOBAL_CONFIG.update(DEFAULTS)
+
+        # Create a temp config with a distinctive value
+        config_path = tmp_path / "config.jsonc"
+        config_path.write_text('{"max_folder_files": 9999}')
+        monkeypatch.setenv("CODE_INDEX_PATH", str(tmp_path))
+
+        # Track whether load_config was called
+        call_count = 0
+
+        # Import fresh — need to get the original reference before patching
+        import src.jcodemunch_mcp.config as cfg_module
+        real_load = cfg_module.load_config
+
+        def tracked_load(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return real_load(*args, **kwargs)
+
+        cfg_module.load_config = tracked_load
+
+        # Patch sys.exit to prevent exit
+        monkeypatch.setattr("sys.exit", lambda code=0: None)
+
+        # Patch asyncio.run to avoid starting the actual server
+        async def fake_asyncio_run(coro):
+            # Just run the coroutine briefly, don't actually start the server
+            pass
+
+        monkeypatch.setattr("asyncio.run", fake_asyncio_run)
+
+        # Also patch the MCP server.run to prevent actual startup
+        import src.jcodemunch_mcp.server as server_module
+        async def fake_server_run(*args, **kwargs):
+            pass
+        monkeypatch.setattr(server_module.server, "run", fake_server_run)
+
+        from src.jcodemunch_mcp.server import main
+        main(["serve"])
+
+        assert call_count >= 1, "load_config should have been called during serve"
+
+    @pytest.mark.asyncio
+    async def test_config_loaded_before_list_tools(self, monkeypatch, tmp_path):
+        """After main() starts, config should be loaded and usable by list_tools."""
+        # Use the SAME module object that server.py imports
+        import src.jcodemunch_mcp.config as cfg_module
+        cfg_module._GLOBAL_CONFIG.clear()
+        cfg_module._GLOBAL_CONFIG.update({"max_folder_files": 2000})  # default
+
+        config_path = tmp_path / "config.jsonc"
+        config_path.write_text('{"max_folder_files": 7777}')
+        monkeypatch.setenv("CODE_INDEX_PATH", str(tmp_path))
+
+        monkeypatch.setattr("sys.exit", lambda code=0: None)
+
+        async def fake_asyncio_run(coro):
+            pass
+
+        monkeypatch.setattr("asyncio.run", fake_asyncio_run)
+
+        import src.jcodemunch_mcp.server as server_module
+        async def fake_server_run(*args, **kwargs):
+            pass
+        monkeypatch.setattr(server_module.server, "run", fake_server_run)
+
+        from src.jcodemunch_mcp.server import main
+        main(["serve"])
+
+        # After main() runs, config should reflect the file (not just defaults)
+        # cfg_module is the same object that server.py's config_module references
+        assert cfg_module.get("max_folder_files") == 7777

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 """Tests for JSONC config parsing."""
 
+import json
 import tempfile
 from pathlib import Path
 
@@ -15,13 +16,19 @@ class TestJSONCParser:
         """Should strip // comments to end of line."""
         text = '{"key": "value" // this is a comment\n}'
         result = _strip_jsonc(text)
+        # Space before // is preserved; valid JSON
         assert result == '{"key": "value" \n}'
+        import json
+        json.loads(result)  # Must be valid JSON
 
     def test_strips_line_comment_no_trailing_newline(self):
         """Should strip // comment at end of file."""
         text = '{"key": "value"} // comment'
         result = _strip_jsonc(text)
+        # Space before // is preserved
         assert result == '{"key": "value"} '
+        import json
+        json.loads(result)  # Must be valid JSON
 
     def test_strips_block_comments(self):
         """Should strip /* */ block comments."""
@@ -214,3 +221,35 @@ class TestConfigGetters:
             assert is_language_enabled("python") is True
             assert is_language_enabled("javascript") is True
             assert is_language_enabled("sql") is False
+
+
+class TestTemplateGeneration:
+    """Test config template generation."""
+
+    def test_generate_template_returns_valid_jsonc(self):
+        """Should generate valid JSONC template."""
+        from src.jcodemunch_mcp.config import generate_template
+
+        template = generate_template()
+
+        # Should be parseable after stripping comments
+        from src.jcodemunch_mcp.config import _strip_jsonc
+        stripped = _strip_jsonc(template)
+        parsed = json.loads(stripped)
+
+        assert "languages" in parsed
+        assert "disabled_tools" in parsed
+        assert "meta_fields" in parsed
+
+    def test_template_languages_synced_from_registry(self):
+        """Should include all languages from LANGUAGE_REGISTRY."""
+        from src.jcodemunch_mcp.config import generate_template
+        from src.jcodemunch_mcp.parser.languages import LANGUAGE_REGISTRY
+
+        template = generate_template()
+        stripped = _strip_jsonc(template)
+        parsed = json.loads(stripped)
+
+        # All registry languages should be in template
+        for lang in LANGUAGE_REGISTRY.keys():
+            assert lang in parsed["languages"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -128,3 +128,39 @@ class TestConfigLoading:
 
             # Should use default
             assert get("max_folder_files") == 2000
+
+
+class TestProjectConfig:
+    """Test project-level config loading."""
+
+    def test_project_config_merges_over_global(self):
+        """Should merge project config over global config."""
+        from src.jcodemunch_mcp.config import (
+            load_config, load_project_config, get,
+            _GLOBAL_CONFIG, _PROJECT_CONFIGS
+        )
+
+        _GLOBAL_CONFIG.clear()
+        _PROJECT_CONFIGS.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Set up global config
+            global_config = Path(tmpdir) / "global" / "config.jsonc"
+            global_config.parent.mkdir()
+            global_config.write_text('{"max_folder_files": 2000, "use_ai_summaries": true}')
+
+            load_config(str(global_config.parent))
+
+            # Set up project config
+            project_root = Path(tmpdir) / "project"
+            project_root.mkdir()
+            project_config = project_root / ".jcodemunch.jsonc"
+            project_config.write_text('{"max_folder_files": 5000}')
+
+            load_project_config(str(project_root))
+
+            # Project value should override
+            repo_key = str(project_root.resolve())
+            assert get("max_folder_files", repo=repo_key) == 5000
+            # Non-overridden values should come from global
+            assert get("use_ai_summaries", repo=repo_key) is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,3 +19,26 @@ class TestJSONCParser:
         text = '{"key": "value"} // comment'
         result = _strip_jsonc(text)
         assert result == '{"key": "value"} '
+
+    def test_strips_block_comments(self):
+        """Should strip /* */ block comments."""
+        text = '{"key" /* comment */: "value"}'
+        result = _strip_jsonc(text)
+        assert result == '{"key" : "value"}'
+
+    def test_strips_multiline_block_comments(self):
+        """Should strip multiline /* */ comments."""
+        text = '''{
+    "key": "value" /* this is
+    a multiline
+    comment */
+}'''
+        result = _strip_jsonc(text)
+        assert '"key"' in result
+        assert 'this is' not in result
+
+    def test_preserves_strings_with_comment_chars(self):
+        """Should not strip // or /* inside quoted strings."""
+        text = '{"url": "http://example.com", "note": "use /* here*/"}'
+        result = _strip_jsonc(text)
+        assert result == text  # Should be unchanged

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,8 @@
 """Tests for JSONC config parsing."""
 
+import tempfile
+from pathlib import Path
+
 import pytest
 
 from src.jcodemunch_mcp.config import _strip_jsonc
@@ -66,3 +69,24 @@ class TestConfigDefaults:
         """Should default to empty list (all tools enabled)."""
         from src.jcodemunch_mcp.config import DEFAULTS
         assert DEFAULTS["disabled_tools"] == []
+
+
+class TestConfigLoading:
+    """Test config file loading."""
+
+    def test_missing_file_uses_defaults(self, monkeypatch):
+        """Should use defaults when config file doesn't exist."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        # Clear any existing config
+        _GLOBAL_CONFIG.clear()
+
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            non_existent = Path(tmpdir) / "nonexistent" / "config.jsonc"
+            monkeypatch.setenv("CODE_INDEX_PATH", str(Path(tmpdir) / "nonexistent"))
+
+            load_config(str(Path(tmpdir) / "nonexistent"))
+
+            assert get("max_folder_files") == 2000
+            assert get("use_ai_summaries") is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,3 +90,21 @@ class TestConfigLoading:
 
             assert get("max_folder_files") == 2000
             assert get("use_ai_summaries") is True
+
+    def test_loads_valid_config(self, monkeypatch):
+        """Should load valid JSONC config."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('''{
+                "max_folder_files": 5000,
+                "use_ai_summaries": false
+            }''')
+
+            load_config(tmpdir)
+
+            assert get("max_folder_files") == 5000
+            assert get("use_ai_summaries") is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -108,3 +108,23 @@ class TestConfigLoading:
 
             assert get("max_folder_files") == 5000
             assert get("use_ai_summaries") is False
+
+    def test_type_mismatch_logs_warning_and_uses_default(self, monkeypatch, caplog):
+        """Should log warning and use default on type mismatch."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+        import logging
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{ "max_folder_files": "2000" }')  # String instead of int
+
+            with caplog.at_level(logging.WARNING):
+                load_config(tmpdir)
+
+            # Should have logged a warning
+            assert "invalid type" in caplog.text.lower()
+
+            # Should use default
+            assert get("max_folder_files") == 2000

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -882,9 +882,9 @@ def test_parse_env_value_list_comma_separated_fallback():
     result = _parse_env_value('["*.log", "*.tmp"]', list)
     assert result == ["*.log", "*.tmp"]
 
-    # Empty string should return None (no tokens)
+    # Empty string should return [] (allows clearing list via env var)
     result = _parse_env_value("", list)
-    assert result is None
+    assert result == []
 
     # Whitespace-only tokens should be stripped
     result = _parse_env_value("*.log,  ,*.tmp", list)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,3 +42,27 @@ class TestJSONCParser:
         text = '{"url": "http://example.com", "note": "use /* here*/"}'
         result = _strip_jsonc(text)
         assert result == text  # Should be unchanged
+
+
+class TestConfigDefaults:
+    """Test default config values."""
+
+    def test_default_max_folder_files(self):
+        """Should default to 2000 max folder files."""
+        from src.jcodemunch_mcp.config import DEFAULTS
+        assert DEFAULTS["max_folder_files"] == 2000
+
+    def test_default_max_index_files(self):
+        """Should default to 10000 max index files."""
+        from src.jcodemunch_mcp.config import DEFAULTS
+        assert DEFAULTS["max_index_files"] == 10000
+
+    def test_default_languages_is_none(self):
+        """Should default to None (all languages enabled)."""
+        from src.jcodemunch_mcp.config import DEFAULTS
+        assert DEFAULTS["languages"] is None
+
+    def test_default_disabled_tools_is_empty(self):
+        """Should default to empty list (all tools enabled)."""
+        from src.jcodemunch_mcp.config import DEFAULTS
+        assert DEFAULTS["disabled_tools"] == []

--- a/tests/test_extra_extensions.py
+++ b/tests/test_extra_extensions.py
@@ -1,110 +1,115 @@
-"""Tests for JCODEMUNCH_EXTRA_EXTENSIONS env var handling."""
+"""Tests for extra_extensions config handling."""
 
 import pytest
 from jcodemunch_mcp.parser.languages import (
     LANGUAGE_EXTENSIONS,
     _apply_extra_extensions,
 )
+from jcodemunch_mcp import config as config_module
 
 
 @pytest.fixture(autouse=True)
 def restore_extensions():
-    """Restore LANGUAGE_EXTENSIONS to its original state after each test."""
-    original = dict(LANGUAGE_EXTENSIONS)
+    """Restore LANGUAGE_EXTENSIONS and config to their original state after each test."""
+    import jcodemunch_mcp.parser.languages as lang_module
+    original_ext = dict(LANGUAGE_EXTENSIONS)
+    original_config = config_module._GLOBAL_CONFIG.copy()
     yield
     LANGUAGE_EXTENSIONS.clear()
-    LANGUAGE_EXTENSIONS.update(original)
+    LANGUAGE_EXTENSIONS.update(original_ext)
+    config_module._GLOBAL_CONFIG.clear()
+    config_module._GLOBAL_CONFIG.update(original_config)
+    lang_module._APPLIED_EXTENSIONS = False
 
 
-def test_valid_extra_extensions(monkeypatch):
-    """Valid .ext:lang pairs are merged into LANGUAGE_EXTENSIONS."""
-    monkeypatch.setenv("JCODEMUNCH_EXTRA_EXTENSIONS", ".cgi:perl,.psgi:perl")
+def _apply_with_config(extensions: dict):
+    """Set extra_extensions in config and run _apply_extra_extensions."""
+    config_module._GLOBAL_CONFIG["extra_extensions"] = extensions
     _apply_extra_extensions()
+
+
+def test_valid_extra_extensions():
+    """Valid .ext:lang pairs are merged into LANGUAGE_EXTENSIONS."""
+    _apply_with_config({".cgi": "perl", ".psgi": "perl"})
     assert LANGUAGE_EXTENSIONS[".cgi"] == "perl"
     assert LANGUAGE_EXTENSIONS[".psgi"] == "perl"
 
 
-def test_unknown_language_skipped(monkeypatch, caplog):
+def test_unknown_language_skipped(caplog):
     """Unknown language values are skipped with a WARNING log."""
     import logging
-    monkeypatch.setenv("JCODEMUNCH_EXTRA_EXTENSIONS", ".xyz:cobol")
     with caplog.at_level(logging.WARNING):
-        _apply_extra_extensions()
+        _apply_with_config({".xyz": "cobol"})
     assert ".xyz" not in LANGUAGE_EXTENSIONS
     assert any("cobol" in r.message or "cobol" in str(r.args) for r in caplog.records)
 
 
-def test_malformed_entry_no_colon(monkeypatch, caplog):
-    """Entry with no colon separator is skipped with a WARNING log."""
+def test_malformed_entry_no_colon(caplog):
+    """Entry with no colon separator is skipped (handled at startup via _parse_env_value)."""
     import logging
-    monkeypatch.setenv("JCODEMUNCH_EXTRA_EXTENSIONS", ".cgiperls")
+    # The comma-separated parsing is done at startup in config.py
+    # An entry without colon would produce empty result
     with caplog.at_level(logging.WARNING):
-        _apply_extra_extensions()
+        _apply_with_config({".cgiperls": ""})
     assert ".cgiperls" not in LANGUAGE_EXTENSIONS
     assert len(caplog.records) >= 1
 
 
-def test_malformed_entry_empty_ext(monkeypatch, caplog):
+def test_malformed_entry_empty_ext(caplog):
     """Entry with empty extension is skipped with a WARNING log."""
     import logging
-    monkeypatch.setenv("JCODEMUNCH_EXTRA_EXTENSIONS", ":perl")
     with caplog.at_level(logging.WARNING):
-        _apply_extra_extensions()
+        _apply_with_config({"": "perl"})
     assert "" not in LANGUAGE_EXTENSIONS
     assert len(caplog.records) >= 1
 
 
-def test_malformed_entry_empty_lang(monkeypatch, caplog):
+def test_malformed_entry_empty_lang(caplog):
     """Entry with empty language is skipped with a WARNING log."""
     import logging
-    monkeypatch.setenv("JCODEMUNCH_EXTRA_EXTENSIONS", ".cgi:")
     with caplog.at_level(logging.WARNING):
-        _apply_extra_extensions()
+        _apply_with_config({".cgi": ""})
     assert ".cgi" not in LANGUAGE_EXTENSIONS
     assert len(caplog.records) >= 1
 
 
-def test_empty_env_var(monkeypatch):
-    """Absent or empty env var leaves LANGUAGE_EXTENSIONS unchanged."""
-    monkeypatch.delenv("JCODEMUNCH_EXTRA_EXTENSIONS", raising=False)
+def test_empty_extra_extensions():
+    """Absent or empty extra_extensions leaves LANGUAGE_EXTENSIONS unchanged."""
     before = dict(LANGUAGE_EXTENSIONS)
+    config_module._GLOBAL_CONFIG["extra_extensions"] = {}
     _apply_extra_extensions()
     assert LANGUAGE_EXTENSIONS == before
 
 
-def test_whitespace_only_env_var(monkeypatch):
-    """Whitespace-only env var leaves LANGUAGE_EXTENSIONS unchanged."""
-    monkeypatch.setenv("JCODEMUNCH_EXTRA_EXTENSIONS", "   ")
+def test_whitespace_only_extra_extensions():
+    """Whitespace-only values in extra_extensions are handled gracefully."""
     before = dict(LANGUAGE_EXTENSIONS)
+    # Empty dict equivalent
+    config_module._GLOBAL_CONFIG["extra_extensions"] = {}
     _apply_extra_extensions()
     assert LANGUAGE_EXTENSIONS == before
 
 
-def test_override_builtin_extension(monkeypatch):
+def test_override_builtin_extension():
     """A valid entry can override an existing built-in extension mapping."""
-    monkeypatch.setenv("JCODEMUNCH_EXTRA_EXTENSIONS", ".pl:python")
-    _apply_extra_extensions()
+    _apply_with_config({".pl": "python"})
     assert LANGUAGE_EXTENSIONS[".pl"] == "python"
 
 
-def test_mixed_valid_and_invalid(monkeypatch, caplog):
+def test_mixed_valid_and_invalid(caplog):
     """Valid entries are applied even when mixed with invalid ones."""
     import logging
-    monkeypatch.setenv(
-        "JCODEMUNCH_EXTRA_EXTENSIONS",
-        ".cgi:perl,.xyz:cobol,.psgi:perl,badentry"
-    )
     with caplog.at_level(logging.WARNING):
-        _apply_extra_extensions()
+        _apply_with_config({".cgi": "perl", ".xyz": "cobol", ".psgi": "perl"})
     assert LANGUAGE_EXTENSIONS[".cgi"] == "perl"
     assert LANGUAGE_EXTENSIONS[".psgi"] == "perl"
     assert ".xyz" not in LANGUAGE_EXTENSIONS
-    assert len(caplog.records) >= 2
+    assert len(caplog.records) >= 1
 
 
-def test_extra_whitespace_in_entries(monkeypatch):
-    """Leading/trailing whitespace in tokens is stripped."""
-    monkeypatch.setenv("JCODEMUNCH_EXTRA_EXTENSIONS", " .cgi : perl , .psgi : perl ")
-    _apply_extra_extensions()
+def test_extra_whitespace_in_entries():
+    """Leading/trailing whitespace in tokens is stripped (handled at startup parsing)."""
+    # Whitespace is stripped during startup _parse_env_value comma-separated parsing
+    # _apply_extra_extensions receives a clean dict
+    _apply_with_config({".cgi": "perl", ".psgi": "perl"})
     assert LANGUAGE_EXTENSIONS[".cgi"] == "perl"
-    assert LANGUAGE_EXTENSIONS[".psgi"] == "perl"

--- a/tests/test_extra_extensions.py
+++ b/tests/test_extra_extensions.py
@@ -14,6 +14,7 @@ def restore_extensions():
     import jcodemunch_mcp.parser.languages as lang_module
     original_ext = dict(LANGUAGE_EXTENSIONS)
     original_config = config_module._GLOBAL_CONFIG.copy()
+    lang_module._APPLIED_EXTENSIONS = False
     yield
     LANGUAGE_EXTENSIONS.clear()
     LANGUAGE_EXTENSIONS.update(original_ext)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -260,13 +260,31 @@ class TestMaxIndexFilesConfig:
         with patch.dict(os.environ, {}, clear=True):
             assert get_max_index_files() == DEFAULT_MAX_INDEX_FILES
 
-    def test_reads_env_override(self):
-        with patch.dict(os.environ, {MAX_INDEX_FILES_ENV_VAR: "1234"}, clear=True):
-            assert get_max_index_files() == 1234
+    def test_reads_config_override(self):
+        from jcodemunch_mcp import config as config_module
 
-    def test_invalid_env_falls_back_to_default(self):
-        with patch.dict(os.environ, {MAX_INDEX_FILES_ENV_VAR: "invalid"}, clear=True):
+        orig_config = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
+
+        try:
+            config_module._GLOBAL_CONFIG["max_index_files"] = 1234
+            assert get_max_index_files() == 1234
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(orig_config)
+
+    def test_invalid_config_falls_back_to_default(self):
+        from jcodemunch_mcp import config as config_module
+
+        orig_config = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
+
+        try:
+            config_module._GLOBAL_CONFIG["max_index_files"] = "invalid"
             assert get_max_index_files() == DEFAULT_MAX_INDEX_FILES
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(orig_config)
 
     def test_non_positive_explicit_value_is_rejected(self):
         with pytest.raises(ValueError, match="positive integer"):
@@ -278,23 +296,42 @@ class TestMaxFolderFilesConfig:
         assert DEFAULT_MAX_FOLDER_FILES < DEFAULT_MAX_INDEX_FILES
 
     def test_defaults_when_env_is_unset(self):
-        with patch.dict(os.environ, {}, clear=True):
+        from jcodemunch_mcp import config as config_module
+
+        orig_config = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
+
+        try:
             assert get_max_folder_files() == DEFAULT_MAX_FOLDER_FILES
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(orig_config)
 
-    def test_folder_specific_env_var_takes_priority(self):
-        env = {MAX_FOLDER_FILES_ENV_VAR: "500", MAX_INDEX_FILES_ENV_VAR: "9999"}
-        with patch.dict(os.environ, env, clear=True):
+    def test_folder_config_takes_priority(self):
+        from jcodemunch_mcp import config as config_module
+
+        orig_config = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
+
+        try:
+            config_module._GLOBAL_CONFIG["max_folder_files"] = 500
             assert get_max_folder_files() == 500
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(orig_config)
 
-    def test_falls_back_to_legacy_env_var(self):
-        env = {MAX_INDEX_FILES_ENV_VAR: "1234"}
-        with patch.dict(os.environ, env, clear=True):
-            assert get_max_folder_files() == 1234
+    def test_invalid_folder_config_falls_back_to_default(self):
+        from jcodemunch_mcp import config as config_module
 
-    def test_invalid_folder_env_falls_back_to_legacy(self):
-        env = {MAX_FOLDER_FILES_ENV_VAR: "bad", MAX_INDEX_FILES_ENV_VAR: "999"}
-        with patch.dict(os.environ, env, clear=True):
-            assert get_max_folder_files() == 999
+        orig_config = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
+
+        try:
+            config_module._GLOBAL_CONFIG["max_folder_files"] = -1
+            assert get_max_folder_files() == DEFAULT_MAX_FOLDER_FILES
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(orig_config)
 
     def test_both_invalid_returns_default(self):
         env = {MAX_FOLDER_FILES_ENV_VAR: "bad", MAX_INDEX_FILES_ENV_VAR: "also_bad"}
@@ -309,58 +346,77 @@ class TestMaxFolderFilesConfig:
             get_max_folder_files(0)
 
 
-# --- Extra Ignore Patterns (JCODEMUNCH_EXTRA_IGNORE_PATTERNS) ---
+# --- Extra Ignore Patterns (extra_ignore_patterns config) ---
 
 class TestGetExtraIgnorePatterns:
-    def test_no_env_no_call_returns_empty(self):
-        with patch.dict(os.environ, {}, clear=True):
+    def test_no_config_no_call_returns_empty(self):
+        from jcodemunch_mcp import config as config_module
+
+        orig_config = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
+
+        try:
             assert get_extra_ignore_patterns() == []
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(orig_config)
 
     def test_call_patterns_only(self):
-        with patch.dict(os.environ, {}, clear=True):
+        from jcodemunch_mcp import config as config_module
+
+        orig_config = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
+
+        try:
             result = get_extra_ignore_patterns(["*.log", "tmp/"])
             assert result == ["*.log", "tmp/"]
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(orig_config)
 
-    def test_env_comma_separated(self):
-        env = {EXTRA_IGNORE_PATTERNS_ENV_VAR: "**/scrapes/**, **/images/**"}
-        with patch.dict(os.environ, env, clear=True):
+    def test_config_patterns(self):
+        from jcodemunch_mcp import config as config_module
+
+        orig_config = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
+
+        try:
+            config_module._GLOBAL_CONFIG["extra_ignore_patterns"] = ["**/scrapes/**", "*.png"]
             result = get_extra_ignore_patterns()
             assert "**/scrapes/**" in result
-            assert "**/images/**" in result
+            assert "*.png" in result
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(orig_config)
 
-    def test_env_json_array(self):
-        import json
-        patterns = ["**/scrapes/**", "*.png"]
-        env = {EXTRA_IGNORE_PATTERNS_ENV_VAR: json.dumps(patterns)}
-        with patch.dict(os.environ, env, clear=True):
-            result = get_extra_ignore_patterns()
-            assert result == patterns
+    def test_config_and_call_are_merged(self):
+        from jcodemunch_mcp import config as config_module
 
-    def test_env_and_call_are_merged(self):
-        env = {EXTRA_IGNORE_PATTERNS_ENV_VAR: "global/"}
-        with patch.dict(os.environ, env, clear=True):
+        orig_config = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
+
+        try:
+            config_module._GLOBAL_CONFIG["extra_ignore_patterns"] = ["global/"]
             result = get_extra_ignore_patterns(["local/"])
             assert "global/" in result
             assert "local/" in result
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(orig_config)
 
-    def test_env_patterns_come_first(self):
-        env = {EXTRA_IGNORE_PATTERNS_ENV_VAR: "first/"}
-        with patch.dict(os.environ, env, clear=True):
-            result = get_extra_ignore_patterns(["second/"])
-            assert result.index("first/") < result.index("second/")
+    def test_empty_config_returns_call_only(self):
+        from jcodemunch_mcp import config as config_module
 
-    def test_empty_env_string_returns_call_only(self):
-        env = {EXTRA_IGNORE_PATTERNS_ENV_VAR: ""}
-        with patch.dict(os.environ, env, clear=True):
+        orig_config = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
+
+        try:
+            config_module._GLOBAL_CONFIG["extra_ignore_patterns"] = []
             result = get_extra_ignore_patterns(["only/"])
             assert result == ["only/"]
-
-    def test_invalid_json_falls_back_to_comma_split(self):
-        env = {EXTRA_IGNORE_PATTERNS_ENV_VAR: "a/, b/"}
-        with patch.dict(os.environ, env, clear=True):
-            result = get_extra_ignore_patterns()
-            assert "a/" in result
-            assert "b/" in result
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(orig_config)
 
 
 # --- Integration: discover_local_files with security ---
@@ -419,17 +475,24 @@ class TestDiscoverLocalFilesSecure:
         assert "main.py" in names
         assert "temp.py" not in names
 
-    def test_respects_env_file_limit(self, tmp_path):
-        """Environment override controls local folder file discovery limit."""
+    def test_respects_config_file_limit(self, tmp_path):
+        """Config controls local folder file discovery limit."""
         from jcodemunch_mcp.tools.index_folder import discover_local_files
+        from jcodemunch_mcp import config as config_module
 
         for i in range(10):
             (tmp_path / f"file{i}.py").write_text(f"x = {i}\n")
 
-        with patch.dict(os.environ, {MAX_FOLDER_FILES_ENV_VAR: "3", MAX_INDEX_FILES_ENV_VAR: "3"}, clear=False):
-            files, *_ = discover_local_files(tmp_path)
+        orig_config = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
 
-        assert len(files) == 3
+        try:
+            config_module._GLOBAL_CONFIG["max_folder_files"] = 3
+            files, *_ = discover_local_files(tmp_path)
+            assert len(files) == 3
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(orig_config)
 
     def test_exact_env_file_limit_does_not_report_truncation(self, tmp_path):
         """Exact file-count matches should not be treated as truncation."""
@@ -530,3 +593,76 @@ class TestIndexStoreEncodingSafety:
         result = store.get_symbol_content("test", "repo", "test-py::foo")
         assert result is not None
         assert "def foo():" in result
+
+
+class TestSecurityConfigIntegration:
+    """Test security module uses config.get() instead of env vars."""
+
+    def test_get_max_index_files_uses_config(self, monkeypatch):
+        """get_max_index_files should read from config, not env vars."""
+        from jcodemunch_mcp import config as config_module
+
+        orig_config = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
+
+        try:
+            config_module._GLOBAL_CONFIG["max_index_files"] = 15000
+
+            # Env var should be ignored
+            monkeypatch.setenv("JCODEMUNCH_MAX_INDEX_FILES", "5000")
+
+            result = get_max_index_files()
+            assert result == 15000
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(orig_config)
+
+    def test_get_max_folder_files_uses_config(self, monkeypatch):
+        """get_max_folder_files should read from config, not env vars."""
+        from jcodemunch_mcp import config as config_module
+
+        orig_config = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
+
+        try:
+            config_module._GLOBAL_CONFIG["max_folder_files"] = 3000
+
+            # Env vars should be ignored
+            monkeypatch.delenv("JCODEMUNCH_MAX_FOLDER_FILES", raising=False)
+            monkeypatch.delenv("JCODEMUNCH_MAX_INDEX_FILES", raising=False)
+
+            result = get_max_folder_files()
+            assert result == 3000
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(orig_config)
+
+    def test_get_extra_ignore_patterns_uses_config(self, monkeypatch):
+        """get_extra_ignore_patterns should read from config, not env vars."""
+        from jcodemunch_mcp import config as config_module
+
+        orig_config = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
+
+        try:
+            config_module._GLOBAL_CONFIG["extra_ignore_patterns"] = ["*.test", "build/"]
+
+            # Env var should be ignored
+            monkeypatch.delenv("JCODEMUNCH_EXTRA_IGNORE_PATTERNS", raising=False)
+
+            result = get_extra_ignore_patterns()
+            assert "*.test" in result
+            assert "build/" in result
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(orig_config)
+
+    def test_get_max_index_files_param_override(self):
+        """Per-call max_files param should still work."""
+        result = get_max_index_files(max_files=5000)
+        assert result == 5000
+
+    def test_get_max_folder_files_param_override(self):
+        """Per-call max_files param should still work."""
+        result = get_max_folder_files(max_files=1000)
+        assert result == 1000

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -384,12 +384,22 @@ async def test_call_tool_uses_our_schema_cache_not_sdk():
 
 
 @pytest.mark.asyncio
-async def test_suppress_meta_removes_meta_envelope():
-    """suppress_meta=True strips the _meta key from the response."""
-    with patch("jcodemunch_mcp.server.list_repos", return_value={"repos": []}):
-        result = await call_tool("list_repos", {"suppress_meta": True})
-    payload = json.loads(result[0].text)
-    assert "_meta" not in payload
+async def test_meta_fields_empty_removes_meta_envelope():
+    """meta_fields=[] strips the _meta key from the response."""
+    from jcodemunch_mcp import config as config_module
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["meta_fields"] = []
+        with patch("jcodemunch_mcp.server.list_repos", return_value={"repos": []}):
+            result = await call_tool("list_repos", {})
+        payload = json.loads(result[0].text)
+        assert "_meta" not in payload
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
 
 
 @pytest.mark.asyncio
@@ -491,19 +501,28 @@ async def test_disabled_tools_empty_all_tools_present(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_suppress_meta_false_keeps_meta_envelope():
-    """suppress_meta=False (or absent) keeps the _meta envelope."""
-    with patch("jcodemunch_mcp.server.list_repos", return_value={"repos": []}):
-        result = await call_tool("list_repos", {})
-    payload = json.loads(result[0].text)
-    assert "_meta" in payload
+async def test_meta_fields_null_keeps_meta_envelope():
+    """meta_fields=null keeps the _meta envelope."""
+    from jcodemunch_mcp import config as config_module
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["meta_fields"] = None
+        with patch("jcodemunch_mcp.server.list_repos", return_value={"repos": []}):
+            result = await call_tool("list_repos", {})
+        payload = json.loads(result[0].text)
+        assert "_meta" in payload
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
 
 
 @pytest.mark.asyncio
-async def test_list_tools_all_have_suppress_meta():
-    """Every tool schema exposes suppress_meta as an optional boolean property."""
+async def test_list_tools_no_suppress_meta_param():
+    """No tool schema exposes suppress_meta (replaced by meta_fields config)."""
     tools = await list_tools()
     for tool in tools:
         props = (tool.inputSchema or {}).get("properties", {})
-        assert "suppress_meta" in props, f"{tool.name} missing suppress_meta"
-        assert props["suppress_meta"]["type"] == "boolean"
+        assert "suppress_meta" not in props, f"{tool.name} should not have suppress_meta"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -519,6 +519,49 @@ async def test_no_descriptions_config_keeps_original(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_sql_removed_auto_disables_search_columns(monkeypatch):
+    """search_columns should be auto-disabled when SQL not in languages."""
+    from jcodemunch_mcp import config as config_module
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["languages"] = ["python", "javascript"]
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []  # Explicitly empty
+
+        tools = await list_tools()
+        tool_names = [t.name for t in tools]
+
+        # search_columns should be auto-disabled
+        assert "search_columns" not in tool_names
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+@pytest.mark.asyncio
+async def test_sql_enabled_keeps_search_columns(monkeypatch):
+    """search_columns should stay enabled when SQL is in languages."""
+    from jcodemunch_mcp import config as config_module
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["languages"] = ["python", "sql"]
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+
+        tools = await list_tools()
+        tool_names = [t.name for t in tools]
+
+        assert "search_columns" in tool_names
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+@pytest.mark.asyncio
 async def test_language_enum_reflects_config_limited(monkeypatch):
     """Language enum should only include configured languages."""
     from jcodemunch_mcp import config as config_module

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -393,7 +393,62 @@ async def test_suppress_meta_removes_meta_envelope():
 
 
 @pytest.mark.asyncio
-async def test_disabled_tools_removed_from_list_tools(monkeypatch):
+async def test_language_enum_reflects_config_limited(monkeypatch):
+    """Language enum should only include configured languages."""
+    from jcodemunch_mcp import config as config_module
+    from jcodemunch_mcp.parser.languages import LANGUAGE_REGISTRY
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["languages"] = ["python", "javascript"]
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+
+        tools = await list_tools()
+        search_symbols_tool = next((t for t in tools if t.name == "search_symbols"), None)
+        assert search_symbols_tool is not None
+
+        lang_param = search_symbols_tool.inputSchema.get("properties", {}).get("language", {})
+        enum_values = lang_param.get("enum", [])
+
+        assert "python" in enum_values
+        assert "javascript" in enum_values
+        assert "sql" not in enum_values
+        assert "rust" not in enum_values
+        # Should match exactly the configured languages
+        assert set(enum_values) == {"python", "javascript"}
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+@pytest.mark.asyncio
+async def test_language_enum_all_languages_when_config_none(monkeypatch):
+    """When languages config is None, enum includes all registry languages."""
+    from jcodemunch_mcp import config as config_module
+    from jcodemunch_mcp.parser.languages import LANGUAGE_REGISTRY
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["languages"] = None
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+
+        tools = await list_tools()
+        search_symbols_tool = next((t for t in tools if t.name == "search_symbols"), None)
+        lang_param = search_symbols_tool.inputSchema.get("properties", {}).get("language", {})
+        enum_values = lang_param.get("enum", [])
+
+        for lang in LANGUAGE_REGISTRY.keys():
+            assert lang in enum_values, f"{lang} missing from enum"
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+
     """Should remove disabled tools from list_tools output."""
     from jcodemunch_mcp import config as config_module
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -617,7 +617,8 @@ async def test_language_enum_all_languages_when_config_none(monkeypatch):
         config_module._GLOBAL_CONFIG.update(orig_config)
 
 
-
+@pytest.mark.asyncio
+async def test_disabled_tools_filtered_from_schema(monkeypatch):
     """Should remove disabled tools from list_tools output."""
     from jcodemunch_mcp import config as config_module
 
@@ -679,9 +680,221 @@ async def test_meta_fields_null_keeps_meta_envelope():
 
 
 @pytest.mark.asyncio
+async def test_meta_fields_empty_list_removes_meta():
+    """meta_fields=[] removes _meta entirely (maximum token savings)."""
+    from jcodemunch_mcp import config as config_module
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["meta_fields"] = []
+        with patch("jcodemunch_mcp.server.list_repos", return_value={"repos": [], "_meta": {"timing_ms": 5.0}}):
+            result = await call_tool("list_repos", {})
+        payload = json.loads(result[0].text)
+        assert "_meta" not in payload
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+@pytest.mark.asyncio
 async def test_list_tools_no_suppress_meta_param():
     """No tool schema exposes suppress_meta (replaced by meta_fields config)."""
     tools = await list_tools()
     for tool in tools:
         props = (tool.inputSchema or {}).get("properties", {})
         assert "suppress_meta" not in props, f"{tool.name} should not have suppress_meta"
+
+
+@pytest.mark.asyncio
+async def test_sql_language_gating_removes_search_columns(monkeypatch):
+    """Removing 'sql' from languages auto-disables search_columns tool."""
+    from jcodemunch_mcp import config as config_module
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        # Enable only python and javascript — sql is NOT in the list
+        config_module._GLOBAL_CONFIG["languages"] = ["python", "javascript"]
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+
+        tools = await list_tools()
+        tool_names = [t.name for t in tools]
+
+        # search_columns must be absent when sql is not in languages
+        assert "search_columns" not in tool_names
+        # Other tools should remain
+        assert "search_symbols" in tool_names
+        assert "get_file_tree" in tool_names
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+@pytest.mark.asyncio
+async def test_sql_in_languages_keeps_search_columns(monkeypatch):
+    """When sql IS in languages, search_columns remains in the schema."""
+    from jcodemunch_mcp import config as config_module
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["languages"] = ["python", "sql"]
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+
+        tools = await list_tools()
+        tool_names = [t.name for t in tools]
+
+        # search_columns must be present when sql is in languages
+        assert "search_columns" in tool_names
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+# ── Description Override Empty String Tests (B1, B2) ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_descriptions_empty_string_tool_clears_description():
+    """Empty string _tool clears the tool description (B1)."""
+    from jcodemunch_mcp import config as config_module
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        # Set _tool to empty string — should clear the description
+        config_module._GLOBAL_CONFIG["descriptions"] = {
+            "search_symbols": {"_tool": ""},
+        }
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+
+        tools = await list_tools()
+        search_symbols = next((t for t in tools if t.name == "search_symbols"), None)
+        assert search_symbols is not None
+        # Empty string means "use hardcoded minimal base only"
+        assert search_symbols.description == ""
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+@pytest.mark.asyncio
+async def test_descriptions_empty_string_param_clears_description():
+    """Empty string param description clears the param description (B2)."""
+    from jcodemunch_mcp import config as config_module
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        # Set param to empty string via _shared — should clear repo param description
+        config_module._GLOBAL_CONFIG["descriptions"] = {
+            "_shared": {"repo": ""},
+        }
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+
+        tools = await list_tools()
+        search_symbols = next((t for t in tools if t.name == "search_symbols"), None)
+        assert search_symbols is not None
+
+        # repo param description should be cleared to empty string
+        repo_param = search_symbols.inputSchema.get("properties", {}).get("repo", {})
+        assert repo_param.get("description") == ""
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+# ── Meta Fields Partial List Test (E1) ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_meta_fields_partial_list_preserves_tool_fields():
+    """Partial meta_fields list preserves tool-generated fields like timing_ms (E1)."""
+    import jcodemunch_mcp.server as server_module
+    from jcodemunch_mcp import config as config_module
+    import functools
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    orig_list_repos = server_module.list_repos
+
+    def fake_list_repos(storage_path=None):
+        return {"repos": [], "_meta": {
+            "timing_ms": 12.5,
+            "tokens_saved": 1000,
+            "candidates_scored": 50,
+        }}
+
+    try:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG["meta_fields"] = ["timing_ms"]
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+
+        # Patch at the functools.partial level by replacing the module-level name
+        # and clearing the _TOOL_SCHEMAS cache so schemas are rebuilt
+        server_module.list_repos = fake_list_repos
+        # Clear the tool schemas cache so call_tool picks up the patched function
+        server_module._TOOL_SCHEMAS = None
+
+        result = await call_tool("list_repos", {})
+
+        payload = json.loads(result[0].text)
+        assert "_meta" in payload
+        # timing_ms should be preserved
+        assert payload["_meta"]["timing_ms"] == 12.5
+        # tokens_saved should NOT be in _meta (not in partial list)
+        assert "tokens_saved" not in payload["_meta"]
+        # candidates_scored should NOT be in _meta (not in partial list)
+        assert "candidates_scored" not in payload["_meta"]
+    finally:
+        server_module.list_repos = orig_list_repos
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+# ── Project-Level Tool Disabling Test (M2) ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_project_tool_disabled_rejected_in_call_tool():
+    """Project-level disabled_tools rejects the tool at call_tool with an error (M2)."""
+    from jcodemunch_mcp import config as config_module
+
+    orig_global = config_module._GLOBAL_CONFIG.copy()
+    orig_project = config_module._PROJECT_CONFIGS.copy()
+    config_module._GLOBAL_CONFIG.clear()
+    config_module._PROJECT_CONFIGS.clear()
+
+    try:
+        # Global config: tool is NOT disabled (schema includes it)
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+        config_module._GLOBAL_CONFIG["meta_fields"] = None
+
+        # Project config: index_folder IS disabled
+        project_root = "/fake/project"
+        config_module._PROJECT_CONFIGS[project_root] = {
+            **config_module._GLOBAL_CONFIG,
+            "disabled_tools": ["index_folder"],
+        }
+
+        # Attempting to call index_folder for the project should be rejected
+        result = await call_tool("index_folder", {
+            "path": "/fake/project/src",
+            "repo": project_root,
+        })
+
+        payload = json.loads(result[0].text)
+        assert "error" in payload
+        assert "index_folder" in payload["error"]
+        assert "disabled" in payload["error"].lower()
+        assert "project" in payload["error"].lower()
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_global)
+        config_module._PROJECT_CONFIGS.clear()
+        config_module._PROJECT_CONFIGS.update(orig_project)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -811,6 +811,32 @@ async def test_descriptions_empty_string_param_clears_description():
         config_module._GLOBAL_CONFIG.update(orig_config)
 
 
+@pytest.mark.asyncio
+async def test_descriptions_flat_string_overrides_tool_description():
+    """Flat string format 'tool_name': 'description' overrides tool description."""
+    from jcodemunch_mcp import config as config_module
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["descriptions"] = {
+            "search_symbols": "Find symbols in this Python project",
+        }
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+
+        tools = await list_tools()
+        search_symbols = next(t for t in tools if t.name == "search_symbols")
+        assert search_symbols.description == "Find symbols in this Python project"
+
+        # Param descriptions should be unchanged (flat format doesn't touch params)
+        repo_param = search_symbols.inputSchema.get("properties", {}).get("repo", {})
+        assert repo_param.get("description")  # should still have original description
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
 # ── Meta Fields Partial List Test (E1) ─────────────────────────────────────────────
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -500,7 +500,8 @@ async def test_no_descriptions_config_keeps_original(monkeypatch):
         config_module._GLOBAL_CONFIG.update(orig_config)
 
 
-
+@pytest.mark.asyncio
+async def test_meta_fields_empty_list_removes_meta_envelope():
     """meta_fields=[] strips the _meta key from the response."""
     from jcodemunch_mcp import config as config_module
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -384,6 +384,67 @@ async def test_call_tool_uses_our_schema_cache_not_sdk():
 
 
 @pytest.mark.asyncio
+async def test_descriptions_shared_applied_to_all_tools(monkeypatch):
+    """_shared description should apply to all tools with that param."""
+    from jcodemunch_mcp import config as config_module
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["descriptions"] = {
+            "_shared": {
+                "repo": "Custom shared repo description"
+            }
+        }
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+
+        tools = await list_tools()
+
+        for tool_name in ["search_symbols", "get_file_tree", "get_symbol"]:
+            tool = next((t for t in tools if t.name == tool_name), None)
+            if tool:
+                repo_param = tool.inputSchema.get("properties", {}).get("repo", {})
+                if repo_param:
+                    assert "Custom shared repo description" in repo_param.get("description", "")
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+@pytest.mark.asyncio
+async def test_descriptions_tool_specific_overrides_shared(monkeypatch):
+    """Tool-specific description should override _shared for that param."""
+    from jcodemunch_mcp import config as config_module
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["descriptions"] = {
+            "_shared": {"repo": "Shared description"},
+            "search_symbols": {"repo": "search_symbols specific desc"}
+        }
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+
+        tools = await list_tools()
+
+        search_tool = next((t for t in tools if t.name == "search_symbols"), None)
+        assert search_tool is not None
+        repo_param = search_tool.inputSchema.get("properties", {}).get("repo", {})
+        assert "search_symbols specific desc" in repo_param.get("description", "")
+
+        tree_tool = next((t for t in tools if t.name == "get_file_tree"), None)
+        assert tree_tool is not None
+        repo_param = tree_tool.inputSchema.get("properties", {}).get("repo", {})
+        assert "Shared description" in repo_param.get("description", "")
+        assert "search_symbols specific" not in repo_param.get("description", "")
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+@pytest.mark.asyncio
 async def test_descriptions_config_overrides_tool_descriptions(monkeypatch):
     """Config descriptions should override tool descriptions."""
     from jcodemunch_mcp import config as config_module

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -384,7 +384,62 @@ async def test_call_tool_uses_our_schema_cache_not_sdk():
 
 
 @pytest.mark.asyncio
-async def test_meta_fields_empty_removes_meta_envelope():
+async def test_descriptions_config_overrides_tool_descriptions(monkeypatch):
+    """Config descriptions should override tool descriptions."""
+    from jcodemunch_mcp import config as config_module
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["descriptions"] = {
+            "search_symbols": {
+                "_tool": "Custom search_symbols description",
+                "repo": "Custom repo description"
+            },
+            "_shared": {
+                "repo": "Shared custom repo desc"
+            }
+        }
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+
+        tools = await list_tools()
+        search_symbols = next((t for t in tools if t.name == "search_symbols"), None)
+        assert search_symbols is not None
+        assert search_symbols.description == "Custom search_symbols description"
+
+        # Param description should also be overridden
+        repo_param = search_symbols.inputSchema.get("properties", {}).get("repo", {})
+        assert repo_param.get("description") == "Custom repo description"
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+@pytest.mark.asyncio
+async def test_no_descriptions_config_keeps_original(monkeypatch):
+    """When descriptions config is absent, original tool descriptions are used."""
+    from jcodemunch_mcp import config as config_module
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["descriptions"] = {}
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+
+        tools = await list_tools()
+        search_symbols = next((t for t in tools if t.name == "search_symbols"), None)
+        assert search_symbols is not None
+
+        # Should keep original description (starts with "Search for")
+        assert search_symbols.description.startswith("Search for")
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+
     """meta_fields=[] strips the _meta key from the response."""
     from jcodemunch_mcp import config as config_module
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -393,6 +393,49 @@ async def test_suppress_meta_removes_meta_envelope():
 
 
 @pytest.mark.asyncio
+async def test_disabled_tools_removed_from_list_tools(monkeypatch):
+    """Should remove disabled tools from list_tools output."""
+    from jcodemunch_mcp import config as config_module
+
+    # Save and clear existing config
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["disabled_tools"] = ["index_repo", "search_columns"]
+
+        tools = await list_tools()
+        tool_names = [t.name for t in tools]
+
+        assert "index_repo" not in tool_names
+        assert "search_columns" not in tool_names
+        assert "get_file_tree" in tool_names  # Not disabled
+        # Total should be 24 (26 - 2 disabled)
+        assert len(tools) == 24
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+@pytest.mark.asyncio
+async def test_disabled_tools_empty_all_tools_present(monkeypatch):
+    """When disabled_tools is empty, all 26 tools are present."""
+    from jcodemunch_mcp import config as config_module
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+
+        tools = await list_tools()
+        assert len(tools) == 26
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+@pytest.mark.asyncio
 async def test_suppress_meta_false_keeps_meta_envelope():
     """suppress_meta=False (or absent) keeps the _meta envelope."""
     with patch("jcodemunch_mcp.server.list_repos", return_value={"repos": []}):

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -124,6 +124,9 @@ def test_anthropic_summarizer_base_url():
             "ANTHROPIC_BASE_URL": "https://proxy.example.com/v1",
             "JCODEMUNCH_ALLOW_REMOTE_SUMMARIZER": "1",
         }, clear=True):
+            # Set config value directly (module already imported)
+            from jcodemunch_mcp import config as _cfg_module
+            _cfg_module._GLOBAL_CONFIG["allow_remote_summarizer"] = True
             from jcodemunch_mcp.summarizer.batch_summarize import BatchSummarizer
             summarizer = BatchSummarizer()
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -85,32 +85,50 @@ def test_discover_source_files_prioritizes_src():
     assert truncated is True
 
 
-def test_discover_source_files_uses_env_override():
-    """Test that environment override is used when max_files is omitted."""
+def test_discover_source_files_uses_config_override():
+    """Test that config override is used when max_files is omitted."""
+    from jcodemunch_mcp import config as config_module
+
     tree_entries = [
         {"path": f"file{i}.py", "type": "blob", "size": 100}
         for i in range(20)
     ]
 
-    with patch.dict("os.environ", {MAX_INDEX_FILES_ENV_VAR: "7"}, clear=False):
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["max_index_files"] = 7
         files, _, truncated = discover_source_files(tree_entries)
 
-    assert len(files) == 7
-    assert truncated is True
+        assert len(files) == 7
+        assert truncated is True
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
 
 
-def test_discover_source_files_explicit_max_overrides_env():
-    """Explicit max_files should win over environment configuration."""
+def test_discover_source_files_explicit_max_overrides_config():
+    """Explicit max_files should win over config."""
+    from jcodemunch_mcp import config as config_module
+
     tree_entries = [
         {"path": f"file{i}.py", "type": "blob", "size": 100}
         for i in range(20)
     ]
 
-    with patch.dict("os.environ", {MAX_INDEX_FILES_ENV_VAR: "7"}, clear=False):
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+
+    try:
+        config_module._GLOBAL_CONFIG["max_index_files"] = 7
         files, _, truncated = discover_source_files(tree_entries, max_files=5)
 
-    assert len(files) == 5
-    assert truncated is True
+        assert len(files) == 5
+        assert truncated is True
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
 
 
 def test_discover_source_files_exact_limit_is_not_truncated():
@@ -231,17 +249,24 @@ class TestNestedGitignore:
 
 
 class TestFolderFileLimitEnvVar:
-    def test_folder_specific_env_var_respected(self, tmp_path):
-        """JCODEMUNCH_MAX_FOLDER_FILES should cap index_folder file discovery."""
+    def test_folder_config_respected(self, tmp_path):
+        """max_folder_files config should cap index_folder file discovery."""
         from jcodemunch_mcp.tools.index_folder import discover_local_files
+        from jcodemunch_mcp import config as config_module
 
         for i in range(10):
             (tmp_path / f"file{i}.py").write_text(f"def f{i}(): pass\n")
 
-        with patch.dict("os.environ", {MAX_FOLDER_FILES_ENV_VAR: "3"}, clear=False):
-            files, _, _ = discover_local_files(tmp_path)
+        orig_config = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
 
-        assert len(files) == 3
+        try:
+            config_module._GLOBAL_CONFIG["max_folder_files"] = 3
+            files, _, _ = discover_local_files(tmp_path)
+            assert len(files) == 3
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(orig_config)
 
     def test_legacy_env_var_still_works_for_folders(self, tmp_path):
         """JCODEMUNCH_MAX_INDEX_FILES should still cap index_folder when folder var unset."""
@@ -250,11 +275,16 @@ class TestFolderFileLimitEnvVar:
         for i in range(10):
             (tmp_path / f"file{i}.py").write_text(f"def f{i}(): pass\n")
 
-        env = {MAX_INDEX_FILES_ENV_VAR: "4"}
-        # Ensure the folder-specific var is absent so legacy fallback is tested
-        with patch.dict("os.environ", env, clear=False):
-            import os
-            os.environ.pop(MAX_FOLDER_FILES_ENV_VAR, None)
+        from jcodemunch_mcp import config as config_module
+
+        orig_config = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
+
+        try:
+            config_module._GLOBAL_CONFIG["max_folder_files"] = 4
             files, _, _ = discover_local_files(tmp_path)
 
-        assert len(files) == 4
+            assert len(files) == 4
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(orig_config)


### PR DESCRIPTION
## Why

jcodemunch-mcp has grown to **24+ environment variables**. This creates three problems:

1. **No per-project customization.** A Python-only monorepo still loads all 25+ language parsers, the dbt context provider, and the SQL preprocessor on every indexing run. There is no way to say "this project only uses Python."

2. **No tool-level control.** Every client gets every tool and every `_meta` field. The `suppress_meta` parameter was duplicated across all 27 tool schemas, adding **~594 tokens per `list_tools` call** just for a boolean that most clients never use.

3. **Env vars don't compose.** Setting `JCODEMUNCH_MAX_FOLDER_FILES` in a shell profile applies globally. If one project needs 5,000 files and another needs 500, you juggle env vars per terminal session.

## What

Fixes #161 
A centralized `.jsonc` config file that replaces scattered env vars with structured, per-project configuration:

```
~/.code-index/config.jsonc          # global defaults
<project-root>/.jcodemunch.jsonc    # per-project overrides (version-controlled)
```

### New capabilities (not possible with env vars alone)

| Feature | Config key | Effect |
|---------|-----------|--------|
| Language filtering | `languages` | Skip tree-sitter parsing for unconfigured languages |
| Tool disabling | `disabled_tools` | Remove tools from schema and block execution |
| Meta field control | `meta_fields` | `null` = all, `[]` = strip `_meta`, list = named fields only |
| Description overrides | `descriptions` | Flat string or nested dict format for tool + param descriptions |
| Per-project overrides | `.jcodemunch.jsonc` | Merges over global config, committed to repo |

### Schema changes

| Old (per-tool parameter) | New (config-level) | Tokens saved |
|--------------------------|-------------------|--------------|
| `suppress_meta: boolean` on every tool | `meta_fields` config key | **~594 tokens/turn** (removed from all 27 tool schemas) |

The legacy `suppress_meta` per-call parameter still works at runtime for backward compatibility — it is just no longer advertised in the schema.

### Config resolution order

```
1. Hardcoded defaults
2. Global config.jsonc       — overwrites defaults
3. Project .jcodemunch.jsonc — merges over global, per-repo
4. Environment variables     — FALLBACK only (fills gaps, doesn't override)
5. CLI flags                 — highest priority
```

Env vars act as fallback (not override) so a global `JCODEMUNCH_MAX_FOLDER_FILES=10000` in someone's shell profile cannot silently break a project's tuned `max_folder_files: 500`. Existing env vars emit a one-time deprecation warning.

### CLI

```bash
jcodemunch-mcp config          # print effective config with source tracking
jcodemunch-mcp config --init   # generate commented template
jcodemunch-mcp config --check  # validate config + prerequisites
```

## How

### New module: `config.py` (687 lines)

- JSONC parser: strips `//` and `/* */` comments, handles trailing commas, escaped quotes
- Type-validated loading with per-key warnings for invalid types
- Hash-based project config caching (avoids re-parsing on watcher reindex cycles)
- Thread-safe project config mutations via `threading.Lock`
- `_resolve_repo_key()` with positive + negative caching for O(1) repo lookups
- Env var fallback with `_explicit_keys` tracking (only fills absent keys)

### Server integration

- `list_tools()`: filters `disabled_tools`, narrows `search_symbols` language enum, applies description overrides, auto-disables `search_columns` when SQL not in languages
- `call_tool()`: project-level tool rejection via `is_tool_disabled(name, repo=repo_arg)`, config-driven `meta_fields` handling
- `_run_config()`: displays effective config grouped by concern with source tracking (default/config/env)

### Parser integration

- `parse_file()` in `extractor.py`: general `is_language_enabled()` gate — skips tree-sitter entirely for unconfigured languages (was previously only gating SQL)
- `security.py`: `get_max_folder_files()` reads from config, removed unsafe `max_index_files` fallback (could jump from 2K to 10K)

### Upstream merge (v1.10.18-19)

- Integrated `resolve_repo` tool and `JCODEMUNCH_PATH_MAP` into the config system
- `path_map` added to DEFAULTS, CONFIG_TYPES, ENV_VAR_MAPPING
- `parse_path_map()` reads from config first, env var as fallback

## Benchmarks

Profiled against a repo with 358 Python files and 5,847 symbols (7 iterations, median):

### Warm index (normal operation)

| Metric | Main | Config branch | Change |
|--------|------|--------------|--------|
| Total (16 tools) | 164.44 ms | 163.01 ms | **-0.9%** |

No measurable overhead from the config system. `config.get()` is a single dict lookup.

### Cold index (first load from disk)

| Metric | Main | Config branch | Change |
|--------|------|--------------|--------|
| Total (16 tools) | 1040.06 ms | 1039.64 ms | **-0.0%** |

### Language filtering (`languages: ["python"]`)

| Metric | All languages | Python only | Change |
|--------|--------------|-------------|--------|
| Symbols parsed | 11 | 4 | **-64%** |
| Index time | 76.2 ms | 58.1 ms | **-24%** |
| `search_columns` available | Yes | No (auto-gated) | |

### Bugs found and fixed during review

- `_resolve_repo_key()` cache miss: caused `IndexStore.list_repos()` scan on every tool call (50% regression, fixed)
- `_apply_description_overrides()` crashed on flat string format (`AttributeError`)
- Mixed f-string/%-format in logger calls
- `get_max_folder_files()` fallback could jump from 2,000 to 10,000

## Test plan

- [x] `pytest` — 1104 passed, 4 skipped
- [x] New test file: `test_config.py` (89 tests covering JSONC parser, loading, type validation, project merge, env var fallback, language/tool gating, template generation)
- [x] New server tests: description overrides (7 tests), disabled tools (2), meta fields (3), SQL gating (1), language enum (1)
- [x] Security tests: `get_max_folder_files` config integration (6 new tests)
- [x] Benchmark: warm/cold index regression profiling, language filter profiling
- [x] Manual: `config`, `config --init`, `config --check` CLI commands
- [x] Manual: flat + nested description override formats
- [x] Manual: `languages: ["python"]` gates SQL extractor, dbt provider, and search_columns

## Documentation

- `CONFIGURATION.md`: complete config guide (resolution order, all 25 keys, migration guide)
- `README.md`: updated with config file reference

---

Generated with [Claude Code](https://claude.com/claude-code)