### PR TITLE
fix: debug logging for skip reasons + exclude_secret_patterns config

### DIFF
--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -52,6 +52,7 @@ DEFAULTS = {
     "staleness_days": 7,
     "max_results": 500,
     "extra_ignore_patterns": [],
+    "exclude_secret_patterns": [],
     "extra_extensions": {},
     "context_providers": True,
     "meta_fields": None,  # None = all fields
@@ -83,6 +84,7 @@ CONFIG_TYPES = {
     "staleness_days": int,
     "max_results": int,
     "extra_ignore_patterns": list,
+    "exclude_secret_patterns": list,
     "extra_extensions": dict,
     "context_providers": bool,
     "meta_fields": (list, type(None)),

--- a/src/jcodemunch_mcp/security.py
+++ b/src/jcodemunch_mcp/security.py
@@ -157,7 +157,10 @@ def is_secret_file(file_path: str) -> bool:
     path_lower = file_path.lower()
     _, ext = os.path.splitext(name)
 
+    excluded = set(_config.get("exclude_secret_patterns", []))
     for pattern in SECRET_PATTERNS:
+        if pattern in excluded:
+            continue
         if pattern in _SECRET_DOC_EXEMPT_PATTERNS and ext in _SECRET_GLOB_SAFE_EXTENSIONS:
             continue
         if fnmatch.fnmatch(name, pattern):

--- a/src/jcodemunch_mcp/tools/index_folder.py
+++ b/src/jcodemunch_mcp/tools/index_folder.py
@@ -162,6 +162,8 @@ def discover_local_files(
     root = folder_path.resolve()
 
     skip_counts: dict[str, int] = {
+        "skip_dir": 0,
+        "skip_file": 0,
         "symlink": 0,
         "symlink_escape": 0,
         "path_traversal": 0,
@@ -198,7 +200,19 @@ def discover_local_files(
 
     for dirpath, dirnames, filenames in os.walk(str(root), followlinks=False):
         # Prune directories that should always be skipped before descending.
-        dirnames[:] = [d for d in dirnames if not SKIP_DIRS_REGEX.match(d)]
+        pruned = []
+        kept = []
+        for d in dirnames:
+            if SKIP_DIRS_REGEX.match(d):
+                pruned.append(d)
+            else:
+                kept.append(d)
+        if pruned:
+            rel_dir = os.path.relpath(dirpath, root_str)
+            for d in pruned:
+                skip_counts["skip_dir"] += 1
+                logger.debug("SKIP skip_dir: %s", os.path.join(rel_dir, d))
+        dirnames[:] = kept
         dpath = Path(dirpath)
 
         # Load .gitignore for this directory BEFORE filtering its files so
@@ -214,6 +228,8 @@ def discover_local_files(
 
         for filename in filenames:
             if SKIP_FILES_REGEX.search(filename):
+                skip_counts["skip_file"] += 1
+                logger.debug("SKIP skip_file: %s", os.path.join(os.path.relpath(dirpath, root_str), filename))
                 continue
             file_path = dpath / filename
             # Symlink protection
@@ -265,6 +281,7 @@ def discover_local_files(
             # Secret detection
             if is_secret_file(rel_path):
                 skip_counts["secret"] += 1
+                logger.debug("SKIP secret: %s", rel_path)
                 warnings.append(f"Skipped secret file: {rel_path}")
                 continue
 


### PR DESCRIPTION
## Summary

Closes #167

- **Add debug logging** for three silent skip paths in `discover_local_files`:
  - `skip_dir` — directory pruning via `SKIP_DIRS_REGEX` (was completely silent)
  - `skip_file` — file pattern skips via `SKIP_FILES_REGEX` (was completely silent)
  - `secret` — add `logger.debug()` alongside existing `warnings.append()`
- **Add `skip_dir` and `skip_file` counters** to `skip_counts` dict so they appear in the discovery summary
- **Add `exclude_secret_patterns` config option** — a list of `SECRET_PATTERNS` entries to suppress, giving users an immediate workaround for the `*secret*` full-path match false positive

## Motivation

A Go monorepo had 19 source files silently excluded because their parent directory contained "secret" in the name (e.g., `models/eventsource_security_otpauthsecret_v1/aggregate.go`). The `*secret*` glob in `SECRET_PATTERNS` matches the full relative path, not just the filename. With no debug logging on directory pruning or secret skips, this was very difficult to diagnose.

## Usage

Add to `~/.code-index/config.jsonc`:
```jsonc
{
  "exclude_secret_patterns": ["*secret*"]
}
```

Run with `JCODEMUNCH_LOG_LEVEL=DEBUG` to see all skip decisions:
```
DEBUG:jcodemunch_mcp.tools.index_folder:SKIP skip_dir: grpchandlers/token/tokenadminhandler/testdata
DEBUG:jcodemunch_mcp.tools.index_folder:SKIP secret: cmd/eventsourcesecurityotpauthsecretv1/config_gen.go
DEBUG:jcodemunch_mcp.tools.index_folder:SKIP skip_file: ./go.sum
```

## Test plan

- [x] 41 existing secret-related tests pass
- [x] 26 existing discover/skip tests pass
- [x] Verified on real Go monorepo: 19 false-positive secret skips eliminated with config
- [x] Verified `.env`, `.pem`, `id_rsa` still caught when `*secret*` is excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)