### PR TITLE
Add YAML and Ansible parser support

### DIFF
--- a/src/jcodemunch_mcp/parser/extractor.py
+++ b/src/jcodemunch_mcp/parser/extractor.py
@@ -80,6 +80,10 @@ def parse_file(content: str, filename: str, language: str, source_bytes: Optiona
         symbols = _parse_asm_symbols(source_bytes, filename)
     elif language == "xml":
         symbols = _parse_xml_symbols(source_bytes, filename)
+    elif language == "yaml":
+        symbols = _parse_yaml_symbols(source_bytes, filename)
+    elif language == "ansible":
+        symbols = _parse_ansible_symbols(source_bytes, filename)
     elif language == "openapi":
         symbols = _parse_openapi_symbols(source_bytes, filename)
     elif language == "al":
@@ -5704,6 +5708,391 @@ def _parse_xml_symbols(source_bytes: bytes, filename: str) -> list[Symbol]:
             _walk(child)
 
     _walk(tree.root_node)
+    return symbols
+
+
+def _load_yaml_data(source: str):
+    """Load YAML content, returning None on parser/import failure."""
+    try:
+        import yaml as _yaml
+        docs = [doc for doc in _yaml.safe_load_all(source) if doc is not None]
+        if not docs:
+            return None
+        if len(docs) == 1:
+            return docs[0]
+        return docs
+    except Exception:
+        return None
+
+
+def _build_line_offsets(source: str) -> tuple[list[str], list[int]]:
+    """Return source lines plus cumulative UTF-8 byte offsets."""
+    lines = source.splitlines(keepends=True)
+    offsets = [0]
+    for line in lines:
+        offsets.append(offsets[-1] + len(line.encode("utf-8")))
+    return lines, offsets
+
+
+def _find_line(lines: list[str], text: str, after: int = 0) -> int:
+    """Find the first 1-based line containing text after a starting index."""
+    needle = str(text).strip().lower()
+    if not needle:
+        return max(after + 1, 1)
+    for idx in range(max(after, 0), len(lines)):
+        if needle in lines[idx].lower():
+            return idx + 1
+    return max(after + 1, 1)
+
+
+def _byte_start(offsets: list[int], line_1based: int) -> int:
+    """Return the byte offset for a 1-based line number."""
+    idx = line_1based - 1
+    return offsets[idx] if 0 <= idx < len(offsets) else 0
+
+
+def _scalar_signature(name: str, value: object) -> str:
+    """Render a short key/value signature for scalar YAML values."""
+    text = repr(value)
+    if len(text) > 80:
+        text = text[:77] + "..."
+    return f"{name}: {text}"
+
+
+def _append_virtual_symbol(
+    symbols: list[Symbol],
+    filename: str,
+    language: str,
+    name: str,
+    qualified_name: str,
+    kind: str,
+    signature: str,
+    line: int,
+    offsets: list[int],
+    docstring: str = "",
+    parent: Optional[str] = None,
+) -> str:
+    """Append a synthesized symbol backed by signature bytes."""
+    payload = signature.encode("utf-8")
+    symbol_id = make_symbol_id(filename, qualified_name, kind)
+    symbols.append(Symbol(
+        id=symbol_id,
+        file=filename,
+        name=name,
+        qualified_name=qualified_name,
+        kind=kind,
+        language=language,
+        signature=signature,
+        docstring=docstring,
+        parent=parent,
+        line=line,
+        end_line=line,
+        byte_offset=_byte_start(offsets, line),
+        byte_length=len(payload),
+        content_hash=compute_content_hash(payload),
+    ))
+    return symbol_id
+
+
+def _yaml_list_item_segment(item: object, index: int) -> str:
+    """Prefer semantic list item names over raw indices when possible."""
+    if isinstance(item, dict):
+        for key in ("name", "key", "id"):
+            value = item.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return f"[{index}]"
+
+
+def _walk_yaml_value(
+    value: object,
+    path_parts: list[str],
+    filename: str,
+    language: str,
+    symbols: list[Symbol],
+    lines: list[str],
+    offsets: list[int],
+    after_line: int = 0,
+) -> None:
+    """Recursively extract structural symbols from generic YAML content."""
+    if isinstance(value, dict):
+        cursor = after_line
+        for key, child in value.items():
+            key_name = str(key)
+            qualified_name = ".".join(path_parts + [key_name]) if path_parts else key_name
+            line = _find_line(lines, f"{key_name}:", cursor - 1)
+            next_cursor = line + 1
+            cursor = next_cursor
+            if isinstance(child, (dict, list)):
+                kind = "type"
+                signature = f"{key_name}:"
+                _append_virtual_symbol(
+                    symbols, filename, language, key_name, qualified_name, kind, signature, line, offsets
+                )
+                _walk_yaml_value(
+                    child, path_parts + [key_name], filename, language, symbols, lines, offsets, next_cursor
+                )
+            else:
+                signature = _scalar_signature(key_name, child)
+                _append_virtual_symbol(
+                    symbols,
+                    filename,
+                    language,
+                    key_name,
+                    qualified_name,
+                    "constant",
+                    signature,
+                    line,
+                    offsets,
+                )
+    elif isinstance(value, list):
+        cursor = after_line
+        for index, child in enumerate(value):
+            segment = _yaml_list_item_segment(child, index)
+            item_line = cursor or 1
+            if isinstance(child, dict) and isinstance(child.get("name"), str):
+                item_line = _find_line(lines, str(child["name"]), cursor - 1)
+            elif path_parts:
+                item_line = _find_line(lines, path_parts[-1], cursor - 1)
+            next_cursor = item_line + 1
+            cursor = next_cursor
+            if isinstance(child, (dict, list)):
+                _walk_yaml_value(
+                    child, path_parts + [segment], filename, language, symbols, lines, offsets, next_cursor
+                )
+
+
+def _parse_yaml_symbols(source_bytes: bytes, filename: str) -> list[Symbol]:
+    """Parse generic YAML and extract structural symbols from keys and containers."""
+    source = source_bytes.decode("utf-8", errors="replace")
+    data = _load_yaml_data(source)
+    if not isinstance(data, (dict, list)):
+        return []
+
+    lines, offsets = _build_line_offsets(source)
+    symbols: list[Symbol] = []
+    if isinstance(data, list) and all(isinstance(item, dict) for item in data):
+        cursor = 0
+        for item in data:
+            _walk_yaml_value(item, [], filename, "yaml", symbols, lines, offsets, cursor)
+            cursor += 1
+        return symbols
+    _walk_yaml_value(data, [], filename, "yaml", symbols, lines, offsets)
+    return symbols
+
+
+def _looks_like_ansible_play(item: object) -> bool:
+    """Heuristic for Ansible playbook entries."""
+    return isinstance(item, dict) and any(
+        key in item for key in ("hosts", "tasks", "handlers", "pre_tasks", "post_tasks", "roles")
+    )
+
+
+def _ansible_task_name(task: dict, index: int) -> str:
+    """Pick a stable display name for an Ansible task."""
+    name = task.get("name")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    skip = {
+        "name", "when", "vars", "register", "tags", "loop", "with_items",
+        "delegate_to", "become", "become_user", "notify", "listen",
+        "environment", "args", "retries", "delay", "until", "changed_when",
+        "failed_when", "loop_control", "ignore_errors", "import_tasks",
+        "include_tasks", "block", "rescue", "always",
+    }
+    for key in task:
+        if key not in skip:
+            return str(key)
+    return f"task_{index + 1}"
+
+
+def _ansible_role_name(role: object, index: int) -> str:
+    """Extract a role name from roles entries."""
+    if isinstance(role, str) and role.strip():
+        return role.strip()
+    if isinstance(role, dict):
+        for key in ("role", "name"):
+            value = role.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return f"role_{index + 1}"
+
+
+def _append_ansible_tasks(
+    symbols: list[Symbol],
+    filename: str,
+    offsets: list[int],
+    lines: list[str],
+    section_name: str,
+    tasks: object,
+    scope_name: str,
+    parent_id: Optional[str] = None,
+    start_line: int = 0,
+) -> None:
+    """Append Ansible task-like entries as function symbols."""
+    if not isinstance(tasks, list):
+        return
+    cursor = start_line
+    for index, task in enumerate(tasks):
+        if not isinstance(task, dict):
+            continue
+        task_name = _ansible_task_name(task, index)
+        line = _find_line(lines, task_name, cursor - 1)
+        if line == cursor and task_name.startswith("task_"):
+            line = _find_line(lines, "-", cursor - 1)
+        cursor = line
+        qualified_name = f"{scope_name}.{section_name}.{task_name}"
+        signature = f"{section_name} {task_name}"
+        docstring = ""
+        when_clause = task.get("when")
+        if isinstance(when_clause, str) and when_clause.strip():
+            docstring = f"when: {when_clause.strip()}"
+        _append_virtual_symbol(
+            symbols,
+            filename,
+            "ansible",
+            task_name,
+            qualified_name,
+            "function",
+            signature,
+            line,
+            offsets,
+            docstring=docstring,
+            parent=parent_id,
+        )
+
+
+def _append_ansible_vars(
+    symbols: list[Symbol],
+    filename: str,
+    offsets: list[int],
+    lines: list[str],
+    values: object,
+    scope_name: str,
+    after_line: int = 0,
+) -> None:
+    """Append Ansible variable symbols from nested mapping structures."""
+    if isinstance(values, dict):
+        cursor = after_line
+        for key, child in values.items():
+            key_name = str(key)
+            qualified_name = f"{scope_name}.{key_name}" if scope_name else key_name
+            line = _find_line(lines, f"{key_name}:", cursor - 1)
+            next_cursor = line + 1
+            cursor = next_cursor
+            if isinstance(child, dict):
+                _append_virtual_symbol(
+                    symbols, filename, "ansible", key_name, qualified_name, "type", f"{key_name}:", line, offsets
+                )
+                _append_ansible_vars(symbols, filename, offsets, lines, child, qualified_name, next_cursor)
+            elif isinstance(child, list):
+                _append_virtual_symbol(
+                    symbols, filename, "ansible", key_name, qualified_name, "type", f"{key_name}:", line, offsets
+                )
+                list_cursor = next_cursor
+                for idx, item in enumerate(child):
+                    segment = _yaml_list_item_segment(item, idx)
+                    if isinstance(item, dict):
+                        item_line = list_cursor
+                        if isinstance(item.get("name"), str) and item["name"].strip():
+                            item_line = _find_line(lines, item["name"], list_cursor - 1)
+                        item_cursor = item_line + 1
+                        _append_ansible_vars(
+                            symbols, filename, offsets, lines, item, f"{qualified_name}.{segment}", item_cursor
+                        )
+                        list_cursor = item_cursor
+            else:
+                _append_virtual_symbol(
+                    symbols,
+                    filename,
+                    "ansible",
+                    key_name,
+                    qualified_name,
+                    "constant",
+                    _scalar_signature(key_name, child),
+                    line,
+                    offsets,
+                )
+
+
+def _parse_ansible_symbols(source_bytes: bytes, filename: str) -> list[Symbol]:
+    """Parse common Ansible YAML structures such as plays, tasks, roles, and vars."""
+    source = source_bytes.decode("utf-8", errors="replace")
+    data = _load_yaml_data(source)
+    if not isinstance(data, (dict, list)):
+        return []
+
+    lower = filename.lower().replace("\\", "/")
+    lines, offsets = _build_line_offsets(source)
+    symbols: list[Symbol] = []
+
+    is_var_file = any(marker in lower for marker in ("/group_vars/", "/host_vars/", "/vars/", "/defaults/"))
+    is_task_file = any(marker in lower for marker in ("/tasks/", "/handlers/"))
+
+    if isinstance(data, list) and any(_looks_like_ansible_play(item) for item in data):
+        cursor = 0
+        for index, play in enumerate(data):
+            if not isinstance(play, dict):
+                continue
+            play_name = play.get("name")
+            if not isinstance(play_name, str) or not play_name.strip():
+                hosts = play.get("hosts")
+                if isinstance(hosts, str) and hosts.strip():
+                    play_name = f"play {hosts.strip()}"
+                else:
+                    play_name = f"play_{index + 1}"
+            play_line = _find_line(lines, str(play_name), cursor - 1)
+            cursor = play_line
+            host_text = play.get("hosts")
+            docstring = f"hosts: {host_text}" if isinstance(host_text, str) and host_text.strip() else ""
+            play_id = _append_virtual_symbol(
+                symbols,
+                filename,
+                "ansible",
+                str(play_name),
+                str(play_name),
+                "class",
+                f"play {play_name}",
+                play_line,
+                offsets,
+                docstring=docstring,
+            )
+            for section in ("pre_tasks", "tasks", "post_tasks", "handlers"):
+                _append_ansible_tasks(
+                    symbols, filename, offsets, lines, section, play.get(section), str(play_name), play_id, play_line
+                )
+            roles = play.get("roles")
+            if isinstance(roles, list):
+                role_cursor = play_line
+                for role_index, role in enumerate(roles):
+                    role_name = _ansible_role_name(role, role_index)
+                    role_line = _find_line(lines, role_name, role_cursor - 1)
+                    role_cursor = role_line
+                    _append_virtual_symbol(
+                        symbols,
+                        filename,
+                        "ansible",
+                        role_name,
+                        f"{play_name}.roles.{role_name}",
+                        "type",
+                        f"role {role_name}",
+                        role_line,
+                        offsets,
+                        parent=play_id,
+                    )
+        return symbols
+
+    if is_task_file and isinstance(data, list):
+        section = "handlers" if "/handlers/" in lower else "tasks"
+        scope_name = section.rstrip("s")
+        _append_ansible_tasks(symbols, filename, offsets, lines, section, data, scope_name, None, 1)
+        return symbols
+
+    if is_var_file and isinstance(data, dict):
+        _append_ansible_vars(symbols, filename, offsets, lines, data, "")
+        return symbols
+
+    _walk_yaml_value(data, [], filename, "ansible", symbols, lines, offsets)
     return symbols
 
 

--- a/src/jcodemunch_mcp/parser/languages.py
+++ b/src/jcodemunch_mcp/parser/languages.py
@@ -149,6 +149,9 @@ LANGUAGE_EXTENSIONS = {
     # XML / XUL
     ".xml": "xml",
     ".xul": "xml",
+    # YAML / Ansible (Ansible path heuristics handled in get_language_for_path)
+    ".yaml": "yaml",
+    ".yml": "yaml",
     # OpenAPI / Swagger (compound extensions; basenames handled in get_language_for_path)
     ".openapi.yaml": "openapi",
     ".openapi.yml": "openapi",
@@ -1301,6 +1304,34 @@ XML_SPEC = LanguageSpec(
 )
 
 
+YAML_SPEC = LanguageSpec(
+    ts_language="yaml",
+    symbol_node_types={},
+    name_fields={},
+    param_fields={},
+    return_type_fields={},
+    docstring_strategy="preceding_comment",
+    decorator_node_type=None,
+    container_node_types=[],
+    constant_patterns=[],
+    type_patterns=[],
+)
+
+
+ANSIBLE_SPEC = LanguageSpec(
+    ts_language="yaml",
+    symbol_node_types={},
+    name_fields={},
+    param_fields={},
+    return_type_fields={},
+    docstring_strategy="preceding_comment",
+    decorator_node_type=None,
+    container_node_types=[],
+    constant_patterns=[],
+    type_patterns=[],
+)
+
+
 # OpenAPI / Swagger specification
 # NOTE: Parsed by _parse_openapi_symbols() in extractor.py using yaml/json.
 # File detection uses compound extensions (.openapi.yaml, .swagger.json, …)
@@ -1368,6 +1399,8 @@ LANGUAGE_REGISTRY = {
     "autohotkey": AHK_SPEC,
     "asm": ASM_SPEC,
     "xml": XML_SPEC,
+    "yaml": YAML_SPEC,
+    "ansible": ANSIBLE_SPEC,
     "openapi": OPENAPI_SPEC,
 }
 
@@ -1381,6 +1414,38 @@ _OPENAPI_BASENAMES = frozenset({
     "openapi.yaml", "openapi.yml", "openapi.json",
     "swagger.yaml", "swagger.yml", "swagger.json",
 })
+
+_ANSIBLE_PLAYBOOK_DIRS = frozenset({"playbooks", "playbook"})
+_ANSIBLE_ROLE_DIR_SEGMENTS = frozenset({"tasks", "handlers", "vars", "defaults", "meta"})
+_ANSIBLE_SPECIAL_DIRS = frozenset({"group_vars", "host_vars"})
+_ANSIBLE_BASENAMES = frozenset({
+    "site.yml", "site.yaml",
+    "requirements.yml", "requirements.yaml",
+    "galaxy.yml", "galaxy.yaml",
+})
+
+
+def _looks_like_ansible_path(path: str) -> bool:
+    """Best-effort path heuristics for Ansible YAML files."""
+    lower = path.lower().replace("\\", "/")
+    base = os.path.basename(lower)
+    parts = [part for part in lower.split("/") if part]
+    if not base.endswith((".yml", ".yaml")):
+        return False
+
+    if base in _ANSIBLE_BASENAMES:
+        return True
+    if any(marker in parts for marker in _ANSIBLE_PLAYBOOK_DIRS):
+        return True
+    if any(marker in parts for marker in _ANSIBLE_SPECIAL_DIRS):
+        return True
+
+    for idx, part in enumerate(parts):
+        if part != "roles" or idx + 2 >= len(parts):
+            continue
+        if parts[idx + 2] in _ANSIBLE_ROLE_DIR_SEGMENTS:
+            return True
+    return False
 
 
 def _apply_extra_extensions() -> None:
@@ -1423,8 +1488,9 @@ def get_language_for_path(path: str) -> "Optional[str]":
 
     Check order:
     1. Well-known OpenAPI/Swagger basenames (openapi.yaml, swagger.json, …).
-    2. Compound suffixes (e.g. ``.blade.php``, ``.openapi.yaml``).
-    3. Last extension (e.g. ``.php``).
+    2. Ansible path heuristics for YAML inventory/playbook files.
+    3. Compound suffixes (e.g. ``.blade.php``, ``.openapi.yaml``).
+    4. Last extension (e.g. ``.php``).
     """
     _apply_extra_extensions()
     import os as _os
@@ -1433,12 +1499,15 @@ def get_language_for_path(path: str) -> "Optional[str]":
     # 1. Basename match for OpenAPI sentinel files
     if base in _OPENAPI_BASENAMES:
         return "openapi"
-    # 2. Compound extension (e.g. ".blade.php", ".openapi.yaml")
+    # 2. Path heuristics for Ansible YAML files
+    if _looks_like_ansible_path(lower):
+        return "ansible"
+    # 3. Compound extension (e.g. ".blade.php", ".openapi.yaml")
     first_dot = base.find(".")
     if first_dot != -1:
         compound = base[first_dot:]
         if compound in LANGUAGE_EXTENSIONS:
             return LANGUAGE_EXTENSIONS[compound]
-    # 3. Simple extension
+    # 4. Simple extension
     _, ext = _os.path.splitext(lower)
     return LANGUAGE_EXTENSIONS.get(ext)

--- a/tests/test_yaml_language.py
+++ b/tests/test_yaml_language.py
@@ -1,0 +1,140 @@
+"""Tests for YAML and Ansible parsing support."""
+
+from jcodemunch_mcp.parser import parse_file
+from jcodemunch_mcp.parser.languages import get_language_for_path
+
+
+GENERIC_YAML_SOURCE = """
+services:
+  api:
+    image: example/api:latest
+    ports:
+      - "8080:8080"
+feature_flags:
+  signup: true
+"""
+
+
+ANSIBLE_PLAYBOOK_SOURCE = """
+- name: Configure web nodes
+  hosts: web
+  tasks:
+    - name: Install nginx
+      ansible.builtin.package:
+        name: nginx
+        state: present
+    - name: Start service
+      ansible.builtin.service:
+        name: nginx
+        state: started
+  handlers:
+    - name: Restart nginx
+      ansible.builtin.service:
+        name: nginx
+        state: restarted
+"""
+
+
+ANSIBLE_TASKS_SOURCE = """
+- name: Create app directory
+  ansible.builtin.file:
+    path: /srv/app
+    state: directory
+
+- ansible.builtin.template:
+    src: app.conf.j2
+    dest: /etc/app.conf
+"""
+
+
+ANSIBLE_VARS_SOURCE = """
+app_port: 8080
+app_debug: true
+database:
+  host: db.internal
+  port: 5432
+"""
+
+
+MULTI_DOC_YAML_SOURCE = """
+services:
+  api:
+    image: example/api:latest
+---
+feature_flags:
+  signup: true
+"""
+
+
+def test_yaml_extension_mapping():
+    assert get_language_for_path("settings.yaml") == "yaml"
+    assert get_language_for_path("settings.yml") == "yaml"
+
+
+def test_ansible_path_heuristics_override_yaml():
+    assert get_language_for_path("playbooks/site.yml") == "ansible"
+    assert get_language_for_path("playbooks/deploy.yml") == "ansible"
+    assert get_language_for_path("roles/web/tasks/main.yaml") == "ansible"
+    assert get_language_for_path("group_vars/all.yml") == "ansible"
+    assert get_language_for_path("inventory/group_vars/all.yml") == "ansible"
+
+
+def test_openapi_basename_still_wins_over_yaml():
+    assert get_language_for_path("openapi.yaml") == "openapi"
+    assert get_language_for_path("swagger.yml") == "openapi"
+
+
+def test_parse_generic_yaml_symbols():
+    symbols = parse_file(GENERIC_YAML_SOURCE, "config/settings.yaml", "yaml")
+    by_qualified = {symbol.qualified_name: symbol for symbol in symbols}
+
+    assert "services" in by_qualified
+    assert by_qualified["services"].kind == "type"
+    assert "services.api" in by_qualified
+    assert by_qualified["services.api"].kind == "type"
+    assert "services.api.image" in by_qualified
+    assert by_qualified["services.api.image"].kind == "constant"
+    assert "feature_flags.signup" in by_qualified
+    assert by_qualified["feature_flags.signup"].kind == "constant"
+
+
+def test_parse_multi_document_yaml_symbols():
+    symbols = parse_file(MULTI_DOC_YAML_SOURCE, "config/settings.yaml", "yaml")
+    by_qualified = {symbol.qualified_name: symbol for symbol in symbols}
+
+    assert "services.api.image" in by_qualified
+    assert "feature_flags.signup" in by_qualified
+
+
+def test_parse_ansible_playbook_symbols():
+    symbols = parse_file(ANSIBLE_PLAYBOOK_SOURCE, "playbooks/site.yml", "ansible")
+    by_qualified = {symbol.qualified_name: symbol for symbol in symbols}
+
+    assert "Configure web nodes" in by_qualified
+    assert by_qualified["Configure web nodes"].kind == "class"
+    assert "Configure web nodes.tasks.Install nginx" in by_qualified
+    assert by_qualified["Configure web nodes.tasks.Install nginx"].kind == "function"
+    assert "Configure web nodes.handlers.Restart nginx" in by_qualified
+    assert by_qualified["Configure web nodes.handlers.Restart nginx"].kind == "function"
+
+
+def test_parse_ansible_tasks_file_symbols():
+    symbols = parse_file(ANSIBLE_TASKS_SOURCE, "roles/app/tasks/main.yml", "ansible")
+    by_qualified = {symbol.qualified_name: symbol for symbol in symbols}
+
+    assert "task.tasks.Create app directory" in by_qualified
+    assert by_qualified["task.tasks.Create app directory"].kind == "function"
+    assert "task.tasks.ansible.builtin.template" in by_qualified
+    assert by_qualified["task.tasks.ansible.builtin.template"].kind == "function"
+
+
+def test_parse_ansible_var_symbols():
+    symbols = parse_file(ANSIBLE_VARS_SOURCE, "inventory/group_vars/all.yml", "ansible")
+    by_qualified = {symbol.qualified_name: symbol for symbol in symbols}
+
+    assert "app_port" in by_qualified
+    assert by_qualified["app_port"].kind == "constant"
+    assert "database" in by_qualified
+    assert by_qualified["database"].kind == "type"
+    assert "database.host" in by_qualified
+    assert by_qualified["database.host"].kind == "constant"


### PR DESCRIPTION
## Summary
- rebase the YAML and Ansible parser support work onto the current upstream `main`
- add YAML and Ansible extraction support in the parser
- add coverage for the new YAML language handling

## Verification
- `uv run pytest tests/test_yaml_language.py`