### PR TITLE
feat: tri-state AI summarizer config, OpenRouter provider, circuit breaker & test_summarizer tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,9 @@ Tree-sitter grammar lacks clean named fields for these — custom regex extracto
 | `JCODEMUNCH_MAX_FOLDER_FILES` | 2,000 | File cap for folder indexing |
 | `JCODEMUNCH_FILE_TREE_MAX_FILES` | 500 | Cap for get_file_tree results |
 | `JCODEMUNCH_GITIGNORE_WARN_THRESHOLD` | 500 | Missing-.gitignore warning threshold (0 = disable) |
-| `JCODEMUNCH_USE_AI_SUMMARIES` | true | Set false/0/no/off to disable AI summaries globally |
+| `JCODEMUNCH_USE_AI_SUMMARIES` | auto | AI summarization mode: `auto` (detect provider), `true` (use explicit config), `false`/`0`/`no`/`off` (disable) |
+| `JCODEMUNCH_SUMMARIZER_PROVIDER` | — | Explicit summarizer provider: `anthropic`, `gemini`, `openai`, `minimax`, `glm`, `openrouter`, `none` |
+| `JCODEMUNCH_SUMMARIZER_MODEL` | — | Model name override for the selected summarizer provider |
 | `JCODEMUNCH_TRUSTED_FOLDERS` | — | Roots trusted for index_folder; whitelist mode by default |
 | `JCODEMUNCH_EXTRA_IGNORE_PATTERNS` | — | Always-on gitignore patterns (comma-sep or JSON array) |
 | `JCODEMUNCH_PATH_MAP` | — | Cross-platform path remapping; format: `orig1=new1,orig2=new2` |
@@ -79,6 +81,7 @@ Tree-sitter grammar lacks clean named fields for these — custom regex extracto
 | `GOOGLE_API_KEY` | — | Enables Gemini Flash summaries (`pip install jcodemunch-mcp[gemini]`) |
 | `OPENAI_API_BASE` | — | Local LLM endpoint (Ollama, LM Studio) |
 | `OPENAI_WIRE_API` | — | Set `responses` to use OpenAI Responses API instead of chat/completions |
+| `OPENROUTER_API_KEY` | — | Enables OpenRouter summaries (default model: `meta-llama/llama-3.3-70b-instruct:free`) |
 | `GEMINI_EMBED_TASK_AWARE` | 1 | Set `0`/`false`/`no`/`off` to disable task-type hints (`RETRIEVAL_DOCUMENT` / `CODE_RETRIEVAL_QUERY`) when using Gemini embeddings |
 
 ## PR / Issue History

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -855,12 +855,18 @@ def validate_config(config_path: str) -> list[str]:
     for key, value in loaded.items():
         if key in CONFIG_TYPES:
             if not _validate_type(key, value, CONFIG_TYPES[key]):
-                expected = CONFIG_TYPES[key]
-                type_name = getattr(expected, "__name__", str(expected))
-                issues.append(
-                    f"Config key '{key}' has invalid type: "
-                    f"expected {type_name}, got {type(value).__name__}"
-                )
+                if key == "use_ai_summaries":
+                    issues.append(
+                        f"Config key 'use_ai_summaries' has invalid value {value!r}: "
+                        f'expected one of: "auto", "true", "false" (or boolean true/false)'
+                    )
+                else:
+                    expected = CONFIG_TYPES[key]
+                    type_name = getattr(expected, "__name__", str(expected))
+                    issues.append(
+                        f"Config key '{key}' has invalid type: "
+                        f"expected {type_name}, got {type(value).__name__}"
+                    )
             elif key == "trusted_folders":
                 for entry in value:
                     if not Path(entry).expanduser().is_absolute():
@@ -1104,6 +1110,8 @@ def generate_template() -> str:
   // "summarizer_concurrency": 4,
   //   Number of parallel threads for AI summarization.
   //   Higher = faster indexing but more API calls.
+
+  // === AI Summarizer ===
   // Controls whether AI is used to generate symbol summaries during indexing.
   //   "auto"  — auto-detect provider from API key env vars (default behavior)
   //   true    — use the summarizer_provider and summarizer_model values below

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -49,6 +49,8 @@ ENV_VAR_MAPPING = {
     "JCODEMUNCH_WATCH_LOG": "watch_log",
     "JCODEMUNCH_WATCH_PATHS": "watch_paths",
     "JCODEMUNCH_FRESHNESS_MODE": "freshness_mode",
+    "JCODEMUNCH_SUMMARIZER_PROVIDER": "summarizer_provider",
+    "JCODEMUNCH_EMBED_MODEL": "embed_model",
     "JCODEMUNCH_CLAUDE_POLL_INTERVAL": "claude_poll_interval",
     "JCODEMUNCH_LOG_LEVEL": "log_level",
     "JCODEMUNCH_LOG_FILE": "log_file",
@@ -276,6 +278,9 @@ DEFAULTS = {
     "watch_log": None,
     "watch_paths": [],
     "freshness_mode": "relaxed",
+    "strict_timeout_ms": 500,
+    "summarizer_provider": "",
+    "embed_model": "",
     "claude_poll_interval": 5.0,
     "log_level": "WARNING",
     "log_file": None,
@@ -318,6 +323,9 @@ CONFIG_TYPES = {
     "watch_log": (str, type(None)),
     "watch_paths": list,
     "freshness_mode": str,
+    "strict_timeout_ms": int,
+    "summarizer_provider": str,
+    "embed_model": str,
     "claude_poll_interval": float,
     "log_level": str,
     "log_file": (str, type(None)),
@@ -1065,6 +1073,10 @@ def generate_template() -> str:
   //             Best for interactive use (IDE, chat).
   //   strict  - Blocks queries until fresh index is ready.
   //             Best for automation/CI where consistency matters.
+  // "strict_timeout_ms": 500,
+  //   Maximum milliseconds to block queries waiting for a reindex in strict mode.
+  //   After this timeout the query proceeds with the stale index.
+  //   Only applies when freshness_mode is "strict". Default: 500.
   // "claude_poll_interval": 5.0,
   //   Seconds between polling Claude Code worktrees for changes.
 
@@ -1087,6 +1099,14 @@ def generate_template() -> str:
   // "summarizer_concurrency": 4,
   //   Number of parallel threads for AI summarization.
   //   Higher = faster indexing but more API calls.
+  // "summarizer_provider": "",
+  //   Force a specific AI summarizer provider. Auto-detected from API keys when empty.
+  //   Valid values: "anthropic", "gemini", "openai", "minimax", "glm", "none".
+  //   "none" disables AI summaries regardless of API keys set.
+  // "embed_model": "",
+  //   Sentence-transformers model name for local (free) semantic embeddings.
+  //   Example: "all-MiniLM-L6-v2". Requires sentence-transformers package.
+  //   When set, takes priority over GOOGLE_API_KEY and OPENAI_API_KEY embeddings.
   // "allow_remote_summarizer": false,
   //   Allow remote LLM endpoints for summarization (security risk).
   //   Default false blocks non-local summarization.

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -50,6 +50,7 @@ ENV_VAR_MAPPING = {
     "JCODEMUNCH_WATCH_PATHS": "watch_paths",
     "JCODEMUNCH_FRESHNESS_MODE": "freshness_mode",
     "JCODEMUNCH_SUMMARIZER_PROVIDER": "summarizer_provider",
+    "JCODEMUNCH_SUMMARIZER_MODEL": "summarizer_model",
     "JCODEMUNCH_EMBED_MODEL": "embed_model",
     "JCODEMUNCH_CLAUDE_POLL_INTERVAL": "claude_poll_interval",
     "JCODEMUNCH_LOG_LEVEL": "log_level",
@@ -248,7 +249,7 @@ def apply_adaptive_languages(source_root: str, detected: set[str]) -> bool:
     return True
 
 DEFAULTS = {
-    "use_ai_summaries": True,
+    "use_ai_summaries": "auto",
     "trusted_folders": [],
     "trusted_folders_whitelist_mode": True,
     "max_folder_files": 2000,
@@ -280,6 +281,7 @@ DEFAULTS = {
     "freshness_mode": "relaxed",
     "strict_timeout_ms": 500,
     "summarizer_provider": "",
+    "summarizer_model": "",
     "embed_model": "",
     "claude_poll_interval": 5.0,
     "log_level": "WARNING",
@@ -293,7 +295,7 @@ DEFAULTS = {
 }
 
 CONFIG_TYPES = {
-    "use_ai_summaries": bool,
+    "use_ai_summaries": (bool, str),
     "trusted_folders": list,
     "trusted_folders_whitelist_mode": bool,
     "max_folder_files": int,
@@ -325,6 +327,7 @@ CONFIG_TYPES = {
     "freshness_mode": str,
     "strict_timeout_ms": int,
     "summarizer_provider": str,
+    "summarizer_model": str,
     "embed_model": str,
     "claude_poll_interval": float,
     "log_level": str,
@@ -443,6 +446,12 @@ def _validate_type(key: str, value: Any, expected_type: type | tuple) -> bool:
     """Validate value against expected type."""
     if key == "trusted_folders":
         return isinstance(value, list) and all(isinstance(item, str) for item in value)
+    if key == "use_ai_summaries":
+        if isinstance(value, bool):
+            return True
+        if isinstance(value, str):
+            return value.lower() in {"true", "false", "auto"}
+        return False
     if isinstance(expected_type, tuple):
         return isinstance(value, expected_type)
     return isinstance(value, expected_type)
@@ -934,10 +943,6 @@ def generate_template() -> str:
   "version": "{__version__}",
 
   // === Indexing ===
-  // "use_ai_summaries": true,
-  //   Enable AI-generated symbol summaries (requires ANTHROPIC_API_KEY or GOOGLE_API_KEY).
-  //   Set false/0/no/off to disable globally.
-
   // "trusted_folders": [],
   //   Directories allowed for indexing when whitelist_mode is true.
   //   In whitelist mode (default), only these folders can be indexed.
@@ -1099,10 +1104,22 @@ def generate_template() -> str:
   // "summarizer_concurrency": 4,
   //   Number of parallel threads for AI summarization.
   //   Higher = faster indexing but more API calls.
+  // Controls whether AI is used to generate symbol summaries during indexing.
+  //   "auto"  — auto-detect provider from API key env vars (default behavior)
+  //   true    — use the summarizer_provider and summarizer_model values below
+  //   false   — disable AI summarization entirely (signature fallback only)
+  // "use_ai_summaries": "auto",
+
+  // AI summarizer provider to use when use_ai_summaries is true.
+  // Valid values: "anthropic", "gemini", "openai", "minimax", "glm", "none"
+  // Leave empty ("") to auto-detect from available API keys.
   // "summarizer_provider": "",
-  //   Force a specific AI summarizer provider. Auto-detected from API keys when empty.
-  //   Valid values: "anthropic", "gemini", "openai", "minimax", "glm", "none".
-  //   "none" disables AI summaries regardless of API keys set.
+
+  // Model name to use for the selected summarizer provider.
+  // Leave empty ("") to use the provider's default model.
+  // Examples: "claude-haiku-4-5-20251001" (anthropic), "gemini-2.5-flash-lite" (gemini),
+  //           "gpt-4o-mini" (openai), "minimax-m2.7" (minimax), "glm-5" (glm)
+  // "summarizer_model": "",
   // "embed_model": "",
   //   Sentence-transformers model name for local (free) semantic embeddings.
   //   Example: "all-MiniLM-L6-v2". Requires sentence-transformers package.

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -36,6 +36,7 @@ ENV_VAR_MAPPING = {
     "JCODEMUNCH_STATS_FILE_INTERVAL": "stats_file_interval",
     "JCODEMUNCH_SHARE_SAVINGS": "share_savings",
     "JCODEMUNCH_SUMMARIZER_CONCURRENCY": "summarizer_concurrency",
+    "JCODEMUNCH_SUMMARIZER_MAX_FAILURES": "summarizer_max_failures",
     "JCODEMUNCH_ALLOW_REMOTE_SUMMARIZER": "allow_remote_summarizer",
     "JCODEMUNCH_RATE_LIMIT": "rate_limit",
     "JCODEMUNCH_TRANSPORT": "transport",
@@ -290,6 +291,7 @@ DEFAULTS = {
     "stats_file_interval": 3,
     "share_savings": True,
     "summarizer_concurrency": 4,
+    "summarizer_max_failures": 3,
     "allow_remote_summarizer": False,
     "path_map": "",
 }
@@ -336,6 +338,7 @@ CONFIG_TYPES = {
     "stats_file_interval": int,
     "share_savings": bool,
     "summarizer_concurrency": int,
+    "summarizer_max_failures": int,
     "allow_remote_summarizer": bool,
     "path_map": str,
     "version": str,
@@ -1114,6 +1117,10 @@ def generate_template() -> str:
   // "summarizer_concurrency": 4,
   //   Number of parallel threads for AI summarization.
   //   Higher = faster indexing but more API calls.
+  // "summarizer_max_failures": 3,
+  //   Consecutive batch failures before the AI summarizer gives up and
+  //   falls back to signature summaries for remaining symbols.
+  //   Set 0 to disable the circuit breaker (never stop retrying).
 
   // === AI Summarizer ===
   // Controls whether AI is used to generate symbol summaries during indexing.

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -266,7 +266,7 @@ DEFAULTS = {
     "meta_fields": [],  # [] = no _meta (token-efficient; set null in config for all fields)
     "languages": None,  # None = all languages
     "languages_adaptive": False,
-    "disabled_tools": [],
+    "disabled_tools": ["test_summarizer"],
     "descriptions": {},
     "transport": "stdio",
     "host": "127.0.0.1",
@@ -928,6 +928,7 @@ def generate_template() -> str:
         "search_symbols",
         "search_text",
         "suggest_queries",
+        "test_summarizer",
     ])
     tools_str = "\n  // ".join(f'"{t}",' for t in all_tools)
 
@@ -1038,8 +1039,12 @@ def generate_template() -> str:
   // Global: tools listed here are removed from the schema entirely.
   // Project: tools listed here are rejected at call_tool() with an
   //   explanatory error (schema is global, can't be changed per-project).
-  // Default: empty (all tools enabled). Uncomment to disable specific tools.
+  // Default: test_summarizer disabled. Uncomment others to disable them.
   "disabled_tools": [
+    // test_summarizer — diagnostic: sends a probe to the AI summarizer and
+    //   reports status (ok, timeout, error, misconfigured, disabled).
+    //   Remove from this list to enable it, then call it from your MCP client.
+    "test_summarizer",
   // {tools_str}
   ],
 

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -542,8 +542,12 @@ def load_config(storage_path: str | None = None) -> None:
     _apply_env_var_fallback(_explicit_keys)
 
 
-def _parse_env_value(value: str, expected_type: type | tuple) -> Any:
+def _parse_env_value(value: str, expected_type: type | tuple, key: str | None = None) -> Any:
     """Parse env var string to expected type."""
+    # use_ai_summaries accepts "auto", "true", "false" as strings;
+    # generic bool parsing would coerce "auto" to False.
+    if key == "use_ai_summaries":
+        return value.strip().lower()
     try:
         if isinstance(expected_type, tuple):
             for t in expected_type:
@@ -620,7 +624,7 @@ def _apply_env_var_fallback(explicit_keys: set[str] | None = None) -> None:
             expected_type = CONFIG_TYPES.get(config_key)
             if expected_type is None:
                 continue
-            parsed = _parse_env_value(env_value, expected_type)  # type: ignore[arg-type]
+            parsed = _parse_env_value(env_value, expected_type, key=config_key)  # type: ignore[arg-type]
             if parsed is not None:
                 _GLOBAL_CONFIG[config_key] = parsed
 

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -1119,14 +1119,15 @@ def generate_template() -> str:
   // "use_ai_summaries": "auto",
 
   // AI summarizer provider to use when use_ai_summaries is true.
-  // Valid values: "anthropic", "gemini", "openai", "minimax", "glm", "none"
+  // Valid values: "anthropic", "gemini", "openai", "minimax", "glm", "openrouter", "none"
   // Leave empty ("") to auto-detect from available API keys.
   // "summarizer_provider": "",
 
   // Model name to use for the selected summarizer provider.
   // Leave empty ("") to use the provider's default model.
   // Examples: "claude-haiku-4-5-20251001" (anthropic), "gemini-2.5-flash-lite" (gemini),
-  //           "gpt-4o-mini" (openai), "minimax-m2.7" (minimax), "glm-5" (glm)
+  //           "gpt-4o-mini" (openai), "minimax-m2.7" (minimax), "glm-5" (glm),
+  //           "meta-llama/llama-3.3-70b-instruct:free" (openrouter)
   // "summarizer_model": "",
   // "embed_model": "",
   //   Sentence-transformers model name for local (free) semantic embeddings.

--- a/src/jcodemunch_mcp/reindex_state.py
+++ b/src/jcodemunch_mcp/reindex_state.py
@@ -191,6 +191,8 @@ def await_freshness_if_strict(repo: str, timeout_ms: int = 500) -> bool:
 
     In relaxed mode, this returns immediately without waiting.
     In strict mode, waits up to timeout_ms for reindexing to complete.
+    timeout_ms defaults to 500 and is configurable via the strict_timeout_ms
+    config key in config.jsonc.
     Returns True (always — callers use _meta fields to inspect actual state).
     """
     if get_freshness_mode() != "strict":

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -1056,7 +1056,8 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         # MUST use asyncio.to_thread — threading.Event.wait() cannot run on the event loop.
         repo_arg = arguments.get("repo")
         if (name not in _EXCLUDED_FROM_STRICT and repo_arg):
-            await asyncio.to_thread(await_freshness_if_strict, repo_arg, timeout_ms=500)
+            strict_ms = config_module.get("strict_timeout_ms", 500)
+            await asyncio.to_thread(await_freshness_if_strict, repo_arg, timeout_ms=strict_ms)
 
         # Project-level tool disabling: check if tool is disabled for this project
         # Global disabled tools are filtered out in list_tools() schema; project-level

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -34,6 +34,7 @@ from .tools.find_importers import find_importers
 from .tools.find_references import find_references
 from .tools.check_references import check_references
 from .tools.get_session_stats import get_session_stats
+from .tools.test_summarizer import test_summarizer
 from .tools.get_dependency_graph import get_dependency_graph
 from .tools.get_blast_radius import get_blast_radius
 from .tools.get_symbol_diff import get_symbol_diff
@@ -64,6 +65,7 @@ _EXCLUDED_FROM_STRICT = frozenset({
     "list_repos",
     "resolve_repo",
     "get_session_stats",
+    "test_summarizer",
     "index_repo",
     "index_folder",
     "index_file",
@@ -701,6 +703,20 @@ async def list_tools() -> list[Tool]:
             }
         ),
         Tool(
+            name="test_summarizer",
+            description="Verify AI summarizer config and connectivity.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "timeout_ms": {
+                        "type": "integer",
+                        "description": "Slow-response threshold in ms.",
+                        "default": 15000,
+                    },
+                },
+            },
+        ),
+        Tool(
             name="get_dependency_graph",
             description="Get the file-level dependency graph for a given file. Traverses import relationships up to 3 hops. Use to understand what a file depends on ('imports'), what depends on it ('importers'), or both. Prerequisite for blast radius analysis.",
             inputSchema={
@@ -1302,6 +1318,13 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 functools.partial(
                     get_session_stats,
                     storage_path=storage_path,
+                )
+            )
+        elif name == "test_summarizer":
+            result = await asyncio.to_thread(
+                functools.partial(
+                    test_summarizer,
+                    timeout_ms=arguments.get("timeout_ms", 15000),
                 )
             )
         elif name == "get_dependency_graph":

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -75,8 +75,15 @@ logger = logging.getLogger(__name__)
 
 
 def _default_use_ai_summaries() -> bool:
-    """Return the default for use_ai_summaries, respecting config (including env var fallback)."""
-    return config_module.get("use_ai_summaries", True)
+    """Return the default for use_ai_summaries as a bool (True unless explicitly disabled).
+
+    Config values "auto" and True both map to True; "false"/False maps to False.
+    The tri-state distinction (auto vs explicit) is resolved in batch_summarize._create_summarizer().
+    """
+    raw = config_module.get("use_ai_summaries", "auto")
+    if isinstance(raw, bool):
+        return raw
+    return str(raw).lower().strip() not in ("false", "0", "no", "off")
 
 
 def _parse_watcher_flag(value: Optional[str]) -> bool:

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -75,15 +75,17 @@ logger = logging.getLogger(__name__)
 
 
 def _default_use_ai_summaries() -> bool:
-    """Return the default for use_ai_summaries as a bool (True unless explicitly disabled).
+    """Return whether AI summarization is enabled, as a bool.
 
-    Config values "auto" and True both map to True; "false"/False maps to False.
-    The tri-state distinction (auto vs explicit) is resolved in batch_summarize._create_summarizer().
+    Collapses the tri-state config value ("auto", True, "true" → True;
+    "false", False, "0", "no", "off" → False) into a simple gate.
+    Note: _create_summarizer() reads the config directly to resolve
+    the "auto" vs. explicit-provider distinction at summarization time.
     """
     raw = config_module.get("use_ai_summaries", "auto")
     if isinstance(raw, bool):
         return raw
-    return str(raw).lower().strip() not in ("false", "0", "no", "off")
+    return str(raw).strip().lower() not in ("false", "0", "no", "off")
 
 
 def _parse_watcher_flag(value: Optional[str]) -> bool:

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -1945,11 +1945,16 @@ def _run_config(check: bool = False, init: bool = False) -> None:
         print(f"  Active provider:  {green('GLM-5')}  ({suffix})")
         row("  OPENAI_API_BASE", "https://api.z.ai/api/paas/v4/", "default")
         row("  OPENAI_MODEL", "glm-5", "default")
+    elif provider_name == "openrouter":
+        suffix = "JCODEMUNCH_SUMMARIZER_PROVIDER=openrouter" if provider == "openrouter" else "OPENROUTER_API_KEY set"
+        print(f"  Active provider:  {green('OpenRouter')}  ({suffix})")
+        row("  OPENAI_API_BASE", "https://openrouter.ai/api/v1", "default")
+        row("  OPENAI_MODEL", "meta-llama/llama-3.3-70b-instruct:free", "default")
     elif provider == "none":
         print(f"  Active provider:  {yellow('none')} — explicitly disabled, signature fallback active")
     else:
         print(f"  Active provider:  {yellow('none')} — no API key set, signature fallback active")
-        print(f"  {dim('Set ANTHROPIC_API_KEY, GOOGLE_API_KEY, OPENAI_API_BASE, MINIMAX_API_KEY, or ZHIPUAI_API_KEY to enable')}")
+        print(f"  {dim('Set ANTHROPIC_API_KEY, GOOGLE_API_KEY, OPENAI_API_BASE, MINIMAX_API_KEY, ZHIPUAI_API_KEY, or OPENROUTER_API_KEY to enable')}")
 
     # ── Transport ──────────────────────────────────────────────────────────
     section("Transport")

--- a/src/jcodemunch_mcp/summarizer/batch_summarize.py
+++ b/src/jcodemunch_mcp/summarizer/batch_summarize.py
@@ -199,7 +199,8 @@ class BatchSummarizer(BaseSummarizer):
 
             api_key = os.environ.get("ANTHROPIC_API_KEY")
             if api_key:
-                self.model = os.environ.get("ANTHROPIC_MODEL", self.model)
+                cfg_model = (_config.get("summarizer_model", "") or "").strip()
+                self.model = cfg_model or os.environ.get("ANTHROPIC_MODEL", self.model)
                 base_url = os.environ.get("ANTHROPIC_BASE_URL")
                 kwargs = {"api_key": api_key}
                 if base_url:
@@ -268,7 +269,8 @@ class GeminiBatchSummarizer(BaseSummarizer):
 
             api_key = os.environ.get("GOOGLE_API_KEY")
             if api_key:
-                self.model = os.environ.get("GOOGLE_MODEL", self.model)
+                cfg_model = (_config.get("summarizer_model", "") or "").strip()
+                self.model = cfg_model or os.environ.get("GOOGLE_MODEL", self.model)
                 genai.configure(api_key=api_key)
                 self.client = genai.GenerativeModel(self.model)
         except ImportError:

--- a/src/jcodemunch_mcp/summarizer/batch_summarize.py
+++ b/src/jcodemunch_mcp/summarizer/batch_summarize.py
@@ -509,10 +509,10 @@ def _create_summarizer() -> Optional[BaseSummarizer]:
 def get_provider_name() -> Optional[str]:
     """Return the active summarizer provider name, or None if disabled/unset.
 
-    Priority: explicit JCODEMUNCH_SUMMARIZER_PROVIDER env var > auto-detect by key.
+    Priority: summarizer_provider config key > JCODEMUNCH_SUMMARIZER_PROVIDER env var > auto-detect by key.
     Auto-detect order: Anthropic > Gemini > OpenAI-compatible > MiniMax > GLM-5.
     """
-    explicit = os.environ.get("JCODEMUNCH_SUMMARIZER_PROVIDER", "").lower().strip()
+    explicit = (_config.get("summarizer_provider", "") or os.environ.get("JCODEMUNCH_SUMMARIZER_PROVIDER", "")).lower().strip()
     if explicit in _VALID_PROVIDERS:
         return None if explicit == "none" else explicit
 

--- a/src/jcodemunch_mcp/summarizer/batch_summarize.py
+++ b/src/jcodemunch_mcp/summarizer/batch_summarize.py
@@ -467,20 +467,72 @@ class OpenAIBatchSummarizer(BaseSummarizer):
                     sym.summary = signature_fallback(sym)
 
 
+def get_model_name() -> Optional[str]:
+    """Return the configured summarizer_model override, or None if unset.
+
+    Reads the summarizer_model config key. Returns the stripped value, or None
+    if the key is empty or not set.
+    """
+    val = _config.get("summarizer_model", "")
+    if not val:
+        return None
+    return str(val).strip() or None
+
+
 def _create_summarizer() -> Optional[BaseSummarizer]:
-    """Return the appropriate summarizer based on explicit provider or API keys."""
-    name = get_provider_name()
+    """Return the appropriate summarizer based on tri-state use_ai_summaries + provider config.
+
+    Tri-state semantics for use_ai_summaries:
+    - False / "false" / "0" / "no" / "off": AI disabled — returns None immediately.
+    - True (bool, explicit): use summarizer_provider + summarizer_model from config;
+      falls back to auto-detect if provider is empty/unset.
+    - "auto" / "true" / anything else truthy: auto-detect by env vars (legacy behavior).
+    """
+    raw = _config.get("use_ai_summaries", "auto")
+
+    # Normalize to disabled / explicit / auto
+    if isinstance(raw, bool):
+        disabled = not raw
+        explicit_mode = raw  # True → explicit, False → disabled
+    else:
+        s = str(raw).strip().lower()
+        disabled = s in ("false", "0", "no", "off")
+        explicit_mode = False  # string "true"/"auto" → auto-detect
+
+    if disabled:
+        return None
+
+    model_override = get_model_name()
+
+    if explicit_mode:
+        # Use summarizer_provider from config; fall back to auto-detect if unset
+        explicit_provider = (_config.get("summarizer_provider", "") or "").lower().strip()
+        if explicit_provider not in _VALID_PROVIDERS or explicit_provider == "":
+            logger.warning(
+                "use_ai_summaries is 'true' but summarizer_provider is not set; "
+                "falling back to auto-detect"
+            )
+            name = get_provider_name()
+        else:
+            name = None if explicit_provider == "none" else explicit_provider
+    else:
+        name = get_provider_name()
+
     if name == "anthropic":
         s = BatchSummarizer()
+        if model_override:
+            s.model = model_override
         return s if s.client else None
     if name == "gemini":
         s = GeminiBatchSummarizer()
+        if model_override:
+            s.model = model_override
         return s if s.client else None
     if name == "openai":
         s = _make_openai_compat(
             api_key=os.environ.get("OPENAI_API_KEY", "local-llm"),
             base_url=os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1"),
-            model=os.environ.get("OPENAI_MODEL", "gpt-4o-mini"),
+            model=model_override or os.environ.get("OPENAI_MODEL", "gpt-4o-mini"),
         )
         return s if s.client else None
     if name == "minimax":
@@ -488,7 +540,7 @@ def _create_summarizer() -> Optional[BaseSummarizer]:
             s = _make_openai_compat(
                 api_key=os.environ.get("MINIMAX_API_KEY"),
                 base_url="https://api.minimax.io/v1",
-                model="minimax-m2.7",
+                model=model_override or "minimax-m2.7",
             )
         except ValueError:
             return None
@@ -498,7 +550,7 @@ def _create_summarizer() -> Optional[BaseSummarizer]:
             s = _make_openai_compat(
                 api_key=os.environ.get("ZHIPUAI_API_KEY"),
                 base_url="https://api.z.ai/api/paas/v4/",
-                model="glm-5",
+                model=model_override or "glm-5",
             )
         except ValueError:
             return None

--- a/src/jcodemunch_mcp/summarizer/batch_summarize.py
+++ b/src/jcodemunch_mcp/summarizer/batch_summarize.py
@@ -2,8 +2,9 @@
 
 import logging
 import os
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 from urllib.parse import urlparse
 
@@ -79,6 +80,30 @@ class BaseSummarizer:
     model: str = ""
     max_tokens_per_batch: int = 500
     client: object = None
+    _consecutive_failures: int = field(default=0, init=False, repr=False)
+    _circuit_broken: bool = field(default=False, init=False, repr=False)
+    _failure_lock: threading.Lock = field(
+        default_factory=threading.Lock, init=False, repr=False
+    )
+
+    def _record_success(self) -> None:
+        """Reset consecutive failure counter on a successful batch."""
+        with self._failure_lock:
+            self._consecutive_failures = 0
+
+    def _record_failure(self) -> None:
+        """Increment failure counter; trip circuit breaker if threshold reached."""
+        max_failures = _config.get("summarizer_max_failures", 3)
+        with self._failure_lock:
+            self._consecutive_failures += 1
+            if max_failures > 0 and self._consecutive_failures >= max_failures:
+                if not self._circuit_broken:
+                    logger.warning(
+                        "AI summarizer failed %d consecutive batches — "
+                        "disabling for remaining symbols (signature fallback)",
+                        self._consecutive_failures,
+                    )
+                self._circuit_broken = True
 
     def summarize_batch(
         self, symbols: list[Symbol], batch_size: int = 10
@@ -88,6 +113,8 @@ class BaseSummarizer:
         Only processes symbols that don't already have summaries.
         Uses concurrent requests for throughput (configurable via
         JCODEMUNCH_SUMMARIZER_CONCURRENCY, default 4).
+        Trips a circuit breaker after summarizer_max_failures (default 3)
+        consecutive failures, falling back to signature for all remaining.
         Returns updated symbols.
         """
         if not self.client:
@@ -109,17 +136,26 @@ class BaseSummarizer:
 
         if max_workers <= 1 or len(batches) <= 1:
             for batch in batches:
-                self._summarize_one_batch(batch)
+                self._run_batch(batch)
         else:
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
                 futures = {
-                    executor.submit(self._summarize_one_batch, batch): batch
+                    executor.submit(self._run_batch, batch): batch
                     for batch in batches
                 }
                 for future in as_completed(futures):
                     future.result()
 
         return symbols
+
+    def _run_batch(self, batch: list[Symbol]) -> None:
+        """Run a single batch with circuit breaker check."""
+        if self._circuit_broken:
+            for sym in batch:
+                if not sym.summary:
+                    sym.summary = signature_fallback(sym)
+            return
+        self._summarize_one_batch(batch)
 
     def _summarize_one_batch(self, batch: list[Symbol]):
         """Summarize one batch of symbols. Override in subclasses."""
@@ -246,8 +282,11 @@ class BatchSummarizer(BaseSummarizer):
                 else:
                     sym.summary = signature_fallback(sym)
 
+            self._record_success()
+
         except Exception as e:
             logger.warning("AI summarization failed, falling back to signature: %s", e)
+            self._record_failure()
             for sym in batch:
                 if not sym.summary:
                     sym.summary = signature_fallback(sym)
@@ -299,8 +338,11 @@ class GeminiBatchSummarizer(BaseSummarizer):
                 else:
                     sym.summary = signature_fallback(sym)
 
+            self._record_success()
+
         except Exception as e:
             logger.warning("AI summarization failed, falling back to signature: %s", e)
+            self._record_failure()
             for sym in batch:
                 if not sym.summary:
                     sym.summary = signature_fallback(sym)
@@ -466,8 +508,11 @@ class OpenAIBatchSummarizer(BaseSummarizer):
                 else:
                     sym.summary = signature_fallback(sym)
 
+            self._record_success()
+
         except Exception as e:
             logger.warning("AI summarization failed, falling back to signature: %s", e)
+            self._record_failure()
             for sym in batch:
                 if not sym.summary:
                     sym.summary = signature_fallback(sym)

--- a/src/jcodemunch_mcp/summarizer/batch_summarize.py
+++ b/src/jcodemunch_mcp/summarizer/batch_summarize.py
@@ -337,7 +337,10 @@ class OpenAIBatchSummarizer(BaseSummarizer):
                 )
                 self.api_base = None
                 return
-            if not self.api_base or self.api_base == os.environ.get("OPENAI_API_BASE", "").rstrip("/"):
+            cfg_model = (_config.get("summarizer_model", "") or "").strip()
+            if cfg_model:
+                self.model = cfg_model
+            elif not self.api_base or self.api_base == os.environ.get("OPENAI_API_BASE", "").rstrip("/"):
                 self.model = os.environ.get("OPENAI_MODEL", self.model)
             self.max_tokens_per_batch = int(
                 os.environ.get("OPENAI_MAX_TOKENS", str(self.max_tokens_per_batch))

--- a/src/jcodemunch_mcp/summarizer/batch_summarize.py
+++ b/src/jcodemunch_mcp/summarizer/batch_summarize.py
@@ -509,10 +509,17 @@ def _create_summarizer() -> Optional[BaseSummarizer]:
     if explicit_mode:
         # Use summarizer_provider from config; fall back to auto-detect if unset
         explicit_provider = (_config.get("summarizer_provider", "") or "").lower().strip()
-        if explicit_provider not in _VALID_PROVIDERS or explicit_provider == "":
+        if explicit_provider == "":
             logger.warning(
-                "use_ai_summaries is 'true' but summarizer_provider is not set; "
-                "falling back to auto-detect"
+                "use_ai_summaries is 'true' but summarizer_provider is not set; falling back to auto-detect"
+            )
+            name = get_provider_name()
+        elif explicit_provider not in _VALID_PROVIDERS:
+            logger.warning(
+                "summarizer_provider '%s' is not a valid provider; falling back to auto-detect. "
+                "Valid values: %s",
+                explicit_provider,
+                ", ".join(sorted(_VALID_PROVIDERS - {"none"})),
             )
             name = get_provider_name()
         else:
@@ -522,13 +529,9 @@ def _create_summarizer() -> Optional[BaseSummarizer]:
 
     if name == "anthropic":
         s = BatchSummarizer()
-        if model_override:
-            s.model = model_override
         return s if s.client else None
     if name == "gemini":
         s = GeminiBatchSummarizer()
-        if model_override:
-            s.model = model_override
         return s if s.client else None
     if name == "openai":
         s = _make_openai_compat(

--- a/src/jcodemunch_mcp/summarizer/batch_summarize.py
+++ b/src/jcodemunch_mcp/summarizer/batch_summarize.py
@@ -19,8 +19,9 @@ _AUTO_DETECT_ORDER = [
     ("OPENAI_API_BASE", "openai"),
     ("MINIMAX_API_KEY", "minimax"),
     ("ZHIPUAI_API_KEY", "glm"),
+    ("OPENROUTER_API_KEY", "openrouter"),
 ]
-_VALID_PROVIDERS = {"anthropic", "gemini", "openai", "minimax", "glm", "none"}
+_VALID_PROVIDERS = {"anthropic", "gemini", "openai", "minimax", "glm", "openrouter", "none"}
 
 
 def _is_localhost_url(url: str) -> bool:
@@ -560,6 +561,16 @@ def _create_summarizer() -> Optional[BaseSummarizer]:
         except ValueError:
             return None
         return s if s.client else None
+    if name == "openrouter":
+        try:
+            s = _make_openai_compat(
+                api_key=os.environ.get("OPENROUTER_API_KEY"),
+                base_url="https://openrouter.ai/api/v1",
+                model=model_override or "meta-llama/llama-3.3-70b-instruct:free",
+            )
+        except ValueError:
+            return None
+        return s if s.client else None
     return None
 
 
@@ -567,7 +578,7 @@ def get_provider_name() -> Optional[str]:
     """Return the active summarizer provider name, or None if disabled/unset.
 
     Priority: summarizer_provider config key > JCODEMUNCH_SUMMARIZER_PROVIDER env var > auto-detect by key.
-    Auto-detect order: Anthropic > Gemini > OpenAI-compatible > MiniMax > GLM-5.
+    Auto-detect order: Anthropic > Gemini > OpenAI-compatible > MiniMax > GLM-5 > OpenRouter.
     """
     explicit = (_config.get("summarizer_provider", "") or os.environ.get("JCODEMUNCH_SUMMARIZER_PROVIDER", "")).lower().strip()
     if explicit in _VALID_PROVIDERS:

--- a/src/jcodemunch_mcp/summarizer/batch_summarize.py
+++ b/src/jcodemunch_mcp/summarizer/batch_summarize.py
@@ -637,6 +637,7 @@ def summarize_symbols(symbols: list[Symbol], use_ai: bool = True) -> list[Symbol
       3. OPENAI provider/base                         → OpenAI-compatible endpoint
       4. MINIMAX_API_KEY set or provider=minimax     → MiniMax M2.7
       5. ZHIPUAI_API_KEY set or provider=glm         → GLM-5
+      6. OPENROUTER_API_KEY set or provider=openrouter → OpenRouter
       - None set               → skip to Tier 3
     """
     # Tier 1: Extract from docstrings

--- a/src/jcodemunch_mcp/tools/embed_repo.py
+++ b/src/jcodemunch_mcp/tools/embed_repo.py
@@ -10,6 +10,7 @@ import os
 import time
 from typing import Optional
 
+from .. import config as _config
 from ..storage import IndexStore
 from ._utils import resolve_repo
 
@@ -25,11 +26,11 @@ def _detect_provider() -> Optional[tuple[str, str]]:
     """Return (provider_name, model_name) or None when nothing is configured.
 
     Priority order (first match wins):
-    1. sentence-transformers  — ``JCODEMUNCH_EMBED_MODEL`` env var
+    1. sentence-transformers  — ``embed_model`` config key or ``JCODEMUNCH_EMBED_MODEL`` env var
     2. Gemini                 — ``GOOGLE_API_KEY`` + ``GOOGLE_EMBED_MODEL``
     3. OpenAI                 — ``OPENAI_API_KEY`` + ``OPENAI_EMBED_MODEL``
     """
-    st_model = os.environ.get("JCODEMUNCH_EMBED_MODEL", "").strip()
+    st_model = (_config.get("embed_model", "") or os.environ.get("JCODEMUNCH_EMBED_MODEL", "")).strip()
     if st_model:
         return ("sentence_transformers", st_model)
 

--- a/src/jcodemunch_mcp/tools/test_summarizer.py
+++ b/src/jcodemunch_mcp/tools/test_summarizer.py
@@ -1,0 +1,147 @@
+"""Diagnostic tool: verify AI summarizer configuration and connectivity."""
+
+import logging
+import time
+from typing import Any
+
+from .. import config as _config
+from ..parser.symbols import Symbol
+from ..summarizer.batch_summarize import (
+    _create_summarizer,
+    get_model_name,
+    get_provider_name,
+    signature_fallback,
+)
+
+logger = logging.getLogger(__name__)
+
+_TEST_SYMBOL = Symbol(
+    id="test::greet",
+    file="test.py",
+    name="greet",
+    qualified_name="greet",
+    kind="function",
+    language="python",
+    signature="def greet(name: str) -> str:",
+)
+
+
+def test_summarizer(timeout_ms: int = 15000) -> dict[str, Any]:
+    """Send a probe request to the configured AI summarizer and report the result.
+
+    Returns a dict with status, provider info, timing, and any error details.
+    """
+    result: dict[str, Any] = {
+        "status": "unknown",
+        "use_ai_summaries": None,
+        "provider": None,
+        "model": None,
+        "summary": None,
+        "elapsed_ms": None,
+        "error": None,
+    }
+
+    # Step 1: Check if AI summaries are enabled
+    raw = _config.get("use_ai_summaries", "auto")
+    result["use_ai_summaries"] = raw
+
+    if isinstance(raw, bool):
+        disabled = not raw
+    else:
+        disabled = str(raw).strip().lower() in ("false", "0", "no", "off")
+
+    if disabled:
+        result["status"] = "disabled"
+        result["error"] = (
+            "AI summarization is disabled (use_ai_summaries is false). "
+            "Set use_ai_summaries to \"auto\" or true to enable."
+        )
+        return result
+
+    # Step 2: Check provider detection
+    provider = get_provider_name()
+    result["provider"] = provider
+
+    if not provider:
+        result["status"] = "no_provider"
+        result["error"] = (
+            "No summarizer provider detected. "
+            "Set an API key (ANTHROPIC_API_KEY, GOOGLE_API_KEY, OPENAI_API_BASE, "
+            "MINIMAX_API_KEY, ZHIPUAI_API_KEY, OPENROUTER_API_KEY) "
+            "or configure summarizer_provider in your config file."
+        )
+        return result
+
+    # Step 3: Check model
+    model_override = get_model_name()
+    result["model"] = model_override or "(provider default)"
+
+    # Step 4: Try to create the summarizer
+    try:
+        summarizer = _create_summarizer()
+    except Exception as e:
+        result["status"] = "error"
+        result["error"] = f"Failed to create summarizer: {e}"
+        return result
+
+    if not summarizer:
+        result["status"] = "misconfigured"
+        result["error"] = (
+            f"Provider '{provider}' was detected but the summarizer could not be "
+            "initialized. Check that the required package is installed and the "
+            "API key is valid."
+        )
+        return result
+
+    result["model"] = summarizer.model
+
+    # Step 5: Send a test request
+    test_sym = Symbol(
+        id=_TEST_SYMBOL.id,
+        file=_TEST_SYMBOL.file,
+        name=_TEST_SYMBOL.name,
+        qualified_name=_TEST_SYMBOL.qualified_name,
+        kind=_TEST_SYMBOL.kind,
+        language=_TEST_SYMBOL.language,
+        signature=_TEST_SYMBOL.signature,
+    )
+
+    start = time.monotonic()
+    try:
+        summarizer.summarize_batch([test_sym], batch_size=1)
+        elapsed_ms = round((time.monotonic() - start) * 1000)
+        result["elapsed_ms"] = elapsed_ms
+    except Exception as e:
+        elapsed_ms = round((time.monotonic() - start) * 1000)
+        result["elapsed_ms"] = elapsed_ms
+        result["status"] = "error"
+        result["error"] = f"Summarization request failed after {elapsed_ms}ms: {e}"
+        return result
+
+    # Step 6: Evaluate the result
+    summary = test_sym.summary or ""
+    result["summary"] = summary
+
+    fallback = signature_fallback(_TEST_SYMBOL)
+    if not summary:
+        result["status"] = "error"
+        result["error"] = "AI returned an empty summary."
+    elif summary == fallback:
+        # Got signature fallback — AI call likely failed silently
+        result["status"] = "fallback"
+        result["error"] = (
+            f"AI did not produce a summary (fell back to signature: \"{fallback}\"). "
+            "This usually means the API returned an error or an unparseable response. "
+            "Check the server logs for details."
+        )
+    else:
+        result["status"] = "ok"
+
+    if elapsed_ms > timeout_ms:
+        result["status"] = "timeout"
+        result["error"] = (
+            f"AI responded but took {elapsed_ms}ms (threshold: {timeout_ms}ms). "
+            "Consider using a faster model or a closer endpoint."
+        )
+
+    return result

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -198,6 +198,12 @@ class TestConfigDefaults:
         assert DEFAULTS["summarizer_model"] == ""
         assert CONFIG_TYPES["summarizer_model"] is str
 
+    def test_default_use_ai_summaries(self):
+        """use_ai_summaries should default to 'auto'."""
+        from src.jcodemunch_mcp.config import DEFAULTS, CONFIG_TYPES
+        assert DEFAULTS["use_ai_summaries"] == "auto"
+        assert CONFIG_TYPES["use_ai_summaries"] == (bool, str)
+
 
 class TestConfigLoading:
     """Test config file loading."""
@@ -1272,7 +1278,10 @@ class TestConfigValidation:
             config_path = Path(tmpdir) / "config.jsonc"
             config_path.write_text('{"use_ai_summaries": "maybe"}')
             issues = validate_config(str(config_path))
-            assert any("type" in i.lower() or "invalid" in i.lower() for i in issues)
+            assert len(issues) == 1
+            assert "use_ai_summaries" in issues[0]
+            assert "'maybe'" in issues[0]
+            assert '"auto"' in issues[0]
 
     def test_validate_use_ai_summaries_string_yes_rejected(self):
         """"yes" should be rejected as invalid use_ai_summaries value."""
@@ -1284,7 +1293,10 @@ class TestConfigValidation:
             config_path = Path(tmpdir) / "config.jsonc"
             config_path.write_text('{"use_ai_summaries": "yes"}')
             issues = validate_config(str(config_path))
-            assert any("type" in i.lower() or "invalid" in i.lower() for i in issues)
+            assert len(issues) == 1
+            assert "use_ai_summaries" in issues[0]
+            assert "'yes'" in issues[0]
+            assert '"auto"' in issues[0]
 
 
 class TestServerConfigCheck:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -174,6 +174,24 @@ class TestConfigDefaults:
         from src.jcodemunch_mcp.config import DEFAULTS
         assert DEFAULTS["disabled_tools"] == []
 
+    def test_default_strict_timeout_ms(self):
+        """strict_timeout_ms should default to 500ms."""
+        from src.jcodemunch_mcp.config import DEFAULTS, CONFIG_TYPES
+        assert DEFAULTS["strict_timeout_ms"] == 500
+        assert CONFIG_TYPES["strict_timeout_ms"] is int
+
+    def test_default_summarizer_provider(self):
+        """summarizer_provider should default to empty string (auto-detect)."""
+        from src.jcodemunch_mcp.config import DEFAULTS, CONFIG_TYPES
+        assert DEFAULTS["summarizer_provider"] == ""
+        assert CONFIG_TYPES["summarizer_provider"] is str
+
+    def test_default_embed_model(self):
+        """embed_model should default to empty string (no sentence-transformers model)."""
+        from src.jcodemunch_mcp.config import DEFAULTS, CONFIG_TYPES
+        assert DEFAULTS["embed_model"] == ""
+        assert CONFIG_TYPES["embed_model"] is str
+
 
 class TestConfigLoading:
     """Test config file loading."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -218,7 +218,7 @@ class TestConfigLoading:
 
         # And defaults should be available
         assert get("max_folder_files") == 2000
-        assert get("use_ai_summaries") is True
+        assert get("use_ai_summaries") == "auto"
 
     def test_missing_file_uses_defaults(self, monkeypatch):
         """Should use defaults when config file doesn't exist."""
@@ -235,7 +235,7 @@ class TestConfigLoading:
             load_config(str(Path(tmpdir) / "nonexistent"))
 
             assert get("max_folder_files") == 2000
-            assert get("use_ai_summaries") is True
+            assert get("use_ai_summaries") == "auto"
 
     def test_loads_valid_config(self, monkeypatch):
         """Should load valid JSONC config."""
@@ -427,7 +427,7 @@ class TestProjectConfig:
             repo_key = str(project_root.resolve())
             assert get("max_folder_files", repo=repo_key) == 5000
             # Non-overridden values should come from global
-            assert get("use_ai_summaries", repo=repo_key) is True
+            assert get("use_ai_summaries", repo=repo_key) is True  # set explicitly in global config
 
 
 class TestConfigGetters:
@@ -1552,7 +1552,7 @@ class TestConfigTypeValidation:
     """Test config type validation for all config keys."""
 
     def test_bool_type_mismatch_string_true(self):
-        """String 'true' should be rejected for bool type."""
+        """String 'true' should be rejected for pure bool type."""
         from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
         import logging
 
@@ -1560,11 +1560,11 @@ class TestConfigTypeValidation:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             config_path = Path(tmpdir) / "config.jsonc"
-            config_path.write_text('{"use_ai_summaries": "true"}')  # String, not bool
+            config_path.write_text('{"context_providers": "true"}')  # String, not bool
 
             load_config(tmpdir)
             # Should fall back to default (True)
-            assert get("use_ai_summaries") is True
+            assert get("context_providers") is True
 
     def test_int_type_mismatch_float(self):
         """Float should be rejected for int type."""
@@ -1830,7 +1830,7 @@ class TestAllConfigKeys:
         from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
 
         bool_keys = [
-            "use_ai_summaries", "context_providers", "redact_source_root",
+            "context_providers", "redact_source_root",
             "share_savings", "allow_remote_summarizer", "watch"
         ]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -169,10 +169,10 @@ class TestConfigDefaults:
         from src.jcodemunch_mcp.config import DEFAULTS
         assert DEFAULTS["languages"] is None
 
-    def test_default_disabled_tools_is_empty(self):
-        """Should default to empty list (all tools enabled)."""
+    def test_default_disabled_tools(self):
+        """Should default to test_summarizer disabled."""
         from src.jcodemunch_mcp.config import DEFAULTS
-        assert DEFAULTS["disabled_tools"] == []
+        assert DEFAULTS["disabled_tools"] == ["test_summarizer"]
 
     def test_default_strict_timeout_ms(self):
         """strict_timeout_ms should default to 500ms."""
@@ -1740,7 +1740,7 @@ class TestConfigTypeValidation:
 
             load_config(tmpdir)
             # Should fall back to default
-            assert get("disabled_tools") == []
+            assert get("disabled_tools") == ["test_summarizer"]
 
     def test_dict_type_mismatch_list(self):
         """List should be rejected for dict type."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1519,6 +1519,26 @@ def test_parse_env_value_list_comma_separated_fallback():
     assert result == ["*.log", "*.tmp"]
 
 
+# ── use_ai_summaries env var preserves string values ──────────────────────────────
+
+
+def test_parse_env_value_use_ai_summaries_preserves_string():
+    """_parse_env_value returns raw string for use_ai_summaries to preserve 'auto'."""
+    from src.jcodemunch_mcp.config import _parse_env_value
+
+    # "auto" must be preserved as a string, not coerced to False by bool parsing
+    assert _parse_env_value("auto", (bool, str), key="use_ai_summaries") == "auto"
+
+    # "true" stored as string — downstream handlers accept both str and bool
+    assert _parse_env_value("true", (bool, str), key="use_ai_summaries") == "true"
+
+    # "false" stored as string
+    assert _parse_env_value("false", (bool, str), key="use_ai_summaries") == "false"
+
+    # Case-insensitive
+    assert _parse_env_value("AUTO", (bool, str), key="use_ai_summaries") == "auto"
+
+
 # ── Comprehensive Config File Edge Case Tests ────────────────────────────────────
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -192,6 +192,12 @@ class TestConfigDefaults:
         assert DEFAULTS["embed_model"] == ""
         assert CONFIG_TYPES["embed_model"] is str
 
+    def test_default_summarizer_model(self):
+        """summarizer_model should default to empty string."""
+        from src.jcodemunch_mcp.config import DEFAULTS, CONFIG_TYPES
+        assert DEFAULTS["summarizer_model"] == ""
+        assert CONFIG_TYPES["summarizer_model"] is str
+
 
 class TestConfigLoading:
     """Test config file loading."""
@@ -1183,6 +1189,102 @@ class TestConfigValidation:
             missing = Path(tmpdir) / "nonexistent.jsonc"
             issues = validate_config(str(missing))
             assert any("not found" in i.lower() for i in issues)
+
+    def test_validate_use_ai_summaries_bool_true_passes(self):
+        """True (bool) should pass use_ai_summaries validation."""
+        from src.jcodemunch_mcp.config import validate_config, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"use_ai_summaries": true}')
+            issues = validate_config(str(config_path))
+            assert issues == []
+
+    def test_validate_use_ai_summaries_bool_false_passes(self):
+        """False (bool) should pass use_ai_summaries validation."""
+        from src.jcodemunch_mcp.config import validate_config, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"use_ai_summaries": false}')
+            issues = validate_config(str(config_path))
+            assert issues == []
+
+    def test_validate_use_ai_summaries_string_auto_passes(self):
+        """"auto" (str) should pass use_ai_summaries validation."""
+        from src.jcodemunch_mcp.config import validate_config, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"use_ai_summaries": "auto"}')
+            issues = validate_config(str(config_path))
+            assert issues == []
+
+    def test_validate_use_ai_summaries_string_true_passes(self):
+        """"true" (str) should pass use_ai_summaries validation."""
+        from src.jcodemunch_mcp.config import validate_config, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"use_ai_summaries": "true"}')
+            issues = validate_config(str(config_path))
+            assert issues == []
+
+    def test_validate_use_ai_summaries_string_false_passes(self):
+        """"false" (str) should pass use_ai_summaries validation."""
+        from src.jcodemunch_mcp.config import validate_config, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"use_ai_summaries": "false"}')
+            issues = validate_config(str(config_path))
+            assert issues == []
+
+    def test_validate_use_ai_summaries_string_auto_uppercase_passes(self):
+        """"AUTO" (uppercase) should pass use_ai_summaries validation (case-insensitive)."""
+        from src.jcodemunch_mcp.config import validate_config, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"use_ai_summaries": "AUTO"}')
+            issues = validate_config(str(config_path))
+            assert issues == []
+
+    def test_validate_use_ai_summaries_string_maybe_rejected(self):
+        """"maybe" should be rejected as invalid use_ai_summaries value."""
+        from src.jcodemunch_mcp.config import validate_config, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"use_ai_summaries": "maybe"}')
+            issues = validate_config(str(config_path))
+            assert any("type" in i.lower() or "invalid" in i.lower() for i in issues)
+
+    def test_validate_use_ai_summaries_string_yes_rejected(self):
+        """"yes" should be rejected as invalid use_ai_summaries value."""
+        from src.jcodemunch_mcp.config import validate_config, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text('{"use_ai_summaries": "yes"}')
+            issues = validate_config(str(config_path))
+            assert any("type" in i.lower() or "invalid" in i.lower() for i in issues)
 
 
 class TestServerConfigCheck:

--- a/tests/test_reindex_state.py
+++ b/tests/test_reindex_state.py
@@ -211,6 +211,19 @@ class TestFreshnessMode:
         t.join()
         assert elapsed >= 0.03
 
+    def test_await_strict_respects_custom_timeout(self):
+        """A short custom timeout should expire before reindex completes."""
+        set_freshness_mode("strict")
+        mark_reindex_start("test/repo2")
+        t0 = time.monotonic()
+        # Reindex never completes; timeout_ms=50 should expire quickly
+        await_freshness_if_strict("test/repo2", timeout_ms=50)
+        elapsed = time.monotonic() - t0
+        # Should have returned after ~50ms, not blocked indefinitely
+        assert elapsed < 0.5
+        # Cleanup: unblock the event so other tests aren't affected
+        mark_reindex_done("test/repo2")
+
 
 class TestWaitForFreshResult:
     def test_returns_fresh_when_unknown_repo(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,7 @@ from jcodemunch_mcp.server import server, list_tools, call_tool, _coerce_argumen
 
 @pytest.mark.asyncio
 async def test_server_lists_all_tools():
-    """Test that server lists all 30 tools."""
+    """Test that server lists all 30 enabled tools (test_summarizer disabled by default)."""
     tools = await list_tools()
 
     assert len(tools) == 30
@@ -27,6 +27,7 @@ async def test_server_lists_all_tools():
         "get_changed_symbols", "get_ranked_context", "embed_repo",
     }
     assert names == expected
+    assert "test_summarizer" not in names  # disabled by default
 
 
 @pytest.mark.asyncio
@@ -637,8 +638,8 @@ async def test_disabled_tools_filtered_from_schema(monkeypatch):
         assert "index_repo" not in tool_names
         assert "search_columns" not in tool_names
         assert "get_file_tree" in tool_names  # Not disabled
-        # Total should be 28 (30 - 2 disabled)
-        assert len(tools) == 28
+        # Total should be 29 (31 - 2 disabled)
+        assert len(tools) == 29
     finally:
         config_module._GLOBAL_CONFIG.clear()
         config_module._GLOBAL_CONFIG.update(orig_config)
@@ -646,7 +647,7 @@ async def test_disabled_tools_filtered_from_schema(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_disabled_tools_empty_all_tools_present(monkeypatch):
-    """When disabled_tools is empty, all 30 tools are present."""
+    """When disabled_tools is empty, all 31 tools are present."""
     from jcodemunch_mcp import config as config_module
 
     orig_config = config_module._GLOBAL_CONFIG.copy()
@@ -656,7 +657,7 @@ async def test_disabled_tools_empty_all_tools_present(monkeypatch):
         config_module._GLOBAL_CONFIG["disabled_tools"] = []
 
         tools = await list_tools()
-        assert len(tools) == 30
+        assert len(tools) == 31
     finally:
         config_module._GLOBAL_CONFIG.clear()
         config_module._GLOBAL_CONFIG.update(orig_config)

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -939,3 +939,123 @@ def test_create_summarizer_explicit_true_no_provider_warns_and_autodetects(monke
         result = _create_summarizer()
     assert result is None
     assert "summarizer_provider is not set" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Per-provider model override tests
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_model_override_via_config():
+    """summarizer_model config takes priority over ANTHROPIC_MODEL env var for Anthropic."""
+    import sys
+
+    mock_anthropic_module = MagicMock()
+    mock_client = MagicMock()
+    mock_anthropic_module.Anthropic.return_value = mock_client
+
+    with patch.dict(sys.modules, {"anthropic": mock_anthropic_module}):
+        with patch.dict(
+            "os.environ",
+            {"ANTHROPIC_API_KEY": "sk-test", "ANTHROPIC_MODEL": "claude-haiku-fallback"},
+            clear=True,
+        ):
+            with patch(
+                "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+                side_effect=lambda k, d=None: "claude-override-model" if k == "summarizer_model" else d,
+            ):
+                from jcodemunch_mcp.summarizer.batch_summarize import BatchSummarizer
+
+                summarizer = BatchSummarizer()
+
+    assert summarizer.model == "claude-override-model"
+    assert summarizer.client is mock_client
+
+
+def test_gemini_model_override_via_config():
+    """summarizer_model config takes priority over GOOGLE_MODEL env var for Gemini."""
+    import sys
+
+    mock_genai_module = MagicMock()
+    mock_genai_model_instance = MagicMock()
+    mock_genai_module.GenerativeModel.return_value = mock_genai_model_instance
+
+    # Build a google package mock that exposes generativeai as an attribute
+    mock_google_pkg = MagicMock()
+    mock_google_pkg.generativeai = mock_genai_module
+
+    with patch.dict(
+        sys.modules,
+        {"google": mock_google_pkg, "google.generativeai": mock_genai_module},
+    ):
+        with patch.dict(
+            "os.environ",
+            {"GOOGLE_API_KEY": "gkey-test", "GOOGLE_MODEL": "gemini-fallback"},
+            clear=True,
+        ):
+            with patch(
+                "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+                side_effect=lambda k, d=None: "gemini-override-model" if k == "summarizer_model" else d,
+            ):
+                from jcodemunch_mcp.summarizer.batch_summarize import GeminiBatchSummarizer
+
+                summarizer = GeminiBatchSummarizer()
+
+    # The client must be the instance created with the override model
+    assert summarizer.model == "gemini-override-model"
+    mock_genai_module.GenerativeModel.assert_called_once_with("gemini-override-model")
+    assert summarizer.client is mock_genai_model_instance
+
+
+def test_openai_model_override_via_config(monkeypatch):
+    """summarizer_model config is applied to _create_summarizer() for the OpenAI provider."""
+    monkeypatch.setenv("OPENAI_API_BASE", "http://localhost:11434/v1")
+    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+    with patch(
+        "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+        side_effect=lambda k, d=None: (
+            "auto" if k == "use_ai_summaries"
+            else "my-openai-override" if k == "summarizer_model"
+            else d
+        ),
+    ):
+        s = _create_summarizer()
+
+    assert s is not None
+    assert isinstance(s, OpenAIBatchSummarizer)
+    assert s.model == "my-openai-override"
+
+
+def test_minimax_model_override_via_config(monkeypatch):
+    """summarizer_model config is applied to _create_summarizer() for the MiniMax provider."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "mm-test-key")
+    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "ZHIPUAI_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+    from jcodemunch_mcp import config as _cfg_module
+
+    _sentinel = object()
+    _orig = _cfg_module._GLOBAL_CONFIG.get("allow_remote_summarizer", _sentinel)
+    try:
+        _cfg_module._GLOBAL_CONFIG["allow_remote_summarizer"] = True
+        with patch(
+            "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+            side_effect=lambda k, d=None: (
+                "auto" if k == "use_ai_summaries"
+                else "minimax-m3" if k == "summarizer_model"
+                else True if k == "allow_remote_summarizer"
+                else d
+            ),
+        ):
+            s = _create_summarizer()
+    finally:
+        if _orig is _sentinel:
+            _cfg_module._GLOBAL_CONFIG.pop("allow_remote_summarizer", None)
+        else:
+            _cfg_module._GLOBAL_CONFIG["allow_remote_summarizer"] = _orig
+
+    assert s is not None
+    assert isinstance(s, OpenAIBatchSummarizer)
+    assert s.model == "minimax-m3"

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -323,7 +323,7 @@ def test_openai_summarizer_with_mock_client():
         "os.environ",
         {"OPENAI_API_BASE": "http://localhost:11434/v1", "OPENAI_MODEL": "qwen3-coder"},
         clear=True,
-    ):
+    ), patch.object(OpenAIBatchSummarizer, "_init_client"):
         summarizer = OpenAIBatchSummarizer()
         summarizer.client = mock_client
 
@@ -589,11 +589,12 @@ def test_openai_summarizer_explicit_openai_provider_uses_default_api_base():
     ):
         try:
             _cfg_module._GLOBAL_CONFIG["allow_remote_summarizer"] = True
-            summarizer = OpenAIBatchSummarizer(
-                model="gpt-4o-mini",
-                api_base="https://api.openai.com/v1",
-                api_key="sk-test",
-            )
+            with patch.object(OpenAIBatchSummarizer, "_init_client"):
+                summarizer = OpenAIBatchSummarizer(
+                    model="gpt-4o-mini",
+                    api_base="https://api.openai.com/v1",
+                    api_key="sk-test",
+                )
             summarizer.client = mock_client
         finally:
             if _orig is _sentinel:
@@ -643,11 +644,12 @@ def test_openai_summarizer_minimax_provider_defaults():
     ):
         try:
             _cfg_module._GLOBAL_CONFIG["allow_remote_summarizer"] = True
-            summarizer = OpenAIBatchSummarizer(
-                model="minimax-m2.7",
-                api_base="https://api.minimax.io/v1",
-                api_key="test-key",
-            )
+            with patch.object(OpenAIBatchSummarizer, "_init_client"):
+                summarizer = OpenAIBatchSummarizer(
+                    model="minimax-m2.7",
+                    api_base="https://api.minimax.io/v1",
+                    api_key="test-key",
+                )
             summarizer.client = mock_client
         finally:
             if _orig is _sentinel:
@@ -698,11 +700,12 @@ def test_openai_summarizer_glm_provider_defaults():
     ):
         try:
             _cfg_module._GLOBAL_CONFIG["allow_remote_summarizer"] = True
-            summarizer = OpenAIBatchSummarizer(
-                model="glm-5",
-                api_base="https://api.z.ai/api/paas/v4/",
-                api_key="test-key",
-            )
+            with patch.object(OpenAIBatchSummarizer, "_init_client"):
+                summarizer = OpenAIBatchSummarizer(
+                    model="glm-5",
+                    api_base="https://api.z.ai/api/paas/v4/",
+                    api_key="test-key",
+                )
             summarizer.client = mock_client
         finally:
             if _orig is _sentinel:
@@ -774,6 +777,7 @@ def test_openai_summarizer_timeout_config():
     # Test valid float parsing
     # The summarizer reads config.get("allow_remote_summarizer") — patch it
     # alongside the env vars so the non-localhost URL is accepted.
+    # Mock httpx.Client to capture the timeout kwarg without creating a real SSL context.
     with patch.dict(
         "os.environ",
         {
@@ -782,10 +786,12 @@ def test_openai_summarizer_timeout_config():
         },
         clear=True,
     ), patch("jcodemunch_mcp.summarizer.batch_summarize._config.get",
-             side_effect=lambda k, d=None: True if k == "allow_remote_summarizer" else d):
+             side_effect=lambda k, d=None: True if k == "allow_remote_summarizer" else d), \
+         patch("httpx.Client") as mock_httpx:
         summarizer = OpenAIBatchSummarizer()
         assert summarizer.client is not None
-        assert summarizer.client.timeout.read == 120.5
+        call_kwargs = mock_httpx.call_args
+        assert call_kwargs[1]["timeout"] == 120.5
 
     # Test invalid string fallback
     with patch.dict(
@@ -796,10 +802,12 @@ def test_openai_summarizer_timeout_config():
         },
         clear=True,
     ), patch("jcodemunch_mcp.summarizer.batch_summarize._config.get",
-             side_effect=lambda k, d=None: True if k == "allow_remote_summarizer" else d):
+             side_effect=lambda k, d=None: True if k == "allow_remote_summarizer" else d), \
+         patch("httpx.Client") as mock_httpx:
         summarizer = OpenAIBatchSummarizer()
         assert summarizer.client is not None
-        assert summarizer.client.timeout.read == 60.0
+        call_kwargs = mock_httpx.call_args
+        assert call_kwargs[1]["timeout"] == 60.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -11,7 +11,7 @@ from jcodemunch_mcp.summarizer import (
     GeminiBatchSummarizer,
     OpenAIBatchSummarizer,
 )
-from jcodemunch_mcp.summarizer.batch_summarize import _create_summarizer
+from jcodemunch_mcp.summarizer.batch_summarize import _create_summarizer, get_model_name
 
 
 def test_extract_summary_from_docstring_simple():
@@ -800,3 +800,142 @@ def test_openai_summarizer_timeout_config():
         summarizer = OpenAIBatchSummarizer()
         assert summarizer.client is not None
         assert summarizer.client.timeout.read == 60.0
+
+
+# ---------------------------------------------------------------------------
+# Tests for get_model_name() and tri-state use_ai_summaries
+# ---------------------------------------------------------------------------
+
+
+def test_get_model_name_returns_none_when_empty():
+    """get_model_name() returns None when summarizer_model config is empty."""
+    with patch(
+        "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+        side_effect=lambda k, d=None: "" if k == "summarizer_model" else d,
+    ):
+        assert get_model_name() is None
+
+
+def test_get_model_name_returns_value_when_set():
+    """get_model_name() returns the model string when summarizer_model is configured."""
+    with patch(
+        "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+        side_effect=lambda k, d=None: "my-custom-model" if k == "summarizer_model" else d,
+    ):
+        assert get_model_name() == "my-custom-model"
+
+
+def test_get_model_name_strips_whitespace():
+    """get_model_name() strips surrounding whitespace from the model value."""
+    with patch(
+        "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+        side_effect=lambda k, d=None: "  claude-haiku  " if k == "summarizer_model" else d,
+    ):
+        assert get_model_name() == "claude-haiku"
+
+
+def test_create_summarizer_disabled_when_false():
+    """_create_summarizer() returns None when use_ai_summaries is False (bool)."""
+    with patch(
+        "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+        side_effect=lambda k, d=None: False if k == "use_ai_summaries" else d,
+    ):
+        assert _create_summarizer() is None
+
+
+def test_create_summarizer_disabled_when_string_false():
+    """_create_summarizer() returns None when use_ai_summaries is the string 'false'."""
+    with patch(
+        "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+        side_effect=lambda k, d=None: "false" if k == "use_ai_summaries" else d,
+    ):
+        assert _create_summarizer() is None
+
+
+def test_create_summarizer_auto_mode_no_providers(monkeypatch):
+    """_create_summarizer() with use_ai_summaries='auto' returns None when no providers configured."""
+    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    with patch(
+        "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+        side_effect=lambda k, d=None: "auto" if k == "use_ai_summaries" else d,
+    ):
+        assert _create_summarizer() is None
+
+
+def test_create_summarizer_auto_mode_detects_provider(monkeypatch):
+    """_create_summarizer() with use_ai_summaries='auto' picks up auto-detected provider."""
+    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("ZHIPUAI_API_KEY", "test-key")
+    from jcodemunch_mcp import config as _cfg_module
+    _sentinel = object()
+    _orig = _cfg_module._GLOBAL_CONFIG.get("allow_remote_summarizer", _sentinel)
+    try:
+        _cfg_module._GLOBAL_CONFIG["allow_remote_summarizer"] = True
+        with patch(
+            "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+            side_effect=lambda k, d=None: (
+                "auto" if k == "use_ai_summaries"
+                else "" if k == "summarizer_model"
+                else True if k == "allow_remote_summarizer"
+                else d
+            ),
+        ):
+            s = _create_summarizer()
+    finally:
+        if _orig is _sentinel:
+            _cfg_module._GLOBAL_CONFIG.pop("allow_remote_summarizer", None)
+        else:
+            _cfg_module._GLOBAL_CONFIG["allow_remote_summarizer"] = _orig
+    # GLM provider — OpenAIBatchSummarizer with the glm endpoint
+    assert s is not None
+    assert isinstance(s, OpenAIBatchSummarizer)
+    assert s.model == "glm-5"
+
+
+def test_create_summarizer_model_override_applied_to_glm(monkeypatch):
+    """summarizer_model config override is applied to the created GLM summarizer."""
+    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("ZHIPUAI_API_KEY", "test-key")
+    from jcodemunch_mcp import config as _cfg_module
+    _sentinel = object()
+    _orig = _cfg_module._GLOBAL_CONFIG.get("allow_remote_summarizer", _sentinel)
+    try:
+        _cfg_module._GLOBAL_CONFIG["allow_remote_summarizer"] = True
+        with patch(
+            "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+            side_effect=lambda k, d=None: (
+                "auto" if k == "use_ai_summaries"
+                else "glm-6-turbo" if k == "summarizer_model"
+                else True if k == "allow_remote_summarizer"
+                else d
+            ),
+        ):
+            s = _create_summarizer()
+    finally:
+        if _orig is _sentinel:
+            _cfg_module._GLOBAL_CONFIG.pop("allow_remote_summarizer", None)
+        else:
+            _cfg_module._GLOBAL_CONFIG["allow_remote_summarizer"] = _orig
+    assert s is not None
+    assert s.model == "glm-6-turbo"
+
+
+def test_create_summarizer_explicit_true_no_provider_warns_and_autodetects(monkeypatch, caplog):
+    """use_ai_summaries=True with no summarizer_provider logs warning and falls back to auto-detect."""
+    import logging
+    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    with patch(
+        "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+        side_effect=lambda k, d=None: (
+            True if k == "use_ai_summaries"
+            else "" if k in ("summarizer_provider", "summarizer_model")
+            else d
+        ),
+    ), caplog.at_level(logging.WARNING, logger="jcodemunch_mcp.summarizer.batch_summarize"):
+        result = _create_summarizer()
+    assert result is None
+    assert "summarizer_provider is not set" in caplog.text

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1174,3 +1174,120 @@ def test_summarizer_model_config_beats_openai_model_env(monkeypatch):
     assert s.model == "config-model-wins", (
         f"Expected summarizer_model config to win over OPENAI_MODEL env var, got {s.model!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker tests
+# ---------------------------------------------------------------------------
+
+
+def _make_symbols(n: int) -> list[Symbol]:
+    """Create n test symbols without summaries."""
+    return [
+        Symbol(
+            id=f"test::sym{i}",
+            file="test.py",
+            name=f"sym{i}",
+            qualified_name=f"sym{i}",
+            kind="function",
+            language="python",
+            signature=f"def sym{i}():",
+        )
+        for i in range(n)
+    ]
+
+
+def test_circuit_breaker_trips_after_consecutive_failures():
+    """After 3 consecutive failures, remaining batches get signature fallback without API calls."""
+    from jcodemunch_mcp.summarizer.batch_summarize import BaseSummarizer
+
+    class FailingSummarizer(BaseSummarizer):
+        call_count = 0
+
+        def _summarize_one_batch(self, batch):
+            self.call_count += 1
+            try:
+                raise RuntimeError("API is down")
+            except Exception:
+                self._record_failure()
+                for sym in batch:
+                    if not sym.summary:
+                        sym.summary = signature_fallback(sym)
+
+    summarizer = FailingSummarizer(client=object())  # non-None client
+    symbols = _make_symbols(50)  # 50 symbols / batch_size=10 = 5 batches
+
+    with patch(
+        "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+        side_effect=lambda k, d=None: 3 if k == "summarizer_max_failures" else 1 if k == "summarizer_concurrency" else d,
+    ):
+        summarizer.summarize_batch(symbols, batch_size=10)
+
+    # Circuit should trip after 3 failures — batches 4 and 5 are skipped
+    assert summarizer.call_count == 3
+    assert summarizer._circuit_broken is True
+    # All symbols should still have summaries (signature fallback)
+    assert all(sym.summary for sym in symbols)
+
+
+def test_circuit_breaker_resets_on_success():
+    """A successful batch resets the failure counter."""
+    from jcodemunch_mcp.summarizer.batch_summarize import BaseSummarizer
+
+    class FlakySummarizer(BaseSummarizer):
+        call_count = 0
+
+        def _summarize_one_batch(self, batch):
+            self.call_count += 1
+            if self.call_count in (1, 2, 4, 5):
+                # Fail batches 1, 2, 4, 5 — but succeed on 3 (resets counter)
+                self._record_failure()
+                for sym in batch:
+                    if not sym.summary:
+                        sym.summary = signature_fallback(sym)
+                return
+            for sym in batch:
+                sym.summary = "AI summary"
+            self._record_success()
+
+    summarizer = FlakySummarizer(client=object())
+    symbols = _make_symbols(60)  # 6 batches
+
+    with patch(
+        "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+        side_effect=lambda k, d=None: 3 if k == "summarizer_max_failures" else 1 if k == "summarizer_concurrency" else d,
+    ):
+        summarizer.summarize_batch(symbols, batch_size=10)
+
+    # All 6 batches attempted because batch 3 resets the counter
+    # Failures: 1,2 (count=2), success 3 (reset), failures 4,5 (count=2), batch 6 runs
+    assert summarizer.call_count == 6
+    assert summarizer._circuit_broken is False
+
+
+def test_circuit_breaker_disabled_when_zero():
+    """Setting summarizer_max_failures=0 disables the circuit breaker."""
+    from jcodemunch_mcp.summarizer.batch_summarize import BaseSummarizer
+
+    class AlwaysFailSummarizer(BaseSummarizer):
+        call_count = 0
+
+        def _summarize_one_batch(self, batch):
+            self.call_count += 1
+            self._record_failure()
+            for sym in batch:
+                if not sym.summary:
+                    sym.summary = signature_fallback(sym)
+
+    summarizer = AlwaysFailSummarizer(client=object())
+    symbols = _make_symbols(50)  # 5 batches
+
+    with patch(
+        "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+        side_effect=lambda k, d=None: 0 if k == "summarizer_max_failures" else 1 if k == "summarizer_concurrency" else d,
+    ):
+        summarizer.summarize_batch(symbols, batch_size=10)
+
+    # All 5 batches attempted — circuit never trips
+    assert summarizer.call_count == 5
+    assert summarizer._circuit_broken is False

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1150,3 +1150,27 @@ def test_minimax_model_override_via_config(monkeypatch):
     assert s is not None
     assert isinstance(s, OpenAIBatchSummarizer)
     assert s.model == "minimax-m3"
+
+
+def test_summarizer_model_config_beats_openai_model_env(monkeypatch):
+    """summarizer_model config takes priority over OPENAI_MODEL env var in OpenAI provider."""
+    monkeypatch.setenv("OPENAI_API_BASE", "http://localhost:11434/v1")
+    monkeypatch.setenv("OPENAI_MODEL", "env-model-should-lose")
+    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY", "OPENROUTER_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+    with patch(
+        "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+        side_effect=lambda k, d=None: (
+            "auto" if k == "use_ai_summaries"
+            else "config-model-wins" if k == "summarizer_model"
+            else d
+        ),
+    ):
+        s = _create_summarizer()
+
+    assert s is not None
+    assert isinstance(s, OpenAIBatchSummarizer)
+    assert s.model == "config-model-wins", (
+        f"Expected summarizer_model config to win over OPENAI_MODEL env var, got {s.model!r}"
+    )

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -834,6 +834,13 @@ def test_get_model_name_strips_whitespace():
         assert get_model_name() == "claude-haiku"
 
 
+def test_get_model_name_returns_none_for_whitespace_only():
+    """get_model_name returns None for whitespace-only config value."""
+    from jcodemunch_mcp import config as _cfg_module
+    with patch.object(_cfg_module, "_GLOBAL_CONFIG", {"summarizer_model": "   "}):
+        assert get_model_name() is None
+
+
 def test_create_summarizer_disabled_when_false():
     """_create_summarizer() returns None when use_ai_summaries is False (bool)."""
     with patch(
@@ -843,11 +850,12 @@ def test_create_summarizer_disabled_when_false():
         assert _create_summarizer() is None
 
 
-def test_create_summarizer_disabled_when_string_false():
-    """_create_summarizer() returns None when use_ai_summaries is the string 'false'."""
+@pytest.mark.parametrize("falsy_val", ["false", "0", "no", "off"])
+def test_create_summarizer_disabled_when_string_false(falsy_val):
+    """_create_summarizer() returns None for each falsy string value of use_ai_summaries."""
     with patch(
         "jcodemunch_mcp.summarizer.batch_summarize._config.get",
-        side_effect=lambda k, d=None: "false" if k == "use_ai_summaries" else d,
+        side_effect=lambda k, d=None: falsy_val if k == "use_ai_summaries" else d,
     ):
         assert _create_summarizer() is None
 

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1291,3 +1291,100 @@ def test_circuit_breaker_disabled_when_zero():
     # All 5 batches attempted — circuit never trips
     assert summarizer.call_count == 5
     assert summarizer._circuit_broken is False
+
+
+# ---------------------------------------------------------------------------
+# test_summarizer diagnostic tool
+# ---------------------------------------------------------------------------
+
+
+def test_test_summarizer_disabled():
+    """test_summarizer returns disabled status when use_ai_summaries is false."""
+    from jcodemunch_mcp.tools.test_summarizer import test_summarizer as run_test
+
+    with patch(
+        "jcodemunch_mcp.tools.test_summarizer._config.get",
+        side_effect=lambda k, d=None: "false" if k == "use_ai_summaries" else d,
+    ):
+        result = run_test()
+
+    assert result["status"] == "disabled"
+    assert result["error"] is not None
+
+
+def test_test_summarizer_no_provider():
+    """test_summarizer returns no_provider when no API keys are set."""
+    from jcodemunch_mcp.tools.test_summarizer import test_summarizer as run_test
+
+    with patch(
+        "jcodemunch_mcp.tools.test_summarizer._config.get",
+        side_effect=lambda k, d=None: "auto" if k == "use_ai_summaries" else d,
+    ), patch(
+        "jcodemunch_mcp.tools.test_summarizer.get_provider_name",
+        return_value=None,
+    ):
+        result = run_test()
+
+    assert result["status"] == "no_provider"
+
+
+def test_test_summarizer_ok():
+    """test_summarizer returns ok when AI produces a real summary."""
+    from jcodemunch_mcp.tools.test_summarizer import test_summarizer as run_test
+
+    mock_summarizer = MagicMock()
+    mock_summarizer.model = "test-model"
+
+    def fake_summarize(symbols, batch_size=1):
+        for sym in symbols:
+            sym.summary = "Greets the user by name."
+        return symbols
+
+    mock_summarizer.summarize_batch.side_effect = fake_summarize
+
+    with patch(
+        "jcodemunch_mcp.tools.test_summarizer._config.get",
+        side_effect=lambda k, d=None: "auto" if k == "use_ai_summaries" else d,
+    ), patch(
+        "jcodemunch_mcp.tools.test_summarizer.get_provider_name",
+        return_value="anthropic",
+    ), patch(
+        "jcodemunch_mcp.tools.test_summarizer._create_summarizer",
+        return_value=mock_summarizer,
+    ):
+        result = run_test()
+
+    assert result["status"] == "ok"
+    assert result["provider"] == "anthropic"
+    assert result["summary"] == "Greets the user by name."
+    assert result["elapsed_ms"] is not None
+
+
+def test_test_summarizer_fallback():
+    """test_summarizer detects when AI fell back to signature."""
+    from jcodemunch_mcp.tools.test_summarizer import test_summarizer as run_test
+
+    mock_summarizer = MagicMock()
+    mock_summarizer.model = "test-model"
+
+    def fake_fallback(symbols, batch_size=1):
+        for sym in symbols:
+            sym.summary = "def greet(name: str) -> str:"  # signature = fallback
+        return symbols
+
+    mock_summarizer.summarize_batch.side_effect = fake_fallback
+
+    with patch(
+        "jcodemunch_mcp.tools.test_summarizer._config.get",
+        side_effect=lambda k, d=None: "auto" if k == "use_ai_summaries" else d,
+    ), patch(
+        "jcodemunch_mcp.tools.test_summarizer.get_provider_name",
+        return_value="openrouter",
+    ), patch(
+        "jcodemunch_mcp.tools.test_summarizer._create_summarizer",
+        return_value=mock_summarizer,
+    ):
+        result = run_test()
+
+    assert result["status"] == "fallback"
+    assert "signature" in result["error"].lower()

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -225,7 +225,7 @@ def test_get_provider_name_none_disables(monkeypatch):
 
 def test_get_provider_name_unknown_falls_back_to_auto(monkeypatch):
     """Unknown explicit values should fall back to auto-detection."""
-    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "ZHIPUAI_API_KEY"):
+    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "ZHIPUAI_API_KEY", "OPENROUTER_API_KEY"):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("JCODEMUNCH_SUMMARIZER_PROVIDER", "unknown-provider")
     monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
@@ -277,14 +277,33 @@ def test_get_provider_name_auto_detect_glm(monkeypatch):
     assert get_provider_name() == "glm"
 
 
+def test_get_provider_name_auto_detect_openrouter(monkeypatch):
+    """OpenRouter should be detected when it is the only configured provider."""
+    for key in (
+        "JCODEMUNCH_SUMMARIZER_PROVIDER",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "OPENAI_API_BASE",
+        "MINIMAX_API_KEY",
+        "ZHIPUAI_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    assert get_provider_name() == "openrouter"
+
+
 def test_create_summarizer_explicit_provider_missing_key_returns_none(monkeypatch):
-    """Explicit minimax/glm provider selection should degrade gracefully without keys."""
+    """Explicit minimax/glm/openrouter provider selection should degrade gracefully without keys."""
     monkeypatch.setenv("JCODEMUNCH_SUMMARIZER_PROVIDER", "minimax")
     monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
     assert _create_summarizer() is None
 
     monkeypatch.setenv("JCODEMUNCH_SUMMARIZER_PROVIDER", "glm")
     monkeypatch.delenv("ZHIPUAI_API_KEY", raising=False)
+    assert _create_summarizer() is None
+
+    monkeypatch.setenv("JCODEMUNCH_SUMMARIZER_PROVIDER", "openrouter")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     assert _create_summarizer() is None
 
 
@@ -732,6 +751,62 @@ def test_openai_summarizer_glm_provider_defaults():
     assert symbols[0].summary == "Uses the GLM endpoint."
 
 
+def test_openai_summarizer_openrouter_provider_defaults():
+    """OpenRouter should use its fixed API base and default free model."""
+    from jcodemunch_mcp import config as _cfg_module
+
+    _sentinel = object()
+    _orig = _cfg_module._GLOBAL_CONFIG.get("allow_remote_summarizer", _sentinel)
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "choices": [{"message": {"content": "1. Uses the OpenRouter endpoint."}}]
+    }
+
+    mock_client = MagicMock()
+    mock_client.post.return_value = mock_response
+
+    with patch.dict(
+        "os.environ",
+        {
+            "OPENROUTER_API_KEY": "test-key",
+            "JCODEMUNCH_ALLOW_REMOTE_SUMMARIZER": "1",
+        },
+        clear=True,
+    ):
+        try:
+            _cfg_module._GLOBAL_CONFIG["allow_remote_summarizer"] = True
+            with patch.object(OpenAIBatchSummarizer, "_init_client"):
+                summarizer = OpenAIBatchSummarizer(
+                    model="meta-llama/llama-3.3-70b-instruct:free",
+                    api_base="https://openrouter.ai/api/v1",
+                    api_key="test-key",
+                )
+            summarizer.client = mock_client
+        finally:
+            if _orig is _sentinel:
+                _cfg_module._GLOBAL_CONFIG.pop("allow_remote_summarizer", None)
+            else:
+                _cfg_module._GLOBAL_CONFIG["allow_remote_summarizer"] = _orig
+
+    symbols = [
+        Symbol(
+            id="test::openrouter",
+            file="test.py",
+            name="openrouter",
+            qualified_name="openrouter",
+            kind="function",
+            language="python",
+            signature="def openrouter():",
+        )
+    ]
+    summarizer.summarize_batch(symbols)
+
+    mock_client.post.assert_called_once()
+    assert mock_client.post.call_args[0][0] == "https://openrouter.ai/api/v1/chat/completions"
+    assert mock_client.post.call_args[1]["json"]["model"] == "meta-llama/llama-3.3-70b-instruct:free"
+    assert symbols[0].summary == "Uses the OpenRouter endpoint."
+
+
 def test_openai_summarizer_remote_endpoint_requires_allow_flag():
     """Non-localhost OpenAI endpoints are ignored without the allow flag."""
     from jcodemunch_mcp import config as _cfg_module
@@ -870,7 +945,7 @@ def test_create_summarizer_disabled_when_string_false(falsy_val):
 
 def test_create_summarizer_auto_mode_no_providers(monkeypatch):
     """_create_summarizer() with use_ai_summaries='auto' returns None when no providers configured."""
-    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY"):
+    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY", "OPENROUTER_API_KEY"):
         monkeypatch.delenv(key, raising=False)
     with patch(
         "jcodemunch_mcp.summarizer.batch_summarize._config.get",
@@ -881,7 +956,7 @@ def test_create_summarizer_auto_mode_no_providers(monkeypatch):
 
 def test_create_summarizer_auto_mode_detects_provider(monkeypatch):
     """_create_summarizer() with use_ai_summaries='auto' picks up auto-detected provider."""
-    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY"):
+    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY", "OPENROUTER_API_KEY"):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("ZHIPUAI_API_KEY", "test-key")
     from jcodemunch_mcp import config as _cfg_module
@@ -912,7 +987,7 @@ def test_create_summarizer_auto_mode_detects_provider(monkeypatch):
 
 def test_create_summarizer_model_override_applied_to_glm(monkeypatch):
     """summarizer_model config override is applied to the created GLM summarizer."""
-    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY"):
+    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY", "OPENROUTER_API_KEY"):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("ZHIPUAI_API_KEY", "test-key")
     from jcodemunch_mcp import config as _cfg_module
@@ -942,7 +1017,7 @@ def test_create_summarizer_model_override_applied_to_glm(monkeypatch):
 def test_create_summarizer_explicit_true_no_provider_warns_and_autodetects(monkeypatch, caplog):
     """use_ai_summaries=True with no summarizer_provider logs warning and falls back to auto-detect."""
     import logging
-    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY"):
+    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY", "OPENROUTER_API_KEY"):
         monkeypatch.delenv(key, raising=False)
     with patch(
         "jcodemunch_mcp.summarizer.batch_summarize._config.get",
@@ -1026,7 +1101,7 @@ def test_gemini_model_override_via_config():
 def test_openai_model_override_via_config(monkeypatch):
     """summarizer_model config is applied to _create_summarizer() for the OpenAI provider."""
     monkeypatch.setenv("OPENAI_API_BASE", "http://localhost:11434/v1")
-    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY"):
+    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY", "OPENROUTER_API_KEY"):
         monkeypatch.delenv(key, raising=False)
 
     with patch(
@@ -1047,7 +1122,7 @@ def test_openai_model_override_via_config(monkeypatch):
 def test_minimax_model_override_via_config(monkeypatch):
     """summarizer_model config is applied to _create_summarizer() for the MiniMax provider."""
     monkeypatch.setenv("MINIMAX_API_KEY", "mm-test-key")
-    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "ZHIPUAI_API_KEY"):
+    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "ZHIPUAI_API_KEY", "OPENROUTER_API_KEY"):
         monkeypatch.delenv(key, raising=False)
 
     from jcodemunch_mcp import config as _cfg_module

--- a/tests/test_watcher_serve.py
+++ b/tests/test_watcher_serve.py
@@ -868,3 +868,42 @@ class TestWatcherConfigParams:
         )
         assert kwargs is not None
         assert kwargs["use_ai_summaries"] is False
+
+
+class TestDefaultUseAiSummaries:
+    """Unit tests for _default_use_ai_summaries() tri-state normalization."""
+
+    def _call(self, config_value):
+        from jcodemunch_mcp import server as server_mod
+        from jcodemunch_mcp import config as config_mod
+
+        with patch.object(config_mod, "get", return_value=config_value):
+            return server_mod._default_use_ai_summaries()
+
+    def test_auto_string_maps_to_true(self):
+        """'auto' (new default) normalizes to True."""
+        assert self._call("auto") is True
+
+    def test_true_bool_maps_to_true(self):
+        """True (bool, backward compat) normalizes to True."""
+        assert self._call(True) is True
+
+    def test_false_bool_maps_to_false(self):
+        """False (bool) normalizes to False."""
+        assert self._call(False) is False
+
+    def test_false_string_maps_to_false(self):
+        """'false' (string) normalizes to False."""
+        assert self._call("false") is False
+
+    def test_true_string_maps_to_true(self):
+        """'true' (string) normalizes to True."""
+        assert self._call("true") is True
+
+    def test_zero_string_maps_to_false(self):
+        """'0' string normalizes to False."""
+        assert self._call("0") is False
+
+    def test_off_string_maps_to_false(self):
+        """'off' string normalizes to False."""
+        assert self._call("off") is False


### PR DESCRIPTION
## Summary

Overhauls AI summarizer configuration to give users full control over provider and model selection through config files, adds OpenRouter as a new provider (with a free default model), introduces a circuit breaker to prevent wasted API calls on misconfigured setups, and ships a diagnostic tool to verify summarizer health.

### Tri-state `use_ai_summaries`

`use_ai_summaries` now accepts three values instead of just true/false:

- **`"auto"` (new default)** — Auto-detect provider from API key env vars. Identical to previous `true` behavior.
- **`true`** — Use explicit `summarizer_provider` + `summarizer_model` from config.
- **`false`** — Disable AI summarization entirely.

Full backward compatibility: existing configs with boolean `true`/`false` continue to work unchanged.

### New config key: `summarizer_model`

Override the default model for any provider via config file or env var:

```jsonc
"summarizer_provider": "openrouter",
"summarizer_model": "anthropic/claude-sonnet-4-5-20250514"
```

**Priority chain:** `summarizer_model` config > provider-specific env var (`ANTHROPIC_MODEL`, `GOOGLE_MODEL`, etc.) > hardcoded default.

### OpenRouter provider

New provider using the OpenAI-compatible API at `https://openrouter.ai/api/v1`. Access 300+ models through a single API key. 

!!! Free models are nice :) Load $10 and you get 1000 free requests per day even if you do not spend the $10. !!!

- **Env var:** `OPENROUTER_API_KEY`
- **Default model:** `meta-llama/llama-3.3-70b-instruct:free` (zero cost)
- **Auto-detect priority:** last in chain (after GLM)

### Strict Freshness timeout

Added a config entry to control the time after which the tool will return whatever is in the index, no longer waiting for the index to finish the refresh,

### Circuit breaker

After `summarizer_max_failures` (default 3) consecutive batch failures, the summarizer stops calling the API and falls back to signature summaries for all remaining symbols. A single successful batch resets the counter. Thread-safe (works with `summarizer_concurrency > 1`). Set `summarizer_max_failures: 0` to disable.

### `test_summarizer` diagnostic tool

Sends a probe request to the configured AI summarizer and reports status:

- **ok** — AI responded with a real summary
- **disabled** — `use_ai_summaries` is false
- **no_provider** — No API key or provider configured
- **misconfigured** — Provider detected but client init failed
- **fallback** — AI call failed silently (signature fallback returned)
- **timeout** — AI responded but exceeded threshold
- **error** — Exception during summarization

**Disabled by default** — remove/comment `"test_summarizer"` from `disabled_tools` in config to enable. Minimal schema to avoid token cost when idle.

## New config keys

- **`use_ai_summaries`** (default `"auto"`, env `JCODEMUNCH_USE_AI_SUMMARIES`) — Tri-state: `auto` / `true` / `false`
- **`summarizer_model`** (default `""`, env `JCODEMUNCH_SUMMARIZER_MODEL`) — Model override for any provider
- **`summarizer_max_failures`** (default `3`, env `JCODEMUNCH_SUMMARIZER_MAX_FAILURES`) — Circuit breaker threshold (0 = disabled)

## New env vars

- **`OPENROUTER_API_KEY`** — Enables OpenRouter summarizer
- **`JCODEMUNCH_SUMMARIZER_MODEL`** — Model override (config equivalent: `summarizer_model`)
- **`JCODEMUNCH_SUMMARIZER_MAX_FAILURES`** — Circuit breaker threshold

## Files changed

- `src/jcodemunch_mcp/config.py` — tri-state type, validation, `summarizer_model` + `summarizer_max_failures` keys, template
- `src/jcodemunch_mcp/summarizer/batch_summarize.py` — tri-state dispatch, model override, OpenRouter, circuit breaker
- `src/jcodemunch_mcp/server.py` — normalize tri-state to bool, `test_summarizer` tool registration, OpenRouter in config display
- `src/jcodemunch_mcp/tools/test_summarizer.py` — new diagnostic tool
- `CLAUDE.md` — documented new env vars
- `tests/` — 60+ new tests covering all paths

## Test plan

- [x] `pytest tests/` — 1400 passed, 4 skipped, 0 failed
- [ ] Manual: set `OPENROUTER_API_KEY`, run `index_folder` — verify summaries generated
- [ ] Manual: set `use_ai_summaries: true` + `summarizer_provider: openrouter` + `summarizer_model: google/gemini-2.5-flash` — verify explicit config path
- [ ] Manual: enable `test_summarizer` tool, call it — verify status report
- [ ] Manual: set invalid API key, call `test_summarizer` — verify `fallback` status
- [ ] Manual: `jcodemunch-mcp config` — verify OpenRouter shown when configured

Co-Authored with: Claude Opus 4.6 / Minimax M2.7 / GLM 5
🤖 Generated with [Claude Code](https://claude.com/claude-code)
