### PR TITLE
fix: handle malformed JSON in hook events and repo resolution

### DIFF
--- a/src/jcodemunch_mcp/hook_event.py
+++ b/src/jcodemunch_mcp/hook_event.py
@@ -16,7 +16,14 @@ def handle_hook_event(event_type: str, manifest_path: Path = DEFAULT_MANIFEST_PA
         jcodemunch-mcp hook-event create
         jcodemunch-mcp hook-event remove
     """
-    payload = json.load(sys.stdin)
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: invalid JSON on stdin: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:
+        print(f"ERROR: failed to read stdin: {exc}", file=sys.stderr)
+        sys.exit(1)
     worktree_path = payload.get("worktreePath") or payload.get("worktree_path")
     if not worktree_path:
         print("ERROR: no worktreePath in stdin payload", file=sys.stderr)

--- a/src/jcodemunch_mcp/tools/resolve_repo.py
+++ b/src/jcodemunch_mcp/tools/resolve_repo.py
@@ -1,12 +1,16 @@
 """Resolve a filesystem path to its indexed repo identifier."""
 
 import hashlib
+import json
+import logging
 import subprocess
 import time
 from pathlib import Path
 from typing import Optional
 
 from ..storage import IndexStore
+
+logger = logging.getLogger(__name__)
 
 
 def _compute_repo_id(folder_path: Path) -> str:
@@ -116,21 +120,25 @@ def _read_repo_metadata(store: IndexStore, owner: str, name: str) -> dict:
     # Try lightweight sidecar
     meta_path = store.base_path / f"{slug}.meta.json"
     if meta_path.exists():
-        import json
-        with open(meta_path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        entry = store._repo_entry_from_data(data)
-        if entry:
-            return entry
+        try:
+            with open(meta_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            entry = store._repo_entry_from_data(data)
+            if entry:
+                return entry
+        except (json.JSONDecodeError, ValueError):
+            logger.debug("Corrupted sidecar JSON at %s, skipping", meta_path)
 
     # Fall back to full index JSON
     index_path = store._index_path(owner, name)
     if index_path.exists():
-        import json
-        with open(index_path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        entry = store._repo_entry_from_data(data)
-        if entry:
-            return entry
+        try:
+            with open(index_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            entry = store._repo_entry_from_data(data)
+            if entry:
+                return entry
+        except (json.JSONDecodeError, ValueError):
+            logger.debug("Corrupted index JSON at %s, skipping", index_path)
 
     return {}


### PR DESCRIPTION
Ran into this while setting up the Claude Code worktree hooks on a fresh install — piped some bad input by accident and got a raw Python traceback instead of a useful error. Looked at the code and found two places where `json.load` is unprotected:

**`hook_event.py`** (line 19): `json.load(sys.stdin)` crashes with `JSONDecodeError` on malformed input. The `read_manifest` function in the same file (line 54) already handles this correctly:

```python
try:
    entry = json.loads(line)
except json.JSONDecodeError:
    continue
```

**`resolve_repo.py`** (lines 120-131): `json.load` on sidecar `.meta.json` and full index `.json` files crashes if either file is corrupted. `index_store.py` (line 707) already wraps the same operation in try-except:

```python
try:
    with open(meta_file, "r", encoding="utf-8") as f:
        data = json.load(f)
    entry = self._repo_entry_from_data(data, _pairs)
except Exception:
    continue
```

### Changes

- `hook_event.py`: Wrap `json.load(sys.stdin)` in try-except with a clear stderr message and `sys.exit(1)`, so the hook fails cleanly instead of dumping a traceback.
- `resolve_repo.py`: Wrap both `json.load` calls in try-except so a corrupted cache file falls through to return `{}` (repo not found) instead of crashing the tool. Adds `logging.debug` for diagnostics.

### Scenario
User's `.meta.json` gets corrupted (disk issue, interrupted write, manual edit). Before: `resolve_repo` tool call fails with unhandled exception. After: falls through gracefully and returns empty, prompting a re-index.