### PR TITLE
feat: Stages 4-6 — Inertia bridge, Vue/Nuxt/Next.js providers, FQN translation

### DIFF
--- a/src/jcodemunch_mcp/parser/context/__init__.py
+++ b/src/jcodemunch_mcp/parser/context/__init__.py
@@ -4,15 +4,18 @@ Context providers detect ecosystem tools (dbt, Terraform, OpenAPI, etc.)
 and inject business context into symbols and file summaries during indexing.
 """
 
-from .base import ContextProvider, FileContext, discover_providers, enrich_symbols, collect_metadata
+from .base import ContextProvider, FileContext, discover_providers, enrich_symbols, collect_metadata, collect_extra_imports
 
 from . import dbt  # noqa: F401
 from . import git_blame  # noqa: F401
 from . import laravel  # noqa: F401
+from . import nuxt  # noqa: F401
+from . import nextjs  # noqa: F401
 
 __all__ = [
     "ContextProvider",
     "FileContext",
+    "collect_extra_imports",
     "collect_metadata",
     "discover_providers",
     "enrich_symbols",

--- a/src/jcodemunch_mcp/parser/context/base.py
+++ b/src/jcodemunch_mcp/parser/context/base.py
@@ -123,6 +123,20 @@ class ContextProvider(ABC):
         """
         return {}
 
+    def get_extra_imports(self) -> dict[str, list[dict]]:
+        """Return additional import edges discovered by this provider.
+
+        Override in subclasses to inject framework-specific import edges
+        into the dependency graph (e.g., Blade template references,
+        route-to-controller mappings).
+
+        Returns:
+            Dict mapping relative file paths to lists of import dicts::
+
+                {"routes/web.php": [{"specifier": "App\\\\Http\\\\Controllers\\\\UserController", "names": ["UserController"]}]}
+        """
+        return {}
+
 
 # -- Registry of known providers --
 
@@ -195,3 +209,32 @@ def enrich_symbols(symbols: list, providers: list[ContextProvider]) -> None:
 
         if context_parts:
             sym.ecosystem_context = "; ".join(context_parts)
+
+
+def collect_extra_imports(
+    providers: list[ContextProvider],
+    file_imports: dict[str, list[dict]],
+) -> None:
+    """Merge extra import edges from context providers into file_imports in-place.
+
+    Providers can inject framework-specific import edges (e.g., Blade template
+    references, route→controller mappings) that the standard language-level
+    import extractor cannot detect.
+    """
+    for provider in providers:
+        try:
+            extras = provider.get_extra_imports()
+            for file_path, imports in extras.items():
+                if file_path in file_imports:
+                    # Deduplicate: only add specifiers not already present
+                    existing = {imp["specifier"] for imp in file_imports[file_path]}
+                    for imp in imports:
+                        if imp["specifier"] not in existing:
+                            file_imports[file_path].append(imp)
+                            existing.add(imp["specifier"])
+                else:
+                    file_imports[file_path] = list(imports)
+        except Exception as e:
+            logger.warning(
+                "Extra imports from '%s' failed: %s", provider.name, e
+            )

--- a/src/jcodemunch_mcp/parser/context/laravel.py
+++ b/src/jcodemunch_mcp/parser/context/laravel.py
@@ -83,7 +83,81 @@ _BLADE_X_COMPONENT = re.compile(r"""<x-(?P<name>[\w\-.]+)""", re.MULTILINE)
 
 # Blade dot-notation: @extends('layouts.app'), @include('partials.header'), view('users.index')
 _BLADE_DOTREF = re.compile(
-    r"""(?:@extends|@include(?:When|First)?|@component|view)\s*\(\s*['"](?P<ref>[^'"]+)['"]""",
+    r"""(?:@extends|@include|@component|view)\s*\(\s*['"](?P<ref>[^'"]+)['"]""",
+    re.MULTILINE,
+)
+
+# @includeWhen($cond, 'view'), @includeUnless($cond, 'view'), @includeFirst(['a', 'b'])
+_BLADE_INCLUDE_CONDITIONAL = re.compile(
+    r"""@include(?:When|Unless)\s*\([^,]+,\s*['"](?P<ref>[^'"]+)['"]""",
+    re.MULTILINE,
+)
+
+# Inertia.js render calls: Inertia::render('Users/Index'), inertia('Dashboard')
+_INERTIA_RENDER = re.compile(
+    r"""(?:Inertia\s*::\s*render|inertia)\s*\(\s*['"](?P<page>[^'"]+)['"]""",
+    re.MULTILINE,
+)
+
+# Frontend API calls: fetch('/api/...'), axios.get('/api/...'), useFetch('/api/...'), $fetch('/api/...')
+_API_CALL = re.compile(
+    r"""(?:fetch|axios\s*\.\s*\w+|\$fetch|useFetch|useAsyncData)\s*\(\s*"""
+    r"""['"`](?P<url>/api/[^'"`$]+)['"`]""",
+    re.MULTILINE,
+)
+
+# Static facade calls: Cache::get(), DB::table(), etc.
+# Built dynamically after _LARAVEL_FACADES is defined (see below).
+
+# Laravel built-in facade → underlying service class mapping
+_LARAVEL_FACADES: dict[str, str] = {
+    "App": "Illuminate\\Foundation\\Application",
+    "Artisan": "Illuminate\\Contracts\\Console\\Kernel",
+    "Auth": "Illuminate\\Auth\\AuthManager",
+    "Blade": "Illuminate\\View\\Compilers\\BladeCompiler",
+    "Broadcast": "Illuminate\\Contracts\\Broadcasting\\Factory",
+    "Bus": "Illuminate\\Contracts\\Bus\\Dispatcher",
+    "Cache": "Illuminate\\Cache\\CacheManager",
+    "Config": "Illuminate\\Config\\Repository",
+    "Context": "Illuminate\\Log\\Context\\Repository",
+    "Cookie": "Illuminate\\Cookie\\CookieJar",
+    "Crypt": "Illuminate\\Encryption\\Encrypter",
+    "Date": "Illuminate\\Support\\DateFactory",
+    "DB": "Illuminate\\Database\\DatabaseManager",
+    "Event": "Illuminate\\Events\\Dispatcher",
+    "File": "Illuminate\\Filesystem\\Filesystem",
+    "Gate": "Illuminate\\Contracts\\Auth\\Access\\Gate",
+    "Hash": "Illuminate\\Hashing\\HashManager",
+    "Http": "Illuminate\\Http\\Client\\Factory",
+    "Lang": "Illuminate\\Translation\\Translator",
+    "Log": "Illuminate\\Log\\LogManager",
+    "Mail": "Illuminate\\Mail\\Mailer",
+    "Notification": "Illuminate\\Notifications\\ChannelManager",
+    "Password": "Illuminate\\Auth\\Passwords\\PasswordBrokerManager",
+    "Pipeline": "Illuminate\\Pipeline\\Pipeline",
+    "Process": "Illuminate\\Process\\Factory",
+    "Queue": "Illuminate\\Queue\\QueueManager",
+    "RateLimiter": "Illuminate\\Cache\\RateLimiter",
+    "Redirect": "Illuminate\\Routing\\Redirector",
+    "Redis": "Illuminate\\Redis\\RedisManager",
+    "Request": "Illuminate\\Http\\Request",
+    "Response": "Illuminate\\Routing\\ResponseFactory",
+    "Route": "Illuminate\\Routing\\Router",
+    "Schedule": "Illuminate\\Console\\Scheduling\\Schedule",
+    "Schema": "Illuminate\\Database\\Schema\\Builder",
+    "Session": "Illuminate\\Session\\SessionManager",
+    "Storage": "Illuminate\\Filesystem\\FilesystemManager",
+    "URL": "Illuminate\\Routing\\UrlGenerator",
+    "Validator": "Illuminate\\Validation\\Factory",
+    "View": "Illuminate\\View\\Factory",
+    "Vite": "Illuminate\\Foundation\\Vite",
+}
+
+# Build regex from known facade names: matches Cache::get(), DB::table(), etc.
+# Excludes Foo::class references (class constant, not a call).
+_FACADE_NAMES_PATTERN = "|".join(re.escape(f) for f in sorted(_LARAVEL_FACADES, key=len, reverse=True))
+_FACADE_STATIC_CALL = re.compile(
+    rf"""(?<![>\w\\])(?P<facade>{_FACADE_NAMES_PATTERN})\s*::\s*(?!class\b)\w+\s*\(""",
     re.MULTILINE,
 )
 
@@ -165,9 +239,12 @@ def _parse_routes(routes_dir: Path) -> list[dict]:
 def _parse_model(content: str) -> dict:
     """Extract Eloquent model metadata from PHP source."""
     relationships: list[str] = []
+    related_models: list[str] = []
     for m in _ELOQUENT_RELATION.finditer(content):
-        model_name = m.group("model").rsplit("\\", 1)[-1]
+        raw_model = m.group("model")
+        model_name = raw_model.rsplit("\\", 1)[-1]
         relationships.append(f"{m.group('type')}({model_name})")
+        related_models.append(raw_model)
 
     scopes: list[str] = [m.group("name") for m in _SCOPE_METHOD.finditer(content)]
 
@@ -184,6 +261,7 @@ def _parse_model(content: str) -> dict:
 
     return {
         "relationships": relationships,
+        "related_models": related_models,
         "scopes": scopes,
         "fillable": props.get("fillable", ""),
         "table": props.get("table", ""),
@@ -262,6 +340,10 @@ class LaravelContextProvider(ContextProvider):
         self._table_columns: dict[str, dict[str, str]] = {}
         # blade view resolution: relative folder path
         self._views_path: Optional[Path] = None
+        # Extra import edges injected into the dependency graph
+        self._extra_imports: dict[str, list[dict]] = {}
+        # API route map: normalized URI → controller file (for fetch/axios matching)
+        self._api_route_map: dict[str, str] = {}
 
     @property
     def name(self) -> str:
@@ -291,6 +373,9 @@ class LaravelContextProvider(ContextProvider):
                 if route["name"]:
                     summary += f" ({route['name']})"
                 self._controller_routes.setdefault(ctrl, []).append(summary)
+
+        # Build API route map: URI → controller file path (for fetch/axios matching)
+        self._build_api_route_map(routes, folder_path)
 
         # Parse Eloquent models
         models_dir = folder_path / "app" / "Models"
@@ -322,6 +407,19 @@ class LaravelContextProvider(ContextProvider):
                     properties=props,
                 )
                 model_count += 1
+
+                # Eloquent relationship → import edges
+                if meta["related_models"]:
+                    rel_path = str(php_file.relative_to(folder_path)).replace("\\", "/")
+                    rel_imports: list[dict] = []
+                    seen_models: set[str] = set()
+                    for raw_model in meta["related_models"]:
+                        if raw_model not in seen_models:
+                            short = raw_model.rsplit("\\", 1)[-1]
+                            rel_imports.append({"specifier": raw_model, "names": [short]})
+                            seen_models.add(raw_model)
+                    if rel_imports:
+                        self._extra_imports.setdefault(rel_path, []).extend(rel_imports)
 
         logger.info("Laravel: parsed %d models", model_count)
 
@@ -369,6 +467,248 @@ class LaravelContextProvider(ContextProvider):
         # Store views path for Blade resolution
         self._views_path = folder_path / "resources" / "views"
 
+        # --- Extra imports: Route files → Controllers ---
+        self._build_route_imports(routes, folder_path)
+
+        # --- Extra imports: Blade templates → referenced views ---
+        self._build_blade_imports(folder_path)
+
+        # --- Extra imports: Facade static calls → underlying classes ---
+        self._build_facade_imports(folder_path)
+
+        # --- Extra imports: Inertia.js renders → Vue/React page components ---
+        self._build_inertia_imports(folder_path)
+
+        # --- Extra imports: fetch/axios API calls → controller files ---
+        self._build_api_call_imports(folder_path)
+
+    def _build_api_route_map(self, routes: list[dict], folder_path: Path) -> None:
+        """Build a URI → controller file path mapping for API call matching."""
+        controllers_dir = folder_path / "app" / "Http" / "Controllers"
+        for route in routes:
+            uri = route.get("uri", "")
+            ctrl = route.get("controller", "")
+            if not uri or not ctrl:
+                continue
+            # Normalize: strip leading slash, replace {param} with *
+            normalized = "/" + uri.lstrip("/")
+            normalized = re.sub(r"\{[^}]+\}", "*", normalized)
+            # Try to find the controller file
+            ctrl_file = _find_controller_file(ctrl, controllers_dir, folder_path)
+            if ctrl_file:
+                self._api_route_map[normalized] = ctrl_file
+
+    def _build_route_imports(self, routes: list[dict], folder_path: Path) -> None:
+        """Create import edges from route files to their controller files."""
+        for route in routes:
+            fqn = route.get("controller_fqn", "")
+            route_file = route.get("file", "")
+            if not fqn or not route_file:
+                continue
+
+            route_rel = f"routes/{route_file}"
+            imp = {"specifier": fqn, "names": [route["controller"]]}
+
+            if route_rel in self._extra_imports:
+                # Avoid duplicate specifiers
+                existing = {i["specifier"] for i in self._extra_imports[route_rel]}
+                if fqn not in existing:
+                    self._extra_imports[route_rel].append(imp)
+            else:
+                self._extra_imports[route_rel] = [imp]
+
+    def _build_blade_imports(self, folder_path: Path) -> None:
+        """Parse Blade templates for @extends, @include, @component, <x-*> references."""
+        views_dir = folder_path / "resources" / "views"
+        if not views_dir.is_dir():
+            return
+
+        blade_count = 0
+        for blade_file in sorted(views_dir.rglob("*.blade.php")):
+            content = _read_php(blade_file)
+            if not content:
+                continue
+
+            rel_path = str(blade_file.relative_to(folder_path)).replace("\\", "/")
+            imports: list[dict] = []
+            seen: set[str] = set()
+
+            # @extends, @include, @component, view()
+            for m in _BLADE_DOTREF.finditer(content):
+                ref = m.group("ref")
+                resolved = _blade_dot_to_path(ref)
+                if resolved and resolved not in seen:
+                    imports.append({"specifier": resolved, "names": []})
+                    seen.add(resolved)
+
+            # @includeWhen($cond, 'view'), @includeUnless($cond, 'view')
+            for m in _BLADE_INCLUDE_CONDITIONAL.finditer(content):
+                ref = m.group("ref")
+                resolved = _blade_dot_to_path(ref)
+                if resolved and resolved not in seen:
+                    imports.append({"specifier": resolved, "names": []})
+                    seen.add(resolved)
+
+            # <x-component> → resources/views/components/component.blade.php
+            for m in _BLADE_X_COMPONENT.finditer(content):
+                name = m.group("name")
+                resolved = _blade_component_to_path(name)
+                if resolved and resolved not in seen:
+                    imports.append({"specifier": resolved, "names": []})
+                    seen.add(resolved)
+
+            if imports:
+                self._extra_imports[rel_path] = imports
+                blade_count += 1
+
+        if blade_count:
+            logger.info("Laravel: extracted Blade imports from %d templates", blade_count)
+
+    def _build_facade_imports(self, folder_path: Path) -> None:
+        """Scan PHP files for facade static calls and create import edges to underlying classes."""
+        facade_count = 0
+        app_dir = folder_path / "app"
+        if not app_dir.is_dir():
+            return
+
+        for php_file in sorted(app_dir.rglob("*.php")):
+            content = _read_php(php_file)
+            if not content:
+                continue
+
+            facades_used: dict[str, str] = {}
+            for m in _FACADE_STATIC_CALL.finditer(content):
+                facade_name = m.group("facade")
+                if facade_name in _LARAVEL_FACADES and facade_name not in facades_used:
+                    facades_used[facade_name] = _LARAVEL_FACADES[facade_name]
+
+            if facades_used:
+                rel_path = str(php_file.relative_to(folder_path)).replace("\\", "/")
+                imports = [
+                    {"specifier": fqn, "names": [name]}
+                    for name, fqn in facades_used.items()
+                ]
+                self._extra_imports.setdefault(rel_path, []).extend(imports)
+                facade_count += 1
+
+        if facade_count:
+            logger.info("Laravel: extracted facade imports from %d files", facade_count)
+
+    def _build_inertia_imports(self, folder_path: Path) -> None:
+        """Create import edges from PHP controllers to Inertia.js Vue/React page components."""
+        # Detect Inertia: composer require OR middleware file
+        requires = _read_composer_require(folder_path)
+        has_middleware = (folder_path / "app" / "Http" / "Middleware" / "HandleInertiaRequests.php").exists()
+        if "inertiajs/inertia-laravel" not in requires and not has_middleware:
+            return
+
+        # Find pages directory
+        pages_dir: Optional[str] = None
+        for candidate in ("resources/js/Pages", "resources/js/pages", "resources/ts/Pages"):
+            if (folder_path / candidate).is_dir():
+                pages_dir = candidate
+                break
+        if pages_dir is None:
+            return
+
+        # Scan PHP files for Inertia::render / inertia() calls
+        app_dir = folder_path / "app"
+        if not app_dir.is_dir():
+            return
+
+        inertia_count = 0
+        for php_file in sorted(app_dir.rglob("*.php")):
+            content = _read_php(php_file)
+            if not content:
+                continue
+
+            pages_found: dict[str, str] = {}
+            for m in _INERTIA_RENDER.finditer(content):
+                page = m.group("page")
+                if page in pages_found:
+                    continue
+                # Strip extension if already present (e.g. 'Users/Index.vue')
+                page_clean = re.sub(r"\.(vue|tsx|jsx)$", "", page)
+                # Resolve page path: try .vue, .tsx, .jsx
+                resolved = None
+                for ext in (".vue", ".tsx", ".jsx"):
+                    candidate_path = f"{pages_dir}/{page_clean}{ext}"
+                    if (folder_path / candidate_path).exists():
+                        resolved = candidate_path
+                        break
+                if resolved is None:
+                    # Default to .vue even if file doesn't exist yet
+                    resolved = f"{pages_dir}/{page_clean}.vue"
+                pages_found[page] = resolved
+
+            if pages_found:
+                rel_path = str(php_file.relative_to(folder_path)).replace("\\", "/")
+                imports = [
+                    {"specifier": target, "names": []}
+                    for target in pages_found.values()
+                ]
+                self._extra_imports.setdefault(rel_path, []).extend(imports)
+                inertia_count += 1
+
+        if inertia_count:
+            logger.info("Laravel: extracted Inertia imports from %d files", inertia_count)
+
+    def _build_api_call_imports(self, folder_path: Path) -> None:
+        """Scan JS/TS/Vue files for fetch/axios API calls and match to Laravel routes."""
+        if not self._api_route_map:
+            return
+
+        api_count = 0
+        for ext_pattern in ("**/*.js", "**/*.ts", "**/*.vue", "**/*.tsx", "**/*.jsx"):
+            for js_file in sorted(folder_path.glob(ext_pattern)):
+                # Skip vendor/node_modules
+                rel = str(js_file.relative_to(folder_path))
+                if "node_modules" in rel or "vendor" in rel:
+                    continue
+
+                try:
+                    content = js_file.read_text("utf-8", errors="replace")
+                except Exception:
+                    continue
+
+                matched_controllers: dict[str, str] = {}
+                for m in _API_CALL.finditer(content):
+                    url = m.group("url")
+                    ctrl_file = self._match_api_url(url)
+                    if ctrl_file and ctrl_file not in matched_controllers:
+                        matched_controllers[ctrl_file] = url
+
+                if matched_controllers:
+                    rel_path = str(js_file.relative_to(folder_path)).replace("\\", "/")
+                    imports = [
+                        {"specifier": ctrl, "names": []}
+                        for ctrl in matched_controllers
+                    ]
+                    self._extra_imports.setdefault(rel_path, []).extend(imports)
+                    api_count += 1
+
+        if api_count:
+            logger.info("Laravel: matched API calls to routes in %d files", api_count)
+
+    def _match_api_url(self, url: str) -> Optional[str]:
+        """Match a frontend API URL to a Laravel route's controller file."""
+        normalized = "/" + url.lstrip("/")
+        # Exact match first
+        if normalized in self._api_route_map:
+            return self._api_route_map[normalized]
+        # Try matching with wildcard routes (replace path segments with *)
+        segments = normalized.rstrip("/").split("/")
+        for route_uri, ctrl_file in self._api_route_map.items():
+            route_segments = route_uri.rstrip("/").split("/")
+            if len(segments) != len(route_segments):
+                continue
+            if all(
+                rs == "*" or rs == seg
+                for rs, seg in zip(route_segments, segments)
+            ):
+                return ctrl_file
+        return None
+
     def get_file_context(self, file_path: str) -> Optional[FileContext]:
         stem = Path(file_path).stem
         ctx = self._file_contexts.get(stem)
@@ -395,13 +735,71 @@ class LaravelContextProvider(ContextProvider):
             return {}
         return {"laravel_columns": self._table_columns}
 
+    def get_extra_imports(self) -> dict[str, list[dict]]:
+        """Return Blade and route import edges for the dependency graph."""
+        return self._extra_imports
+
     def stats(self) -> dict:
         return {
             "models": sum(1 for ctx in self._file_contexts.values()
                          if "eloquent-model" in ctx.tags),
             "controllers_with_routes": len(self._controller_routes),
             "migration_tables": len(self._table_columns),
+            "blade_files_with_imports": sum(
+                1 for k in self._extra_imports
+                if k.startswith("resources/views/")
+            ),
+            "route_files_with_imports": sum(
+                1 for k in self._extra_imports
+                if k.startswith("routes/")
+            ),
+            "files_with_facade_imports": sum(
+                1 for k, v in self._extra_imports.items()
+                if any(imp["specifier"].startswith("Illuminate\\") for imp in v)
+            ),
+            "files_with_inertia_imports": sum(
+                1 for k, v in self._extra_imports.items()
+                if any("Pages/" in imp["specifier"] or "pages/" in imp["specifier"] for imp in v)
+            ),
+            "api_routes_mapped": len(self._api_route_map),
         }
+
+
+def _find_controller_file(
+    controller_name: str, controllers_dir: Path, folder_path: Path
+) -> Optional[str]:
+    """Find a controller's repo-relative file path by class name."""
+    if not controllers_dir.is_dir():
+        return None
+    for php_file in controllers_dir.rglob("*.php"):
+        if php_file.stem == controller_name:
+            return str(php_file.relative_to(folder_path)).replace("\\", "/")
+    return None
+
+
+def _blade_dot_to_path(dot_ref: str) -> Optional[str]:
+    """Convert Blade dot-notation to a relative file path.
+
+    Example: 'layouts.app' → 'resources/views/layouts/app.blade.php'
+    Returns None for empty or invalid references.
+    """
+    if not dot_ref or dot_ref == ".":
+        return None
+    parts = dot_ref.replace(".", "/")
+    return f"resources/views/{parts}.blade.php"
+
+
+def _blade_component_to_path(component_name: str) -> Optional[str]:
+    """Convert <x-component> name to a relative file path.
+
+    Example: 'alert' → 'resources/views/components/alert.blade.php'
+             'forms.input' → 'resources/views/components/forms/input.blade.php'
+    Returns None for empty names.
+    """
+    if not component_name:
+        return None
+    parts = component_name.replace(".", "/")
+    return f"resources/views/components/{parts}.blade.php"
 
 
 def _guess_table(model_stem: str) -> str:

--- a/src/jcodemunch_mcp/parser/context/nextjs.py
+++ b/src/jcodemunch_mcp/parser/context/nextjs.py
@@ -1,0 +1,217 @@
+"""Next.js context provider — detects Next.js projects and enriches symbols with framework metadata.
+
+When a Next.js project is detected (via next.config.js/ts/mjs), this provider:
+1. Parses app/ for App Router file-based routing → enriches components with route metadata
+2. Parses app/api/ for API route handlers → enriches with endpoint metadata
+3. Detects middleware.ts at project root
+4. Exposes route metadata via get_metadata()
+"""
+
+import logging
+import re
+from pathlib import Path
+from typing import Optional
+
+from .base import ContextProvider, FileContext, register_provider
+
+logger = logging.getLogger(__name__)
+
+# Next.js special files (App Router)
+_NEXT_SPECIAL_FILES = frozenset({
+    "page", "layout", "loading", "error", "not-found",
+    "template", "default", "route", "middleware",
+})
+
+
+def _next_route_from_path(file_path: str, app_dir: str = "app") -> str:
+    """Convert a Next.js app/ file path to a route string.
+
+    Examples:
+        'app/page.tsx'              → '/'
+        'app/users/page.tsx'        → '/users'
+        'app/users/[id]/page.tsx'   → '/users/:id'
+        'app/posts/[...slug]/page.tsx' → '/posts/*'
+    """
+    rel = file_path
+    if rel.startswith(app_dir + "/"):
+        rel = rel[len(app_dir) + 1:]
+    # Remove filename (page.tsx, layout.tsx, etc.)
+    parts = rel.split("/")
+    parts = parts[:-1]  # Remove the file itself
+
+    segments = []
+    for part in parts:
+        if part.startswith("[..."):
+            segments.append("*")
+        elif part.startswith("[") and part.endswith("]"):
+            param = part[1:-1]
+            segments.append(f":{param}")
+        elif part.startswith("(") and part.endswith(")"):
+            continue  # Route group — does not affect URL
+        else:
+            segments.append(part)
+
+    return "/" + "/".join(segments) if segments else "/"
+
+
+def _next_api_methods_from_content(content: str) -> list[str]:
+    """Extract exported HTTP method names from a Next.js route handler.
+
+    Example:
+        export async function GET(request: Request) { ... }
+        export async function POST(request: Request) { ... }
+        → ['GET', 'POST']
+    """
+    methods = []
+    for m in re.finditer(
+        r"export\s+(?:async\s+)?function\s+(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\b",
+        content,
+    ):
+        methods.append(m.group(1))
+    return methods
+
+
+@register_provider
+class NextjsContextProvider(ContextProvider):
+    """Context provider for Next.js projects (App Router).
+
+    Detects next.config.js/ts/mjs, then parses:
+    - app/**/page.tsx    → page routes with route metadata
+    - app/**/layout.tsx  → layout nesting
+    - app/api/**/route.ts → API handlers with HTTP methods
+    """
+
+    def __init__(self) -> None:
+        self._folder: Optional[Path] = None
+        self._file_contexts: dict[str, FileContext] = {}
+        self._route_metadata: dict[str, dict] = {}
+        self._api_metadata: dict[str, dict] = {}
+
+    @property
+    def name(self) -> str:
+        return "nextjs"
+
+    def detect(self, folder_path: Path) -> bool:
+        for config_name in ("next.config.js", "next.config.ts", "next.config.mjs"):
+            if (folder_path / config_name).exists():
+                self._folder = folder_path
+                return True
+        return False
+
+    def load(self, folder_path: Path) -> None:
+        if self._folder is None:
+            self._folder = folder_path
+
+        self._parse_app_router(folder_path)
+        self._parse_middleware(folder_path)
+
+    def _parse_app_router(self, folder_path: Path) -> None:
+        """Parse app/ directory for pages, layouts, and API routes."""
+        app_dir = folder_path / "app"
+        if not app_dir.is_dir():
+            return
+
+        for src_file in sorted(app_dir.rglob("*")):
+            if src_file.suffix not in (".tsx", ".ts", ".jsx", ".js"):
+                continue
+            stem = src_file.stem
+            if stem not in _NEXT_SPECIAL_FILES:
+                continue
+
+            rel_path = str(src_file.relative_to(folder_path)).replace("\\", "/")
+            route = _next_route_from_path(rel_path)
+
+            if stem == "route":
+                # API route handler
+                try:
+                    content = src_file.read_text("utf-8", errors="replace")
+                except Exception:
+                    content = ""
+                methods = _next_api_methods_from_content(content) or ["ALL"]
+                endpoint = "/api" + route if not route.startswith("/api") else route
+                # Check if this is actually under app/api/
+                if "api/" in rel_path:
+                    key = f"{', '.join(methods)} {endpoint}"
+                    self._file_contexts[rel_path] = FileContext(
+                        description=f"Next.js API route handler. Endpoint: {endpoint}. Methods: {', '.join(methods)}.",
+                        tags=["nextjs-api", "endpoint", "app-router"],
+                        properties={"methods": ", ".join(methods), "endpoint": endpoint},
+                    )
+                    self._api_metadata[key] = {"handler": rel_path, "methods": methods}
+            elif stem == "page":
+                # Page component
+                params = re.findall(r":(\w+)", route)
+                desc = f"Next.js page. Route: {route}"
+                if params:
+                    desc += f" (params: {', '.join(params)})"
+                self._file_contexts[rel_path] = FileContext(
+                    description=desc,
+                    tags=["nextjs-page", "route", "app-router"],
+                    properties={"route": route},
+                )
+                self._route_metadata[route] = {"page": rel_path, "method": "GET"}
+            elif stem == "layout":
+                self._file_contexts[rel_path] = FileContext(
+                    description=f"Next.js layout for {route or '/'}",
+                    tags=["nextjs-layout", "app-router"],
+                    properties={"scope": route or "/"},
+                )
+            elif stem in ("loading", "error", "not-found"):
+                self._file_contexts[rel_path] = FileContext(
+                    description=f"Next.js {stem} boundary for {route or '/'}",
+                    tags=[f"nextjs-{stem}", "app-router"],
+                    properties={"scope": route or "/"},
+                )
+
+        logger.info(
+            "Next.js: parsed %d page routes, %d API routes",
+            len(self._route_metadata), len(self._api_metadata),
+        )
+
+    def _parse_middleware(self, folder_path: Path) -> None:
+        """Detect middleware.ts at project root."""
+        for name in ("middleware.ts", "middleware.js"):
+            mw_path = folder_path / name
+            if mw_path.exists():
+                try:
+                    content = mw_path.read_text("utf-8", errors="replace")
+                except Exception:
+                    content = ""
+                # Extract matcher config
+                matcher_match = re.search(
+                    r"matcher\s*:\s*\[([^\]]+)\]", content
+                )
+                matchers = []
+                if matcher_match:
+                    matchers = re.findall(r"""['"]([^'"]+)['"]""", matcher_match.group(1))
+
+                rel_path = str(mw_path.relative_to(folder_path)).replace("\\", "/")
+                props: dict[str, str] = {}
+                if matchers:
+                    props["matcher"] = ", ".join(matchers)
+                self._file_contexts[rel_path] = FileContext(
+                    description="Next.js middleware",
+                    tags=["nextjs-middleware"],
+                    properties=props,
+                )
+                break
+
+    def get_file_context(self, file_path: str) -> Optional[FileContext]:
+        return self._file_contexts.get(file_path)
+
+    def get_extra_imports(self) -> dict[str, list[dict]]:
+        return {}  # Next.js doesn't have auto-imports like Nuxt
+
+    def get_metadata(self) -> dict:
+        meta: dict = {}
+        if self._route_metadata:
+            meta["nextjs_routes"] = self._route_metadata
+        if self._api_metadata:
+            meta["nextjs_api"] = self._api_metadata
+        return meta
+
+    def stats(self) -> dict:
+        return {
+            "page_routes": len(self._route_metadata),
+            "api_routes": len(self._api_metadata),
+        }

--- a/src/jcodemunch_mcp/parser/context/nuxt.py
+++ b/src/jcodemunch_mcp/parser/context/nuxt.py
@@ -1,0 +1,254 @@
+"""Nuxt.js context provider — detects Nuxt projects and enriches symbols with framework metadata.
+
+When a Nuxt project is detected (via nuxt.config.ts/js), this provider:
+1. Parses pages/ for file-based routing → enriches page components with route metadata
+2. Parses server/api/ for server API routes → enriches handlers with endpoint metadata
+3. Scans composables/ and utils/ for auto-import candidates → injects synthetic import edges
+4. Exposes route metadata via get_metadata() for search_columns
+"""
+
+import logging
+import re
+from pathlib import Path
+from typing import Optional
+
+from .base import ContextProvider, FileContext, register_provider
+
+logger = logging.getLogger(__name__)
+
+
+def _nuxt_route_from_path(file_path: str, pages_dir: str = "pages") -> str:
+    """Convert a Nuxt pages/ file path to a route string.
+
+    Examples:
+        'pages/index.vue'          → '/'
+        'pages/users/index.vue'    → '/users'
+        'pages/users/[id].vue'     → '/users/:id'
+        'pages/posts/[...slug].vue' → '/posts/*'
+    """
+    # Strip pages dir prefix and extension
+    rel = file_path
+    if rel.startswith(pages_dir + "/"):
+        rel = rel[len(pages_dir) + 1:]
+    rel = re.sub(r"\.(vue|tsx|jsx)$", "", rel)
+
+    # Convert path segments
+    segments = []
+    for part in rel.split("/"):
+        if part == "index":
+            continue
+        if part.startswith("[..."):
+            segments.append("*")
+        elif part.startswith("[") and part.endswith("]"):
+            param = part[1:-1]
+            segments.append(f":{param}")
+        else:
+            segments.append(part)
+
+    return "/" + "/".join(segments) if segments else "/"
+
+
+def _nuxt_api_route_from_path(file_path: str, api_dir: str = "server/api") -> Optional[dict]:
+    """Convert a Nuxt server/api/ file path to an endpoint dict.
+
+    Examples:
+        'server/api/users.get.ts'      → {'method': 'GET', 'endpoint': '/api/users'}
+        'server/api/users.post.ts'     → {'method': 'POST', 'endpoint': '/api/users'}
+        'server/api/users/[id].get.ts' → {'method': 'GET', 'endpoint': '/api/users/:id'}
+        'server/api/health.ts'         → {'method': 'ALL', 'endpoint': '/api/health'}
+    """
+    rel = file_path
+    if rel.startswith(api_dir + "/"):
+        rel = rel[len(api_dir) + 1:]
+    rel = re.sub(r"\.(ts|js|mjs)$", "", rel)
+
+    # Extract HTTP method from filename suffix (e.g., users.get → GET)
+    method = "ALL"
+    for m in ("get", "post", "put", "patch", "delete", "head", "options"):
+        if rel.endswith(f".{m}"):
+            method = m.upper()
+            rel = rel[: -(len(m) + 1)]
+            break
+
+    # Convert segments
+    segments = []
+    for part in rel.split("/"):
+        if part == "index":
+            continue
+        if part.startswith("[..."):
+            segments.append("*")
+        elif part.startswith("[") and part.endswith("]"):
+            segments.append(f":{part[1:-1]}")
+        else:
+            segments.append(part)
+
+    endpoint = "/api/" + "/".join(segments) if segments else "/api"
+    return {"method": method, "endpoint": endpoint}
+
+
+@register_provider
+class NuxtContextProvider(ContextProvider):
+    """Context provider for Nuxt.js projects.
+
+    Detects nuxt.config.ts/js, then parses:
+    - pages/     → file-based routing with route metadata
+    - server/api/ → server API route handlers
+    - composables/, utils/ → auto-import synthetic edges
+    """
+
+    def __init__(self) -> None:
+        self._folder: Optional[Path] = None
+        self._file_contexts: dict[str, FileContext] = {}
+        self._extra_imports: dict[str, list[dict]] = {}
+        self._route_metadata: dict[str, dict] = {}
+        self._api_metadata: dict[str, dict] = {}
+        self._auto_import_symbols: dict[str, str] = {}  # name → file path
+
+    @property
+    def name(self) -> str:
+        return "nuxt"
+
+    def detect(self, folder_path: Path) -> bool:
+        for config_name in ("nuxt.config.ts", "nuxt.config.js", "nuxt.config.mjs"):
+            if (folder_path / config_name).exists():
+                self._folder = folder_path
+                return True
+        return False
+
+    def load(self, folder_path: Path) -> None:
+        if self._folder is None:
+            self._folder = folder_path
+
+        self._parse_pages(folder_path)
+        self._parse_server_api(folder_path)
+        self._build_auto_import_map(folder_path)
+        self._build_auto_import_edges(folder_path)
+
+    def _parse_pages(self, folder_path: Path) -> None:
+        """Parse pages/ directory for file-based routing."""
+        pages_dir = folder_path / "pages"
+        if not pages_dir.is_dir():
+            return
+
+        for vue_file in sorted(pages_dir.rglob("*.vue")):
+            rel_path = str(vue_file.relative_to(folder_path)).replace("\\", "/")
+            route = _nuxt_route_from_path(rel_path)
+
+            # Extract dynamic params
+            params = re.findall(r":(\w+)", route)
+            is_dynamic = bool(params) or "*" in route
+
+            props: dict[str, str] = {"route": route}
+            if params:
+                props["params"] = ", ".join(params)
+            desc = f"Nuxt page component. Route: {route}"
+            if is_dynamic:
+                desc += " (dynamic)"
+
+            stem = vue_file.stem.replace(".vue", "")
+            self._file_contexts[rel_path] = FileContext(
+                description=desc,
+                tags=["nuxt-page", "route"],
+                properties=props,
+            )
+            self._route_metadata[route] = {"page": rel_path, "method": "GET"}
+
+        logger.info("Nuxt: parsed %d page routes", len(self._route_metadata))
+
+    def _parse_server_api(self, folder_path: Path) -> None:
+        """Parse server/api/ directory for API route handlers."""
+        api_dir = folder_path / "server" / "api"
+        if not api_dir.is_dir():
+            return
+
+        for api_file in sorted(api_dir.rglob("*")):
+            if api_file.suffix not in (".ts", ".js", ".mjs"):
+                continue
+            rel_path = str(api_file.relative_to(folder_path)).replace("\\", "/")
+            route_info = _nuxt_api_route_from_path(rel_path)
+            if not route_info:
+                continue
+
+            key = f"{route_info['method']} {route_info['endpoint']}"
+            self._file_contexts[rel_path] = FileContext(
+                description=f"Nuxt server route: {key}",
+                tags=["nuxt-api", "endpoint"],
+                properties={"method": route_info["method"], "endpoint": route_info["endpoint"]},
+            )
+            self._api_metadata[key] = {"handler": rel_path}
+
+        logger.info("Nuxt: parsed %d server API routes", len(self._api_metadata))
+
+    def _build_auto_import_map(self, folder_path: Path) -> None:
+        """Scan composables/ and utils/ for exported function names."""
+        for auto_dir in ("composables", "utils"):
+            dir_path = folder_path / auto_dir
+            if not dir_path.is_dir():
+                continue
+            for src_file in sorted(dir_path.rglob("*")):
+                if src_file.suffix not in (".ts", ".js", ".mjs", ".vue"):
+                    continue
+                rel_path = str(src_file.relative_to(folder_path)).replace("\\", "/")
+                # Use filename stem as the auto-import name (Nuxt convention)
+                name = src_file.stem
+                # For useXxx.ts → useXxx is auto-imported
+                self._auto_import_symbols[name] = rel_path
+
+        logger.info("Nuxt: found %d auto-import candidates", len(self._auto_import_symbols))
+
+    def _build_auto_import_edges(self, folder_path: Path) -> None:
+        """Scan .vue files for usage of auto-imported symbols and create synthetic edges."""
+        if not self._auto_import_symbols:
+            return
+
+        # Build regex from auto-import names
+        names = sorted(self._auto_import_symbols.keys(), key=len, reverse=True)
+        pattern = re.compile(r"\b(" + "|".join(re.escape(n) for n in names) + r")\s*\(")
+
+        edge_count = 0
+        for vue_file in sorted(folder_path.rglob("*.vue")):
+            rel = str(vue_file.relative_to(folder_path))
+            if "node_modules" in rel or ".nuxt" in rel:
+                continue
+            try:
+                content = vue_file.read_text("utf-8", errors="replace")
+            except Exception:
+                continue
+
+            rel_path = rel.replace("\\", "/")
+            seen: set[str] = set()
+            for m in pattern.finditer(content):
+                name = m.group(1)
+                target = self._auto_import_symbols[name]
+                if target not in seen and target != rel_path:
+                    seen.add(target)
+
+            if seen:
+                imports = [{"specifier": t, "names": []} for t in sorted(seen)]
+                self._extra_imports.setdefault(rel_path, []).extend(imports)
+                edge_count += 1
+
+        if edge_count:
+            logger.info("Nuxt: injected auto-import edges for %d files", edge_count)
+
+    def get_file_context(self, file_path: str) -> Optional[FileContext]:
+        return self._file_contexts.get(file_path)
+
+    def get_extra_imports(self) -> dict[str, list[dict]]:
+        return self._extra_imports
+
+    def get_metadata(self) -> dict:
+        meta: dict = {}
+        if self._route_metadata:
+            meta["nuxt_routes"] = self._route_metadata
+        if self._api_metadata:
+            meta["nuxt_api"] = self._api_metadata
+        return meta
+
+    def stats(self) -> dict:
+        return {
+            "page_routes": len(self._route_metadata),
+            "api_routes": len(self._api_metadata),
+            "auto_import_symbols": len(self._auto_import_symbols),
+            "files_with_auto_imports": len(self._extra_imports),
+        }

--- a/src/jcodemunch_mcp/parser/fqn.py
+++ b/src/jcodemunch_mcp/parser/fqn.py
@@ -1,0 +1,97 @@
+"""Bi-directional translation between jcodemunch symbol IDs and PHP FQNs.
+
+Enables interoperability between jcodemunch (``app/Models/User.php::User#class``)
+and PhpStorm / Laravel Idea (``App\\Models\\User``).  Uses PSR-4 mappings from
+composer.json to perform the conversion.
+"""
+
+from typing import Optional
+
+from .imports import resolve_php_namespace
+
+
+def symbol_to_fqn(symbol_id: str, psr4_map: dict[str, str]) -> Optional[str]:
+    """Convert a jcodemunch symbol ID to a PHP fully-qualified name.
+
+    Examples::
+
+        symbol_to_fqn("app/Models/User.php::User#class", {"App\\\\": "app/"})
+        → "App\\\\Models\\\\User"
+
+        symbol_to_fqn("app/Models/User.php::User.posts#method", {"App\\\\": "app/"})
+        → "App\\\\Models\\\\User::posts"
+
+    Only works for PHP symbols (file must end in ``.php``).
+    """
+    if "::" not in symbol_id:
+        return None
+
+    file_path, rest = symbol_id.split("::", 1)
+    if "#" in rest:
+        name, kind = rest.rsplit("#", 1)
+    else:
+        name, kind = rest, ""
+
+    if not file_path.endswith(".php"):
+        return None
+
+    if kind == "method" and "." in name:
+        class_name, method_name = name.rsplit(".", 1)
+        class_fqn = _file_to_namespace(file_path, class_name, psr4_map)
+        if class_fqn:
+            return f"{class_fqn}::{method_name}"
+        return None
+
+    return _file_to_namespace(file_path, name, psr4_map)
+
+
+def _file_to_namespace(
+    file_path: str, class_name: str, psr4_map: dict[str, str]
+) -> Optional[str]:
+    """Reverse PSR-4: file path + class name → FQN."""
+    path_no_ext = file_path[:-4]  # strip .php
+
+    # Sort by longest base_dir first for most-specific match
+    for prefix, base_dir in sorted(psr4_map.items(), key=lambda x: -len(x[1])):
+        base = base_dir.rstrip("/")
+        if path_no_ext.startswith(base + "/") or path_no_ext == base:
+            relative = path_no_ext[len(base):].lstrip("/")
+            namespace = prefix + relative.replace("/", "\\")
+            # Verify the last segment matches class_name
+            last = namespace.rsplit("\\", 1)[-1] if "\\" in namespace else namespace
+            if last == class_name:
+                return namespace
+    return None
+
+
+def fqn_to_symbol(
+    fqn: str,
+    psr4_map: dict[str, str],
+    source_files: set[str],
+) -> Optional[str]:
+    """Convert a PHP FQN to a jcodemunch symbol ID.
+
+    Examples::
+
+        fqn_to_symbol("App\\\\Models\\\\User", psr4, files)
+        → "app/Models/User.php::User#class"
+
+        fqn_to_symbol("App\\\\Models\\\\User::posts", psr4, files)
+        → "app/Models/User.php::User.posts#method"
+
+    Returns None if the FQN cannot be resolved to an indexed file.
+    """
+    method_name: Optional[str] = None
+    lookup_fqn = fqn
+    if "::" in fqn:
+        lookup_fqn, method_name = fqn.rsplit("::", 1)
+
+    file_path = resolve_php_namespace(lookup_fqn, psr4_map, source_files)
+    if not file_path:
+        return None
+
+    class_name = lookup_fqn.rsplit("\\", 1)[-1]
+
+    if method_name:
+        return f"{file_path}::{class_name}.{method_name}#method"
+    return f"{file_path}::{class_name}#class"

--- a/src/jcodemunch_mcp/parser/imports.py
+++ b/src/jcodemunch_mcp/parser/imports.py
@@ -293,12 +293,100 @@ def _extract_sql_dbt_imports(content: str) -> list[dict]:
 # Public API
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Vue <template> component extraction
+# ---------------------------------------------------------------------------
+
+_VUE_TEMPLATE_BLOCK = re.compile(r"<template\b[^>]*>(.*)</template>", re.DOTALL)
+
+_VUE_TEMPLATE_COMPONENT = re.compile(
+    r"""<(?P<tag>[A-Z][\w]*|[a-z]+-[\w-]+)[\s/>]""",
+    re.MULTILINE,
+)
+
+_HTML_STANDARD_ELEMENTS = frozenset({
+    # HTML5 elements
+    "a", "abbr", "address", "area", "article", "aside", "audio",
+    "b", "base", "bdi", "bdo", "blockquote", "body", "br", "button",
+    "canvas", "caption", "cite", "code", "col", "colgroup",
+    "data", "datalist", "dd", "del", "details", "dfn", "dialog", "div", "dl", "dt",
+    "em", "embed",
+    "fieldset", "figcaption", "figure", "footer", "form",
+    "h1", "h2", "h3", "h4", "h5", "h6", "head", "header", "hgroup", "hr", "html",
+    "i", "iframe", "img", "input", "ins",
+    "kbd",
+    "label", "legend", "li", "link",
+    "main", "map", "mark", "menu", "meta", "meter",
+    "nav", "noscript",
+    "object", "ol", "optgroup", "option", "output",
+    "p", "param", "picture", "pre", "progress",
+    "q",
+    "rp", "rt", "ruby",
+    "s", "samp", "script", "search", "section", "select", "slot", "small", "source", "span",
+    "strong", "style", "sub", "summary", "sup",
+    "table", "tbody", "td", "template", "textarea", "tfoot", "th", "thead", "time", "title", "tr", "track",
+    "u", "ul",
+    "var", "video",
+    "wbr",
+    # SVG elements
+    "svg", "path", "circle", "rect", "line", "g", "defs", "use", "text",
+    "polygon", "polyline", "ellipse", "image", "mask", "pattern",
+    # Vue built-in elements
+    "transition", "transition-group", "keep-alive", "teleport", "suspense", "component",
+})
+
+
+def _kebab_to_pascal(name: str) -> str:
+    """Convert kebab-case to PascalCase: 'user-table' → 'UserTable'."""
+    return "".join(part.capitalize() for part in name.split("-"))
+
+
+def _extract_vue_template_components(content: str) -> list[str]:
+    """Extract component names used in Vue <template> blocks."""
+    m = _VUE_TEMPLATE_BLOCK.search(content)
+    if not m:
+        return []
+    template = m.group(1)
+
+    components: set[str] = set()
+    for cm in _VUE_TEMPLATE_COMPONENT.finditer(template):
+        tag = cm.group("tag")
+        # Normalize to lowercase for HTML check
+        if tag.lower() not in _HTML_STANDARD_ELEMENTS:
+            components.add(tag)
+    return sorted(components)
+
+
+def _extract_vue_imports(content: str) -> list[dict]:
+    """Extract imports from Vue SFC: script imports + template component usage."""
+    edges = _extract_js_imports(content)
+
+    template_components = _extract_vue_template_components(content)
+    if not template_components:
+        return edges
+
+    # Collect already-imported names from <script> for dedup
+    imported_names: set[str] = set()
+    for edge in edges:
+        imported_names.update(edge["names"])
+
+    for component in template_components:
+        # Check if already imported (PascalCase or kebab→PascalCase)
+        pascal = _kebab_to_pascal(component) if "-" in component else component
+        if component in imported_names or pascal in imported_names:
+            continue
+        # Synthetic import edge for template-only component usage
+        edges.append({"specifier": pascal, "names": [pascal]})
+
+    return edges
+
+
 _LANGUAGE_EXTRACTORS = {
     "javascript": _extract_js_imports,
     "typescript": _extract_js_imports,
     "tsx": _extract_js_imports,
     "jsx": _extract_js_imports,
-    "vue": _extract_js_imports,
+    "vue": _extract_vue_imports,
     "python": _extract_python_imports,
     "go": _extract_go_imports,
     "java": lambda c: _extract_java_imports(c, "java"),

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -397,7 +397,7 @@ def _build_tools_list() -> list[Tool]:
         ),
         Tool(
             name="get_symbol_source",
-            description="Get full source of one symbol (symbol_id → flat object) or many (symbol_ids[] → {symbols, errors}). Supports verify and context_lines.",
+            description="Get full source of one symbol (symbol_id → flat object) or many (symbol_ids[] → {symbols, errors}). Supports verify, context_lines, and fqn (PHP FQN via PSR-4).",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -423,6 +423,10 @@ def _build_tools_list() -> list[Tool]:
                         "type": "integer",
                         "description": "Number of lines before/after symbol to include for context",
                         "default": 0
+                    },
+                    "fqn": {
+                        "type": "string",
+                        "description": "PHP fully-qualified class name (e.g. 'App\\Models\\User'). Resolves to symbol_id via PSR-4. Alternative to symbol_id."
                     }
                 },
                 "required": ["repo"]
@@ -537,6 +541,10 @@ def _build_tools_list() -> list[Tool]:
                         "type": "boolean",
                         "description": "Skip BM25 entirely and rank solely by embedding cosine similarity. Implies semantic=true.",
                         "default": False
+                    },
+                    "fqn": {
+                        "type": "string",
+                        "description": "PHP fully-qualified class name (e.g. 'App\\Models\\User'). Resolves via PSR-4 and uses the class name as query. Alternative to query."
                     }
                 },
                 "required": ["repo", "query"]
@@ -697,7 +705,8 @@ def _build_tools_list() -> list[Tool]:
             description=(
                 "Get full source + imports for one or more symbols in one call. "
                 "Multi-symbol bundles deduplicate shared imports. "
-                "Set token_budget to cap response size; use budget_strategy to control what's kept."
+                "Set token_budget to cap response size; use budget_strategy to control what's kept. "
+                "Supports fqn (PHP FQN via PSR-4) as alternative to symbol_id."
             ),
             inputSchema={
                 "type": "object",
@@ -744,6 +753,10 @@ def _build_tools_list() -> list[Tool]:
                         "type": "boolean",
                         "description": "When true, include a 'budget_report' field showing tokens used, symbols included/excluded, and strategy applied.",
                         "default": False
+                    },
+                    "fqn": {
+                        "type": "string",
+                        "description": "PHP fully-qualified class name (e.g. 'App\\Models\\User'). Resolves to symbol_id via PSR-4. Alternative to symbol_id."
                     }
                 },
                 "required": ["repo"]
@@ -886,6 +899,10 @@ def _build_tools_list() -> list[Tool]:
                         "type": "integer",
                         "description": "When > 0, also find symbols that *call* this symbol (call-level analysis). Returns a callers list alongside the import-level confirmed/potential. Max 3. Default 0 (disabled).",
                         "default": 0,
+                    },
+                    "fqn": {
+                        "type": "string",
+                        "description": "PHP fully-qualified class name (e.g. 'App\\Models\\User'). Resolves to symbol via PSR-4. Alternative to symbol."
                     },
                 },
                 "required": ["repo", "symbol"]
@@ -1679,6 +1696,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                     verify=arguments.get("verify", False),
                     context_lines=arguments.get("context_lines", 0),
                     storage_path=storage_path,
+                    fqn=arguments.get("fqn"),
                 )
             )
         elif name == "search_symbols":
@@ -1707,6 +1725,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                         semantic_weight=arguments.get("semantic_weight", 0.5),
                         semantic_only=arguments.get("semantic_only", False),
                         storage_path=storage_path,
+                        fqn=arguments.get("fqn"),
                     )
                 )
         elif name == "invalidate_cache":
@@ -1807,6 +1826,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                     budget_strategy=arguments.get("budget_strategy", "most_relevant"),
                     include_budget_report=arguments.get("include_budget_report", False),
                     storage_path=storage_path,
+                    fqn=arguments.get("fqn"),
                 )
             )
         elif name == "get_ranked_context":
@@ -1864,6 +1884,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                     storage_path=storage_path,
                     cross_repo=arguments.get("cross_repo"),
                     call_depth=arguments.get("call_depth", 0),
+                    fqn=arguments.get("fqn"),
                 )
             )
         elif name == "get_call_hierarchy":

--- a/src/jcodemunch_mcp/tools/_indexing_pipeline.py
+++ b/src/jcodemunch_mcp/tools/_indexing_pipeline.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import Optional
 
 from ..parser import parse_file, get_language_for_path
-from ..parser.context import ContextProvider, enrich_symbols
+from ..parser.context import ContextProvider, enrich_symbols, collect_extra_imports
 from ..parser.imports import extract_imports
 from ..parser.symbols import Symbol
 from ..summarizer import summarize_symbols, generate_file_summaries
@@ -143,6 +143,10 @@ def parse_immediate(
         if imps:
             file_imports[rel_path] = imps
 
+    # 6. Merge extra imports from context providers (Blade refs, route→controller, etc.)
+    if providers:
+        collect_extra_imports(providers, file_imports)
+
     return new_symbols, file_summaries, file_langs, file_imports, no_symbols_files
 
 
@@ -260,6 +264,10 @@ def parse_and_prepare_incremental(
         imps = extract_imports(content, rel_path, language)
         if imps:
             file_imports[rel_path] = imps
+
+    # 6. Merge extra imports from context providers (Blade refs, route→controller, etc.)
+    if providers:
+        collect_extra_imports(providers, file_imports)
 
     return new_symbols, file_summaries, file_langs, file_imports, no_symbols_files
 
@@ -390,5 +398,9 @@ def parse_and_prepare_full(
             imps = extract_imports(content, path, language)
             if imps:
                 file_imports[path] = imps
+
+    # 6. Merge extra imports from context providers (Blade refs, route→controller, etc.)
+    if providers:
+        collect_extra_imports(providers, file_imports)
 
     return all_symbols, file_summaries, languages, file_langs, file_imports, no_symbols_files

--- a/src/jcodemunch_mcp/tools/_utils.py
+++ b/src/jcodemunch_mcp/tools/_utils.py
@@ -1,8 +1,11 @@
 """Shared helpers for tool modules."""
 
+import logging
 from typing import Optional
 
 from ..storage import IndexStore
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Bare-name resolution cache (P5)
@@ -64,3 +67,32 @@ def resolve_repo(repo: str, storage_path: Optional[str] = None) -> tuple[str, st
         )
 
     return candidates[0].split("/", 1)
+
+
+def resolve_fqn(
+    repo: str, fqn: str, storage_path: Optional[str] = None
+) -> tuple[Optional[str], Optional[str]]:
+    """Resolve a PHP FQN to a jcodemunch symbol_id.
+
+    Returns ``(symbol_id, None)`` on success or ``(None, error_message)`` on failure.
+    """
+    from ..parser.fqn import fqn_to_symbol
+    from ..parser.imports import build_psr4_map
+
+    try:
+        owner, name = resolve_repo(repo, storage_path)
+    except ValueError as e:
+        return None, f"Repository not found: {e}"
+    store = IndexStore(base_path=storage_path)
+    index = store.load_index(owner, name)
+    if not index:
+        return None, f"Repository not indexed: {owner}/{name}"
+    if not getattr(index, "source_root", None):
+        return None, "Index has no source_root (remote indexes don't support FQN resolution)"
+    psr4 = build_psr4_map(index.source_root)
+    if not psr4:
+        return None, "No PSR-4 autoload config found in composer.json"
+    resolved = fqn_to_symbol(fqn, psr4, frozenset(index.source_files))
+    if not resolved:
+        return None, f"FQN '{fqn}' could not be resolved. File not in index or namespace mismatch."
+    return resolved, None

--- a/src/jcodemunch_mcp/tools/get_blast_radius.py
+++ b/src/jcodemunch_mcp/tools/get_blast_radius.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from ..storage import IndexStore, result_cache_get, result_cache_put
 from ..parser.imports import resolve_specifier
-from ._utils import resolve_repo
+from ._utils import resolve_repo, resolve_fqn
 from .package_registry import extract_root_package_from_specifier
 from ._call_graph import build_symbols_by_file, find_direct_callers, bfs_callers
 
@@ -77,6 +77,7 @@ def get_blast_radius(
     storage_path: Optional[str] = None,
     cross_repo: Optional[bool] = None,
     call_depth: int = 0,
+    fqn: Optional[str] = None,
 ) -> dict:
     """Find all files that would be affected if a symbol's signature or behaviour changed.
 
@@ -100,6 +101,12 @@ def get_blast_radius(
         Dict with symbol info, confirmed/potential affected files, counts, and _meta.
         When call_depth > 0: also includes ``callers`` and ``caller_count``.
     """
+    # FQN resolution: translate PHP FQN → symbol name/id
+    if fqn:
+        _resolved, _ = resolve_fqn(repo, fqn, storage_path)
+        if _resolved:
+            symbol = _resolved
+
     depth = max(1, min(depth, 3))
     call_depth = max(0, min(call_depth, 3))
     start = time.perf_counter()

--- a/src/jcodemunch_mcp/tools/get_context_bundle.py
+++ b/src/jcodemunch_mcp/tools/get_context_bundle.py
@@ -222,6 +222,7 @@ def get_context_bundle(
     budget_strategy: str = "most_relevant",
     include_budget_report: bool = False,
     storage_path: Optional[str] = None,
+    fqn: Optional[str] = None,
 ) -> dict:
     """Get a context bundle: symbol definitions + imports from their files.
 
@@ -258,6 +259,14 @@ def get_context_bundle(
 
     if budget_strategy not in ("most_relevant", "core_first", "compact"):
         return {"error": f"Invalid budget_strategy '{budget_strategy}'. Must be 'most_relevant', 'core_first', or 'compact'."}
+
+    # FQN resolution: translate PHP FQN → symbol_id
+    if fqn and symbol_id is None and symbol_ids is None:
+        from ._utils import resolve_fqn
+        _resolved, _err = resolve_fqn(repo, fqn, storage_path)
+        if _resolved is None:
+            return {"error": _err or f"Could not resolve FQN '{fqn}'."}
+        symbol_id = _resolved
 
     # Normalise inputs
     if symbol_ids is not None:

--- a/src/jcodemunch_mcp/tools/get_symbol.py
+++ b/src/jcodemunch_mcp/tools/get_symbol.py
@@ -6,7 +6,7 @@ import time
 from typing import Optional
 
 from ..storage import IndexStore, record_savings, estimate_savings, cost_avoided as _cost_avoided
-from ._utils import resolve_repo
+from ._utils import resolve_repo, resolve_fqn
 
 
 def _make_meta(timing_ms: float, **kwargs) -> dict:
@@ -23,18 +23,27 @@ def get_symbol_source(
     verify: bool = False,
     context_lines: int = 0,
     storage_path: Optional[str] = None,
+    fqn: Optional[str] = None,
 ) -> dict:
     """Get full source of one or more symbols by ID.
 
     Pass symbol_id (string) for one symbol — returns flat symbol object.
     Pass symbol_ids (array) for batch — returns {symbols, errors}.
     Both modes support verify and context_lines.
+    Pass fqn (PHP FQN like 'App\\Models\\User') to resolve via PSR-4.
     """
+    # FQN resolution: translate PHP FQN → symbol_id
+    if fqn and symbol_id is None and symbol_ids is None:
+        resolved, fqn_error = resolve_fqn(repo, fqn, storage_path)
+        if resolved is None:
+            return {"error": fqn_error or f"Could not resolve FQN '{fqn}'."}
+        symbol_id = resolved
+
     # Normalize: some MCP clients send symbol_ids=[] alongside symbol_id when they mean singular mode
     if symbol_id is not None and symbol_ids is not None and len(symbol_ids) == 0:
         symbol_ids = None
     if symbol_id is None and symbol_ids is None:
-        return {"error": "Provide symbol_id (string) or symbol_ids (array)."}
+        return {"error": "Provide symbol_id (string), symbol_ids (array), or fqn (PHP FQN)."}
     if symbol_id is not None and symbol_ids is not None:
         return {"error": "Provide symbol_id or symbol_ids, not both."}
 

--- a/src/jcodemunch_mcp/tools/index_folder.py
+++ b/src/jcodemunch_mcp/tools/index_folder.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 from .. import config as _config
 from ..parser import parse_file, LANGUAGE_EXTENSIONS, get_language_for_path
-from ..parser.context import discover_providers, enrich_symbols, collect_metadata
+from ..parser.context import discover_providers, enrich_symbols, collect_metadata, collect_extra_imports
 from ..parser.context.framework_profiles import detect_framework, profile_to_meta
 from ..parser.imports import extract_imports, _alias_map_cache as _imap_cache
 from ..security import (
@@ -1048,6 +1048,10 @@ def index_folder(
         # Enrich with context providers before summarization
         if active_providers and all_symbols:
             enrich_symbols(all_symbols, active_providers)
+
+        # Merge extra imports from context providers (Blade refs, facades, etc.)
+        if active_providers:
+            collect_extra_imports(active_providers, file_imports)
 
         # Generate summaries — preserve existing summaries for unchanged files
         if all_symbols:

--- a/src/jcodemunch_mcp/tools/search_symbols.py
+++ b/src/jcodemunch_mcp/tools/search_symbols.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from ..storage import IndexStore, CodeIndex, record_savings, estimate_savings, cost_avoided
 from ..parser.imports import resolve_specifier
-from ._utils import resolve_repo
+from ._utils import resolve_repo, resolve_fqn
 
 BYTES_PER_TOKEN = 4
 
@@ -235,7 +235,8 @@ def search_symbols(
     semantic: bool = False,
     semantic_weight: float = 0.5,
     semantic_only: bool = False,
-    storage_path: Optional[str] = None
+    storage_path: Optional[str] = None,
+    fqn: Optional[str] = None,
 ) -> dict:
     """Search for symbols matching a query.
 
@@ -281,6 +282,12 @@ def search_symbols(
 
     if sort_by not in ("relevance", "centrality", "combined"):
         return {"error": f"Invalid sort_by '{sort_by}'. Must be 'relevance', 'centrality', or 'combined'."}
+
+    # FQN shortcut: resolve PHP FQN and use class name as query
+    if fqn:
+        _resolved, _ = resolve_fqn(repo, fqn, storage_path)
+        if _resolved:
+            query = fqn.rsplit("\\", 1)[-1].split("::")[0]
 
     _MAX_QUERY_LEN = 500
     if len(query) > _MAX_QUERY_LEN:

--- a/tests/test_context_providers.py
+++ b/tests/test_context_providers.py
@@ -10,6 +10,7 @@ from jcodemunch_mcp.parser.context.base import (
     register_provider,
     discover_providers,
     enrich_symbols,
+    collect_extra_imports,
 )
 
 
@@ -262,3 +263,111 @@ class TestEnrichSymbols:
         sym = _make_symbol("source")
         enrich_symbols([sym], [])
         assert sym.ecosystem_context == ""
+
+
+# ===========================================================================
+# collect_extra_imports tests
+# ===========================================================================
+
+
+class _StubProviderWithImports(_StubProvider):
+    """Stub provider that also returns extra imports."""
+
+    def __init__(self, extra_imports=None, **kwargs):
+        super().__init__(**kwargs)
+        self._extra_imports = extra_imports or {}
+
+    def get_extra_imports(self):
+        return self._extra_imports
+
+
+class _FailingImportsProvider(_StubProvider):
+    """Provider whose get_extra_imports raises."""
+
+    def get_extra_imports(self):
+        raise RuntimeError("import extraction failed")
+
+
+class TestCollectExtraImports:
+
+    def test_merges_into_empty(self):
+        provider = _StubProviderWithImports(extra_imports={
+            "routes/web.php": [{"specifier": "UserController", "names": ["UserController"]}],
+        })
+        file_imports: dict[str, list[dict]] = {}
+        collect_extra_imports([provider], file_imports)
+
+        assert "routes/web.php" in file_imports
+        assert len(file_imports["routes/web.php"]) == 1
+        assert file_imports["routes/web.php"][0]["specifier"] == "UserController"
+
+    def test_merges_into_existing_without_duplicates(self):
+        provider = _StubProviderWithImports(extra_imports={
+            "app/Http/Controllers/UserController.php": [
+                {"specifier": "Illuminate\\Cache\\CacheManager", "names": ["Cache"]},
+            ],
+        })
+        # Pre-existing imports (from PHP use statement extraction)
+        file_imports = {
+            "app/Http/Controllers/UserController.php": [
+                {"specifier": "App\\Models\\User", "names": ["User"]},
+            ],
+        }
+        collect_extra_imports([provider], file_imports)
+
+        imports = file_imports["app/Http/Controllers/UserController.php"]
+        assert len(imports) == 2
+        specifiers = {i["specifier"] for i in imports}
+        assert "App\\Models\\User" in specifiers
+        assert "Illuminate\\Cache\\CacheManager" in specifiers
+
+    def test_deduplicates_same_specifier(self):
+        provider = _StubProviderWithImports(extra_imports={
+            "app/main.php": [
+                {"specifier": "App\\Models\\User", "names": ["User"]},
+            ],
+        })
+        file_imports = {
+            "app/main.php": [
+                {"specifier": "App\\Models\\User", "names": ["User"]},
+            ],
+        }
+        collect_extra_imports([provider], file_imports)
+
+        # Should NOT duplicate — still 1 import
+        assert len(file_imports["app/main.php"]) == 1
+
+    def test_multiple_providers(self):
+        p1 = _StubProviderWithImports(extra_imports={
+            "app/Service.php": [{"specifier": "Cache", "names": ["Cache"]}],
+        })
+        p2 = _StubProviderWithImports(extra_imports={
+            "app/Service.php": [{"specifier": "DB", "names": ["DB"]}],
+        })
+        file_imports: dict[str, list[dict]] = {}
+        collect_extra_imports([p1, p2], file_imports)
+
+        assert len(file_imports["app/Service.php"]) == 2
+
+    def test_failing_provider_does_not_crash(self):
+        good = _StubProviderWithImports(extra_imports={
+            "app/a.php": [{"specifier": "X", "names": []}],
+        })
+        bad = _FailingImportsProvider()
+        file_imports: dict[str, list[dict]] = {}
+        collect_extra_imports([bad, good], file_imports)
+
+        # Good provider's imports should still be present
+        assert "app/a.php" in file_imports
+
+    def test_empty_providers_list(self):
+        file_imports = {"a.php": [{"specifier": "X", "names": []}]}
+        collect_extra_imports([], file_imports)
+        assert len(file_imports["a.php"]) == 1
+
+    def test_provider_without_override_returns_empty(self):
+        """Base ContextProvider.get_extra_imports() returns {} by default."""
+        provider = _StubProvider()
+        file_imports: dict[str, list[dict]] = {}
+        collect_extra_imports([provider], file_imports)
+        assert file_imports == {}

--- a/tests/test_find_importers.py
+++ b/tests/test_find_importers.py
@@ -85,6 +85,114 @@ class TestExtractImportsJS:
         assert len(matching) == 1
 
 
+class TestVueTemplateImports:
+    """Test Vue <template> component extraction."""
+
+    def test_pascal_case_component(self):
+        content = """
+<template>
+  <UserTable :users="users" />
+  <Pagination :total="10" />
+</template>
+<script setup>
+const users = []
+</script>
+"""
+        result = extract_imports(content, "src/App.vue", "vue")
+        specifiers = {r["specifier"] for r in result}
+        assert "UserTable" in specifiers
+        assert "Pagination" in specifiers
+
+    def test_kebab_case_component(self):
+        content = """
+<template>
+  <user-table />
+  <my-dialog />
+</template>
+<script setup></script>
+"""
+        result = extract_imports(content, "src/App.vue", "vue")
+        specifiers = {r["specifier"] for r in result}
+        assert "UserTable" in specifiers
+        assert "MyDialog" in specifiers
+
+    def test_already_imported_not_duplicated(self):
+        content = """
+<template>
+  <UserTable />
+</template>
+<script setup>
+import UserTable from '@/components/UserTable.vue'
+</script>
+"""
+        result = extract_imports(content, "src/App.vue", "vue")
+        user_table = [r for r in result if "UserTable" in r.get("names", [])]
+        # Only one entry — from the script import, not duplicated by template
+        assert len(user_table) == 1
+        assert user_table[0]["specifier"] == "@/components/UserTable.vue"
+
+    def test_html_elements_excluded(self):
+        content = """
+<template>
+  <div><span>text</span></div>
+  <button @click="go">Go</button>
+  <input type="text" />
+  <h1>Title</h1>
+</template>
+<script setup></script>
+"""
+        result = extract_imports(content, "src/App.vue", "vue")
+        specifiers = {r["specifier"] for r in result}
+        assert "div" not in specifiers
+        assert "span" not in specifiers
+        assert "button" not in specifiers
+        assert "input" not in specifiers
+
+    def test_vue_builtins_excluded(self):
+        content = """
+<template>
+  <transition name="fade"><div/></transition>
+  <keep-alive><component :is="current"/></keep-alive>
+  <teleport to="body"><div/></teleport>
+</template>
+<script setup></script>
+"""
+        result = extract_imports(content, "src/App.vue", "vue")
+        specifiers = {r["specifier"] for r in result}
+        assert "Transition" not in specifiers
+        assert "KeepAlive" not in specifiers
+        assert "Teleport" not in specifiers
+
+    def test_no_template_block(self):
+        content = """
+<script setup>
+import Foo from './Foo'
+const x = 1
+</script>
+"""
+        result = extract_imports(content, "src/App.vue", "vue")
+        assert len(result) == 1
+        assert result[0]["specifier"] == "./Foo"
+
+    def test_mixed_imported_and_template_only(self):
+        content = """
+<template>
+  <ImportedComponent />
+  <TemplateOnly />
+</template>
+<script setup>
+import ImportedComponent from './ImportedComponent.vue'
+</script>
+"""
+        result = extract_imports(content, "src/App.vue", "vue")
+        specifiers = {r["specifier"] for r in result}
+        assert "./ImportedComponent.vue" in specifiers
+        assert "TemplateOnly" in specifiers
+        # ImportedComponent should NOT appear as a synthetic edge
+        synthetic = [r for r in result if r["specifier"] == "ImportedComponent"]
+        assert len(synthetic) == 0
+
+
 class TestExtractImportsPython:
     """Test Python import extraction."""
 
@@ -1042,3 +1150,174 @@ class TestImportsPersistence:
         index = store.load_index(owner, name)
         assert "app.js" in index.imports
         assert "new_importer.js" in index.imports
+
+
+class TestLaravelExtraImportsPipeline:
+    """Integration: verify that Laravel provider extra imports flow through the pipeline."""
+
+    def test_blade_imports_in_index(self, tmp_path):
+        """Blade @extends/@include create import edges visible in the stored index."""
+        import json
+        store_path = tmp_path / "store"
+
+        # Create minimal Laravel project
+        _write(tmp_path / "artisan", "#!/usr/bin/env php\n<?php\n")
+        _write(tmp_path / "composer.json", json.dumps({
+            "require": {"laravel/framework": "^11.0"},
+            "autoload": {"psr-4": {"App\\": "app/"}},
+        }))
+        _write(tmp_path / "resources" / "views" / "layouts" / "app.blade.php",
+               "<!DOCTYPE html><html>@yield('content')</html>")
+        _write(tmp_path / "resources" / "views" / "home.blade.php",
+               "@extends('layouts.app')\n@section('content')\n<h1>Home</h1>\n@endsection")
+        # Need at least one PHP file with symbols for the index to work
+        _write(tmp_path / "app" / "Models" / "User.php",
+               "<?php\nnamespace App\\Models;\nclass User extends Model {}\n")
+
+        result = index_folder(str(tmp_path), use_ai_summaries=False,
+                              storage_path=str(store_path))
+        assert result["success"] is True
+
+        store = IndexStore(base_path=str(store_path))
+        owner, name = result["repo"].split("/", 1)
+        index = store.load_index(owner, name)
+
+        # Blade file should have an import edge to layouts/app
+        blade_imports = index.imports.get("resources/views/home.blade.php", [])
+        specifiers = {imp["specifier"] for imp in blade_imports}
+        assert "resources/views/layouts/app.blade.php" in specifiers
+
+    def test_facade_imports_in_index(self, tmp_path):
+        """Facade static calls create import edges to Illuminate classes."""
+        import json
+        store_path = tmp_path / "store"
+
+        _write(tmp_path / "artisan", "#!/usr/bin/env php\n<?php\n")
+        _write(tmp_path / "composer.json", json.dumps({
+            "require": {"laravel/framework": "^11.0"},
+            "autoload": {"psr-4": {"App\\": "app/"}},
+        }))
+        _write(tmp_path / "app" / "Services" / "OrderService.php", r"""<?php
+namespace App\Services;
+
+class OrderService
+{
+    public function process()
+    {
+        Cache::put('key', 'value');
+        DB::table('orders')->get();
+    }
+}
+""")
+
+        result = index_folder(str(tmp_path), use_ai_summaries=False,
+                              storage_path=str(store_path))
+        assert result["success"] is True
+
+        store = IndexStore(base_path=str(store_path))
+        owner, name = result["repo"].split("/", 1)
+        index = store.load_index(owner, name)
+
+        svc_imports = index.imports.get("app/Services/OrderService.php", [])
+        specifiers = {imp["specifier"] for imp in svc_imports}
+        assert "Illuminate\\Cache\\CacheManager" in specifiers
+        assert "Illuminate\\Database\\DatabaseManager" in specifiers
+
+    def test_eloquent_relationship_imports_in_index(self, tmp_path):
+        """Eloquent relationship calls create import edges between models."""
+        import json
+        store_path = tmp_path / "store"
+
+        _write(tmp_path / "artisan", "#!/usr/bin/env php\n<?php\n")
+        _write(tmp_path / "composer.json", json.dumps({
+            "require": {"laravel/framework": "^11.0"},
+            "autoload": {"psr-4": {"App\\": "app/"}},
+        }))
+        _write(tmp_path / "app" / "Models" / "User.php", r"""<?php
+namespace App\Models;
+class User extends Model
+{
+    public function posts() { return $this->hasMany(Post::class); }
+}
+""")
+        _write(tmp_path / "app" / "Models" / "Post.php", r"""<?php
+namespace App\Models;
+class Post extends Model {}
+""")
+
+        result = index_folder(str(tmp_path), use_ai_summaries=False,
+                              storage_path=str(store_path))
+        assert result["success"] is True
+
+        store = IndexStore(base_path=str(store_path))
+        owner, name = result["repo"].split("/", 1)
+        index = store.load_index(owner, name)
+
+        user_imports = index.imports.get("app/Models/User.php", [])
+        specifiers = {imp["specifier"] for imp in user_imports}
+        assert "Post" in specifiers
+
+    def test_inertia_imports_in_index(self, tmp_path):
+        """Inertia::render creates import edges from controllers to Vue pages."""
+        import json
+        store_path = tmp_path / "store"
+
+        _write(tmp_path / "artisan", "#!/usr/bin/env php\n<?php\n")
+        _write(tmp_path / "composer.json", json.dumps({
+            "require": {"laravel/framework": "^11.0", "inertiajs/inertia-laravel": "^1.0"},
+            "autoload": {"psr-4": {"App\\": "app/"}},
+        }))
+        _write(tmp_path / "app" / "Http" / "Controllers" / "UserController.php", r"""<?php
+namespace App\Http\Controllers;
+use Inertia\Inertia;
+class UserController extends Controller
+{
+    public function index() { return Inertia::render('Users/Index', ['users' => []]); }
+}
+""")
+        (tmp_path / "resources" / "js" / "Pages" / "Users").mkdir(parents=True)
+        _write(tmp_path / "resources" / "js" / "Pages" / "Users" / "Index.vue",
+               "<template><div>Users</div></template>")
+
+        result = index_folder(str(tmp_path), use_ai_summaries=False,
+                              storage_path=str(store_path))
+        assert result["success"] is True
+
+        store = IndexStore(base_path=str(store_path))
+        owner, name = result["repo"].split("/", 1)
+        index = store.load_index(owner, name)
+
+        ctrl_imports = index.imports.get("app/Http/Controllers/UserController.php", [])
+        specifiers = {imp["specifier"] for imp in ctrl_imports}
+        assert "resources/js/Pages/Users/Index.vue" in specifiers
+
+    def test_vue_template_components_in_index(self, tmp_path):
+        """Vue <template> component usage creates synthetic import edges."""
+        store_path = tmp_path / "store"
+
+        _write(tmp_path / "src" / "components" / "UserTable.vue",
+               "<template><table></table></template>\n<script setup></script>")
+        _write(tmp_path / "src" / "App.vue", """
+<template>
+  <UserTable />
+  <NavBar />
+</template>
+<script setup>
+import UserTable from './components/UserTable.vue'
+</script>
+""")
+
+        result = index_folder(str(tmp_path), use_ai_summaries=False,
+                              storage_path=str(store_path))
+        assert result["success"] is True
+
+        store = IndexStore(base_path=str(store_path))
+        owner, name = result["repo"].split("/", 1)
+        index = store.load_index(owner, name)
+
+        app_imports = index.imports.get("src/App.vue", [])
+        specifiers = {imp["specifier"] for imp in app_imports}
+        # UserTable imported in <script> — should appear
+        assert "./components/UserTable.vue" in specifiers
+        # NavBar only in <template>, not imported — synthetic edge
+        assert "NavBar" in specifiers

--- a/tests/test_fqn.py
+++ b/tests/test_fqn.py
@@ -1,0 +1,184 @@
+"""Tests for FQN ↔ symbol_id translation."""
+
+import json
+from pathlib import Path
+
+from jcodemunch_mcp.parser.fqn import symbol_to_fqn, fqn_to_symbol
+from jcodemunch_mcp.tools._utils import resolve_fqn
+from jcodemunch_mcp.tools.index_folder import index_folder
+from jcodemunch_mcp.storage import IndexStore
+
+
+PSR4_MAP = {
+    "App\\": "app/",
+    "Database\\": "database/",
+}
+
+
+class TestSymbolToFqn:
+
+    def test_class_symbol(self):
+        result = symbol_to_fqn("app/Models/User.php::User#class", PSR4_MAP)
+        assert result == "App\\Models\\User"
+
+    def test_nested_namespace(self):
+        result = symbol_to_fqn(
+            "app/Http/Controllers/Admin/UserController.php::UserController#class",
+            PSR4_MAP,
+        )
+        assert result == "App\\Http\\Controllers\\Admin\\UserController"
+
+    def test_method_symbol(self):
+        result = symbol_to_fqn("app/Models/User.php::User.posts#method", PSR4_MAP)
+        assert result == "App\\Models\\User::posts"
+
+    def test_non_php_returns_none(self):
+        result = symbol_to_fqn("src/main.py::main#function", PSR4_MAP)
+        assert result is None
+
+    def test_no_matching_prefix_returns_none(self):
+        result = symbol_to_fqn("vendor/Foo.php::Foo#class", PSR4_MAP)
+        assert result is None
+
+    def test_no_separator_returns_none(self):
+        result = symbol_to_fqn("just-a-string", PSR4_MAP)
+        assert result is None
+
+    def test_database_prefix(self):
+        result = symbol_to_fqn(
+            "database/Seeders/UserSeeder.php::UserSeeder#class", PSR4_MAP
+        )
+        assert result == "Database\\Seeders\\UserSeeder"
+
+    def test_function_kind_returns_none(self):
+        """Only class/method symbols translate to FQNs."""
+        result = symbol_to_fqn("app/helpers.php::formatDate#function", PSR4_MAP)
+        assert result is None
+
+
+class TestFqnToSymbol:
+
+    SOURCE_FILES = {
+        "app/Models/User.php",
+        "app/Models/Post.php",
+        "app/Http/Controllers/UserController.php",
+        "database/Seeders/UserSeeder.php",
+    }
+
+    def test_simple_class(self):
+        result = fqn_to_symbol("App\\Models\\User", PSR4_MAP, self.SOURCE_FILES)
+        assert result == "app/Models/User.php::User#class"
+
+    def test_nested_class(self):
+        result = fqn_to_symbol(
+            "App\\Http\\Controllers\\UserController", PSR4_MAP, self.SOURCE_FILES
+        )
+        assert result == "app/Http/Controllers/UserController.php::UserController#class"
+
+    def test_with_method(self):
+        result = fqn_to_symbol("App\\Models\\User::posts", PSR4_MAP, self.SOURCE_FILES)
+        assert result == "app/Models/User.php::User.posts#method"
+
+    def test_missing_file_returns_none(self):
+        result = fqn_to_symbol(
+            "App\\Models\\Order", PSR4_MAP, self.SOURCE_FILES
+        )
+        assert result is None
+
+    def test_database_prefix(self):
+        result = fqn_to_symbol(
+            "Database\\Seeders\\UserSeeder", PSR4_MAP, self.SOURCE_FILES
+        )
+        assert result == "database/Seeders/UserSeeder.php::UserSeeder#class"
+
+    def test_roundtrip_class(self):
+        """symbol_to_fqn and fqn_to_symbol should be inverses for class symbols."""
+        symbol_id = "app/Models/Post.php::Post#class"
+        fqn = symbol_to_fqn(symbol_id, PSR4_MAP)
+        assert fqn == "App\\Models\\Post"
+        back = fqn_to_symbol(fqn, PSR4_MAP, self.SOURCE_FILES)
+        assert back == symbol_id
+
+    def test_roundtrip_method(self):
+        symbol_id = "app/Models/User.php::User.posts#method"
+        fqn = symbol_to_fqn(symbol_id, PSR4_MAP)
+        assert fqn == "App\\Models\\User::posts"
+        back = fqn_to_symbol(fqn, PSR4_MAP, self.SOURCE_FILES)
+        assert back == symbol_id
+
+    def test_empty_psr4_map(self):
+        result = fqn_to_symbol("App\\Models\\User", {}, self.SOURCE_FILES)
+        assert result is None
+
+    def test_empty_source_files(self):
+        result = fqn_to_symbol("App\\Models\\User", PSR4_MAP, set())
+        assert result is None
+
+    def test_fqn_without_backslash(self):
+        """Simple class name without namespace should not resolve."""
+        result = fqn_to_symbol("User", PSR4_MAP, self.SOURCE_FILES)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_fqn integration (tools/_utils.py)
+# ---------------------------------------------------------------------------
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class TestResolveFqnIntegration:
+    def test_resolves_indexed_class(self, tmp_path):
+        store_path = tmp_path / "store"
+        _write(tmp_path / "artisan", "<?php\n")
+        _write(tmp_path / "composer.json", json.dumps({
+            "require": {"laravel/framework": "^11.0"},
+            "autoload": {"psr-4": {"App\\": "app/"}},
+        }))
+        _write(tmp_path / "app" / "Models" / "User.php",
+               "<?php\nnamespace App\\Models;\nclass User {}\n")
+
+        result = index_folder(str(tmp_path), use_ai_summaries=False,
+                              storage_path=str(store_path))
+        assert result["success"]
+
+        resolved, err = resolve_fqn(result["repo"], "App\\Models\\User",
+                                    str(store_path))
+        assert err is None
+        assert resolved == "app/Models/User.php::User#class"
+
+    def test_unresolvable_fqn(self, tmp_path):
+        store_path = tmp_path / "store"
+        _write(tmp_path / "composer.json", json.dumps({
+            "autoload": {"psr-4": {"App\\": "app/"}},
+        }))
+        _write(tmp_path / "app" / "Foo.php", "<?php\nclass Foo {}\n")
+
+        result = index_folder(str(tmp_path), use_ai_summaries=False,
+                              storage_path=str(store_path))
+        assert result["success"]
+
+        resolved, err = resolve_fqn(result["repo"], "App\\Models\\Missing",
+                                    str(store_path))
+        assert resolved is None
+        assert "could not be resolved" in err.lower()
+
+    def test_no_psr4_returns_error(self, tmp_path):
+        store_path = tmp_path / "store"
+        _write(tmp_path / "main.py", "print('hello')\n")
+
+        result = index_folder(str(tmp_path), use_ai_summaries=False,
+                              storage_path=str(store_path))
+        assert result["success"]
+
+        resolved, err = resolve_fqn(result["repo"], "App\\Models\\User",
+                                    str(store_path))
+        assert resolved is None
+        assert "PSR-4" in err
+
+    def test_repo_not_found(self):
+        resolved, err = resolve_fqn("nonexistent/repo", "App\\Models\\User")
+        assert resolved is None
+        assert "not indexed" in err.lower()

--- a/tests/test_laravel_provider.py
+++ b/tests/test_laravel_provider.py
@@ -7,6 +7,8 @@ import pytest
 
 from jcodemunch_mcp.parser.context.laravel import (
     LaravelContextProvider,
+    _blade_component_to_path,
+    _blade_dot_to_path,
     _guess_table,
     _parse_migration,
     _parse_model,
@@ -299,3 +301,613 @@ class TestLaravelContextProvider:
 
         ctx = provider.get_file_context("src/something.go")
         assert ctx is None
+
+
+# ---------------------------------------------------------------------------
+# Blade dot-notation helpers
+# ---------------------------------------------------------------------------
+
+class TestBladeDotToPath:
+    def test_simple_view(self):
+        assert _blade_dot_to_path("welcome") == "resources/views/welcome.blade.php"
+
+    def test_nested_view(self):
+        assert _blade_dot_to_path("layouts.app") == "resources/views/layouts/app.blade.php"
+
+    def test_deeply_nested(self):
+        assert _blade_dot_to_path("admin.users.index") == "resources/views/admin/users/index.blade.php"
+
+
+class TestBladeComponentToPath:
+    def test_simple_component(self):
+        assert _blade_component_to_path("alert") == "resources/views/components/alert.blade.php"
+
+    def test_nested_component(self):
+        assert _blade_component_to_path("forms.input") == "resources/views/components/forms/input.blade.php"
+
+    def test_hyphenated_component(self):
+        assert _blade_component_to_path("nav-link") == "resources/views/components/nav-link.blade.php"
+
+
+# ---------------------------------------------------------------------------
+# Blade import extraction
+# ---------------------------------------------------------------------------
+
+BLADE_LAYOUT = """<!DOCTYPE html>
+<html>
+<body>@yield('content')</body>
+</html>
+"""
+
+BLADE_WITH_REFS = """
+@extends('layouts.app')
+
+@section('content')
+    @include('partials.header')
+    @includeWhen($showSidebar, 'partials.sidebar')
+
+    <x-alert />
+    <x-forms.input type="text" />
+
+    {{ view('components.footer') }}
+@endsection
+"""
+
+
+class TestBladeImportExtraction:
+    def test_blade_imports_extracted(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        _write(tmp_path / "resources" / "views" / "layouts" / "app.blade.php", BLADE_LAYOUT)
+        _write(tmp_path / "resources" / "views" / "pages" / "home.blade.php", BLADE_WITH_REFS)
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        home_imports = extras.get("resources/views/pages/home.blade.php", [])
+        specifiers = {imp["specifier"] for imp in home_imports}
+
+        # @extends('layouts.app')
+        assert "resources/views/layouts/app.blade.php" in specifiers
+        # @include('partials.header')
+        assert "resources/views/partials/header.blade.php" in specifiers
+        # @includeWhen(..., 'partials.sidebar')
+        assert "resources/views/partials/sidebar.blade.php" in specifiers
+        # <x-alert>
+        assert "resources/views/components/alert.blade.php" in specifiers
+        # <x-forms.input>
+        assert "resources/views/components/forms/input.blade.php" in specifiers
+
+    def test_layout_has_no_blade_imports(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        _write(tmp_path / "resources" / "views" / "layouts" / "app.blade.php", BLADE_LAYOUT)
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        # Layout doesn't reference other views
+        assert "resources/views/layouts/app.blade.php" not in extras
+
+    def test_no_views_dir_is_safe(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        assert not any(k.startswith("resources/views/") for k in extras)
+
+
+# ---------------------------------------------------------------------------
+# Route → Controller import extraction
+# ---------------------------------------------------------------------------
+
+class TestRouteControllerImports:
+    def test_route_imports_controller(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        _write(tmp_path / "routes" / "api.php", ROUTES_PHP)
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        route_imports = extras.get("routes/api.php", [])
+        specifiers = {imp["specifier"] for imp in route_imports}
+
+        # Short name when use-imported; FQN when inlined
+        assert "UserController" in specifiers
+
+    def test_route_imports_deduplicated(self, tmp_path):
+        """Multiple routes to same controller should produce a single import edge."""
+        _make_laravel_project(tmp_path)
+        _write(tmp_path / "routes" / "api.php", ROUTES_PHP)
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        route_imports = extras.get("routes/api.php", [])
+        # 3 routes all to UserController, but only 1 import edge
+        assert len(route_imports) == 1
+        assert route_imports[0]["names"] == ["UserController"]
+
+    def test_inline_fqn_controller(self, tmp_path):
+        """When controller FQN is inline (no use statement), full namespace is captured."""
+        _make_laravel_project(tmp_path)
+        routes_content = r"""<?php
+Route::get('/users', [\App\Http\Controllers\UserController::class, 'index']);
+"""
+        _write(tmp_path / "routes" / "web.php", routes_content)
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        route_imports = extras.get("routes/web.php", [])
+        specifiers = {imp["specifier"] for imp in route_imports}
+        assert r"\App\Http\Controllers\UserController" in specifiers
+
+    def test_multiple_controllers(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        routes_content = """<?php
+use App\\Http\\Controllers\\UserController;
+use App\\Http\\Controllers\\PostController;
+
+Route::get('/users', [UserController::class, 'index']);
+Route::get('/posts', [PostController::class, 'index']);
+"""
+        _write(tmp_path / "routes" / "web.php", routes_content)
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        route_imports = extras.get("routes/web.php", [])
+        specifiers = {imp["specifier"] for imp in route_imports}
+
+        assert "UserController" in specifiers
+        assert "PostController" in specifiers
+
+
+# ---------------------------------------------------------------------------
+# Eloquent relationship → import edges
+# ---------------------------------------------------------------------------
+
+class TestEloquentRelationshipImports:
+    def test_relationship_creates_import_edge(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        _write(tmp_path / "app" / "Models" / "User.php", MODEL_PHP)
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        model_imports = extras.get("app/Models/User.php", [])
+        specifiers = {imp["specifier"] for imp in model_imports}
+
+        assert "Post" in specifiers
+        assert "Team" in specifiers
+
+    def test_relationship_with_fqn(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        model_with_fqn = r"""<?php
+namespace App\Models;
+
+class Order extends Model
+{
+    public function items()
+    {
+        return $this->hasMany(\App\Models\OrderItem::class);
+    }
+}
+"""
+        _write(tmp_path / "app" / "Models" / "Order.php", model_with_fqn)
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        model_imports = extras.get("app/Models/Order.php", [])
+        specifiers = {imp["specifier"] for imp in model_imports}
+        assert r"\App\Models\OrderItem" in specifiers
+
+    def test_no_relationships_no_imports(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        _write(tmp_path / "app" / "Models" / "Setting.php",
+               "<?php namespace App\\Models; class Setting extends Model {}")
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        assert "app/Models/Setting.php" not in extras
+
+    def test_deduplicated_relationships(self, tmp_path):
+        """Same model referenced in multiple relationships should produce one import."""
+        _make_laravel_project(tmp_path)
+        model = r"""<?php
+namespace App\Models;
+
+class User extends Model
+{
+    public function posts() { return $this->hasMany(Post::class); }
+    public function latestPost() { return $this->hasOne(Post::class); }
+}
+"""
+        _write(tmp_path / "app" / "Models" / "User.php", model)
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        model_imports = extras.get("app/Models/User.php", [])
+        post_imports = [i for i in model_imports if i["specifier"] == "Post"]
+        assert len(post_imports) == 1
+
+
+
+# ---------------------------------------------------------------------------
+# Facade resolution → import edges
+# ---------------------------------------------------------------------------
+
+class TestFacadeImports:
+    def test_facade_call_creates_import(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        controller = r"""<?php
+namespace App\Http\Controllers;
+
+class OrderController extends Controller
+{
+    public function index()
+    {
+        $orders = Cache::get('orders');
+        DB::table('orders')->get();
+        Log::info('Orders fetched');
+    }
+}
+"""
+        _write(tmp_path / "app" / "Http" / "Controllers" / "OrderController.php", controller)
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        imports = extras.get("app/Http/Controllers/OrderController.php", [])
+        specifiers = {imp["specifier"] for imp in imports}
+
+        assert "Illuminate\\Cache\\CacheManager" in specifiers
+        assert "Illuminate\\Database\\DatabaseManager" in specifiers
+        assert "Illuminate\\Log\\LogManager" in specifiers
+
+    def test_facade_class_reference_not_matched(self, tmp_path):
+        """Cache::class should NOT create a facade import (it's a class reference)."""
+        _make_laravel_project(tmp_path)
+        _write(tmp_path / "app" / "Services" / "Foo.php", r"""<?php
+namespace App\Services;
+class Foo {
+    public function bar() { return Cache::class; }
+}
+""")
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        imports = extras.get("app/Services/Foo.php", [])
+        specifiers = {imp["specifier"] for imp in imports}
+        # Cache::class is NOT a facade call
+        assert "Illuminate\\Cache\\CacheManager" not in specifiers
+
+    def test_non_facade_static_call_ignored(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        _write(tmp_path / "app" / "Services" / "Bar.php", r"""<?php
+namespace App\Services;
+class Bar {
+    public function baz() { return MyCustomClass::doSomething(); }
+}
+""")
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        imports = extras.get("app/Services/Bar.php", [])
+        # MyCustomClass is not in the facade registry
+        assert len(imports) == 0
+
+    def test_facade_deduplicated_in_same_file(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        _write(tmp_path / "app" / "Services" / "Dup.php", r"""<?php
+namespace App\Services;
+class Dup {
+    public function a() { Cache::get('x'); }
+    public function b() { Cache::put('y', 1); }
+}
+""")
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        imports = extras.get("app/Services/Dup.php", [])
+        cache_imports = [i for i in imports if "Cache" in i.get("names", [])]
+        assert len(cache_imports) == 1
+
+
+    def test_stats_include_import_counts(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        _write(tmp_path / "routes" / "api.php", ROUTES_PHP)
+        _write(tmp_path / "resources" / "views" / "home.blade.php", BLADE_WITH_REFS)
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        stats = provider.stats()
+        assert stats["route_files_with_imports"] >= 1
+        assert stats["blade_files_with_imports"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Inertia.js cross-language bridge
+# ---------------------------------------------------------------------------
+
+def _make_inertia_project(tmp_path, via_composer=True):
+    """Create a minimal Laravel + Inertia.js project skeleton."""
+    _make_laravel_project(tmp_path)
+    if via_composer:
+        import json
+        composer = json.loads((tmp_path / "composer.json").read_text())
+        composer["require"]["inertiajs/inertia-laravel"] = "^1.0"
+        (tmp_path / "composer.json").write_text(json.dumps(composer))
+    else:
+        _write(tmp_path / "app" / "Http" / "Middleware" / "HandleInertiaRequests.php",
+               "<?php\nnamespace App\\Http\\Middleware;\nclass HandleInertiaRequests {}\n")
+    (tmp_path / "resources" / "js" / "Pages").mkdir(parents=True, exist_ok=True)
+
+
+class TestInertiaImports:
+    def test_inertia_render_creates_import(self, tmp_path):
+        _make_inertia_project(tmp_path)
+        _write(tmp_path / "app" / "Http" / "Controllers" / "UserController.php", r"""<?php
+namespace App\Http\Controllers;
+use Inertia\Inertia;
+
+class UserController extends Controller
+{
+    public function index()
+    {
+        return Inertia::render('Users/Index', ['users' => []]);
+    }
+}
+""")
+        _write(tmp_path / "resources" / "js" / "Pages" / "Users" / "Index.vue",
+               "<template><div>Users</div></template>")
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        ctrl_imports = extras.get("app/Http/Controllers/UserController.php", [])
+        specifiers = {imp["specifier"] for imp in ctrl_imports}
+        assert "resources/js/Pages/Users/Index.vue" in specifiers
+
+    def test_inertia_helper_function(self, tmp_path):
+        _make_inertia_project(tmp_path)
+        _write(tmp_path / "app" / "Http" / "Controllers" / "DashCtrl.php", r"""<?php
+namespace App\Http\Controllers;
+class DashCtrl extends Controller
+{
+    public function show() { return inertia('Dashboard'); }
+}
+""")
+        _write(tmp_path / "resources" / "js" / "Pages" / "Dashboard.vue", "<template/>")
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        imports = extras.get("app/Http/Controllers/DashCtrl.php", [])
+        specifiers = {imp["specifier"] for imp in imports}
+        assert "resources/js/Pages/Dashboard.vue" in specifiers
+
+    def test_inertia_tsx_fallback(self, tmp_path):
+        _make_inertia_project(tmp_path)
+        _write(tmp_path / "app" / "Http" / "Controllers" / "Ctrl.php", r"""<?php
+class Ctrl { public function x() { return Inertia::render('Settings'); } }
+""")
+        _write(tmp_path / "resources" / "js" / "Pages" / "Settings.tsx", "export default () => <div/>;")
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        imports = extras.get("app/Http/Controllers/Ctrl.php", [])
+        specifiers = {imp["specifier"] for imp in imports}
+        assert "resources/js/Pages/Settings.tsx" in specifiers
+
+    def test_no_inertia_no_imports(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        _write(tmp_path / "app" / "Http" / "Controllers" / "Ctrl.php", r"""<?php
+class Ctrl { public function x() { return Inertia::render('Foo'); } }
+""")
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        imports = extras.get("app/Http/Controllers/Ctrl.php", [])
+        # No inertia dependency — no inertia imports
+        inertia_imports = [i for i in imports if "Pages/" in i.get("specifier", "")]
+        assert len(inertia_imports) == 0
+
+    def test_inertia_detected_via_middleware(self, tmp_path):
+        _make_inertia_project(tmp_path, via_composer=False)
+        _write(tmp_path / "app" / "Http" / "Controllers" / "Ctrl.php", r"""<?php
+class Ctrl { public function x() { return Inertia::render('Home'); } }
+""")
+        _write(tmp_path / "resources" / "js" / "Pages" / "Home.vue", "<template/>")
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        imports = extras.get("app/Http/Controllers/Ctrl.php", [])
+        specifiers = {imp["specifier"] for imp in imports}
+        assert "resources/js/Pages/Home.vue" in specifiers
+
+    def test_inertia_multiple_renders_deduplicated(self, tmp_path):
+        """Multiple renders to same page should produce one import edge."""
+        _make_inertia_project(tmp_path)
+        _write(tmp_path / "app" / "Http" / "Controllers" / "Ctrl.php", r"""<?php
+class Ctrl {
+    public function index() { return Inertia::render('Users/Index'); }
+    public function create() { return Inertia::render('Users/Index'); }
+}
+""")
+        _write(tmp_path / "resources" / "js" / "Pages" / "Users" / "Index.vue", "<template/>")
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        imports = extras.get("app/Http/Controllers/Ctrl.php", [])
+        vue_imports = [i for i in imports if i["specifier"].endswith(".vue")]
+        assert len(vue_imports) == 1
+
+    def test_inertia_page_with_extension_not_duplicated(self, tmp_path):
+        """Inertia::render('Users/Index.vue') should not produce .vue.vue path."""
+        _make_inertia_project(tmp_path)
+        _write(tmp_path / "app" / "Http" / "Controllers" / "Ctrl.php", r"""<?php
+class Ctrl { public function x() { return Inertia::render('Home.vue'); } }
+""")
+        _write(tmp_path / "resources" / "js" / "Pages" / "Home.vue", "<template/>")
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        imports = extras.get("app/Http/Controllers/Ctrl.php", [])
+        specifiers = {imp["specifier"] for imp in imports}
+        assert "resources/js/Pages/Home.vue" in specifiers
+        # Must NOT have double extension
+        assert "resources/js/Pages/Home.vue.vue" not in specifiers
+
+
+# ---------------------------------------------------------------------------
+# fetch/axios API call → route matching
+# ---------------------------------------------------------------------------
+
+ROUTES_WITH_API = """<?php
+use App\\Http\\Controllers\\Api\\UserController;
+use App\\Http\\Controllers\\Api\\OrderController;
+
+Route::get('/api/users', [UserController::class, 'index']);
+Route::get('/api/users/{user}', [UserController::class, 'show']);
+Route::post('/api/orders', [OrderController::class, 'store']);
+"""
+
+
+class TestApiCallImports:
+    def test_fetch_matches_route(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        _write(tmp_path / "routes" / "api.php", ROUTES_WITH_API)
+        _write(tmp_path / "app" / "Http" / "Controllers" / "Api" / "UserController.php",
+               "<?php namespace App\\Http\\Controllers\\Api; class UserController {}")
+        _write(tmp_path / "resources" / "js" / "api.js",
+               "fetch('/api/users').then(r => r.json())")
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        js_imports = extras.get("resources/js/api.js", [])
+        specifiers = {imp["specifier"] for imp in js_imports}
+        assert "app/Http/Controllers/Api/UserController.php" in specifiers
+
+    def test_axios_matches_route(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        _write(tmp_path / "routes" / "api.php", ROUTES_WITH_API)
+        _write(tmp_path / "app" / "Http" / "Controllers" / "Api" / "OrderController.php",
+               "<?php namespace App\\Http\\Controllers\\Api; class OrderController {}")
+        _write(tmp_path / "resources" / "js" / "orders.ts",
+               "axios.post('/api/orders', data)")
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        imports = extras.get("resources/js/orders.ts", [])
+        specifiers = {imp["specifier"] for imp in imports}
+        assert "app/Http/Controllers/Api/OrderController.php" in specifiers
+
+    def test_dynamic_segment_matched(self, tmp_path):
+        """fetch('/api/users/123') should match route /api/users/{user}."""
+        _make_laravel_project(tmp_path)
+        _write(tmp_path / "routes" / "api.php", ROUTES_WITH_API)
+        _write(tmp_path / "app" / "Http" / "Controllers" / "Api" / "UserController.php",
+               "<?php namespace App\\Http\\Controllers\\Api; class UserController {}")
+        _write(tmp_path / "resources" / "js" / "user.vue",
+               "<script>fetch('/api/users/42')</script>")
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        imports = extras.get("resources/js/user.vue", [])
+        specifiers = {imp["specifier"] for imp in imports}
+        assert "app/Http/Controllers/Api/UserController.php" in specifiers
+
+    def test_no_routes_no_api_imports(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        _write(tmp_path / "resources" / "js" / "app.js",
+               "fetch('/api/something')")
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        imports = extras.get("resources/js/app.js", [])
+        assert len(imports) == 0
+
+    def test_non_api_fetch_ignored(self, tmp_path):
+        _make_laravel_project(tmp_path)
+        _write(tmp_path / "routes" / "api.php", ROUTES_WITH_API)
+        _write(tmp_path / "app" / "Http" / "Controllers" / "Api" / "UserController.php",
+               "<?php class UserController {}")
+        _write(tmp_path / "resources" / "js" / "ext.js",
+               "fetch('https://external.api.com/data')")
+
+        provider = LaravelContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        imports = extras.get("resources/js/ext.js", [])
+        assert len(imports) == 0

--- a/tests/test_nextjs_provider.py
+++ b/tests/test_nextjs_provider.py
@@ -1,0 +1,223 @@
+"""Tests for the Next.js context provider."""
+
+from pathlib import Path
+
+import pytest
+
+from jcodemunch_mcp.parser.context.nextjs import (
+    NextjsContextProvider,
+    _next_route_from_path,
+    _next_api_methods_from_content,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _make_next_project(tmp_path: Path) -> None:
+    _write(tmp_path / "next.config.js", "module.exports = {}")
+    _write(tmp_path / "package.json", '{"dependencies": {"next": "^14.0.0"}}')
+
+
+# ---------------------------------------------------------------------------
+# Route path conversion
+# ---------------------------------------------------------------------------
+
+class TestNextRouteFromPath:
+    def test_root_page(self):
+        assert _next_route_from_path("app/page.tsx") == "/"
+
+    def test_simple_path(self):
+        assert _next_route_from_path("app/users/page.tsx") == "/users"
+
+    def test_dynamic_param(self):
+        assert _next_route_from_path("app/users/[id]/page.tsx") == "/users/:id"
+
+    def test_catch_all(self):
+        assert _next_route_from_path("app/posts/[...slug]/page.tsx") == "/posts/*"
+
+    def test_route_group_ignored(self):
+        """(auth) route group should not appear in URL."""
+        assert _next_route_from_path("app/(auth)/login/page.tsx") == "/login"
+
+    def test_nested(self):
+        assert _next_route_from_path("app/dashboard/settings/page.tsx") == "/dashboard/settings"
+
+
+class TestNextApiMethods:
+    def test_get_and_post(self):
+        content = """
+export async function GET(request: Request) { return Response.json([]); }
+export async function POST(request: Request) { return Response.json({}); }
+"""
+        methods = _next_api_methods_from_content(content)
+        assert "GET" in methods
+        assert "POST" in methods
+
+    def test_no_exports(self):
+        content = "const handler = () => {}; export default handler;"
+        methods = _next_api_methods_from_content(content)
+        assert methods == []
+
+    def test_sync_function(self):
+        content = "export function DELETE(req: Request) { return new Response(); }"
+        methods = _next_api_methods_from_content(content)
+        assert methods == ["DELETE"]
+
+
+# ---------------------------------------------------------------------------
+# NextjsContextProvider
+# ---------------------------------------------------------------------------
+
+class TestNextjsContextProvider:
+    def test_detect_next_js(self, tmp_path):
+        _make_next_project(tmp_path)
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path) is True
+
+    def test_detect_next_ts(self, tmp_path):
+        _write(tmp_path / "next.config.ts", "export default {}")
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path) is True
+
+    def test_detect_next_mjs(self, tmp_path):
+        _write(tmp_path / "next.config.mjs", "export default {}")
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path) is True
+
+    def test_detect_no_config(self, tmp_path):
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path) is False
+
+    def test_page_routing(self, tmp_path):
+        _make_next_project(tmp_path)
+        _write(tmp_path / "app" / "page.tsx", "export default function Home() { return <div/>; }")
+        _write(tmp_path / "app" / "users" / "[id]" / "page.tsx",
+               "export default function UserPage() { return <div/>; }")
+
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        ctx = provider.get_file_context("app/page.tsx")
+        assert ctx is not None
+        assert "nextjs-page" in ctx.tags
+        assert ctx.properties["route"] == "/"
+
+        ctx2 = provider.get_file_context("app/users/[id]/page.tsx")
+        assert ctx2 is not None
+        assert ":id" in ctx2.properties["route"]
+
+    def test_layout_detected(self, tmp_path):
+        _make_next_project(tmp_path)
+        _write(tmp_path / "app" / "layout.tsx",
+               "export default function RootLayout({ children }) { return <html>{children}</html>; }")
+
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        ctx = provider.get_file_context("app/layout.tsx")
+        assert ctx is not None
+        assert "nextjs-layout" in ctx.tags
+
+    def test_api_route_handler(self, tmp_path):
+        _make_next_project(tmp_path)
+        _write(tmp_path / "app" / "api" / "users" / "route.ts", """
+export async function GET(request: Request) { return Response.json([]); }
+export async function POST(request: Request) { return Response.json({}); }
+""")
+
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        ctx = provider.get_file_context("app/api/users/route.ts")
+        assert ctx is not None
+        assert "nextjs-api" in ctx.tags
+        assert "GET" in ctx.properties["methods"]
+        assert "POST" in ctx.properties["methods"]
+
+    def test_middleware_detected(self, tmp_path):
+        _make_next_project(tmp_path)
+        _write(tmp_path / "middleware.ts", """
+export function middleware(request) { return NextResponse.next(); }
+export const config = { matcher: ['/dashboard/:path*', '/api/:path*'] };
+""")
+
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        ctx = provider.get_file_context("middleware.ts")
+        assert ctx is not None
+        assert "nextjs-middleware" in ctx.tags
+        assert "/dashboard/:path*" in ctx.properties.get("matcher", "")
+
+    def test_error_boundary(self, tmp_path):
+        _make_next_project(tmp_path)
+        _write(tmp_path / "app" / "error.tsx",
+               "export default function Error() { return <div>Error</div>; }")
+
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        ctx = provider.get_file_context("app/error.tsx")
+        assert ctx is not None
+        assert "nextjs-error" in ctx.tags
+
+    def test_metadata_has_routes(self, tmp_path):
+        _make_next_project(tmp_path)
+        _write(tmp_path / "app" / "page.tsx", "export default function Home() { return <div/>; }")
+        _write(tmp_path / "app" / "api" / "health" / "route.ts",
+               "export function GET() { return Response.json({ok: true}); }")
+
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        meta = provider.get_metadata()
+        assert "nextjs_routes" in meta
+        assert "/" in meta["nextjs_routes"]
+        assert "nextjs_api" in meta
+
+    def test_stats(self, tmp_path):
+        _make_next_project(tmp_path)
+        _write(tmp_path / "app" / "page.tsx", "export default () => <div/>;")
+        _write(tmp_path / "app" / "api" / "users" / "route.ts",
+               "export function GET() {}")
+
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        stats = provider.stats()
+        assert stats["page_routes"] >= 1
+        assert stats["api_routes"] >= 1
+
+    def test_no_app_dir_is_safe(self, tmp_path):
+        _make_next_project(tmp_path)
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+        assert provider.stats()["page_routes"] == 0
+
+    def test_route_group_not_in_url(self, tmp_path):
+        _make_next_project(tmp_path)
+        _write(tmp_path / "app" / "(marketing)" / "about" / "page.tsx",
+               "export default () => <div/>;")
+
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        ctx = provider.get_file_context("app/(marketing)/about/page.tsx")
+        assert ctx is not None
+        assert ctx.properties["route"] == "/about"

--- a/tests/test_nuxt_provider.py
+++ b/tests/test_nuxt_provider.py
@@ -1,0 +1,218 @@
+"""Tests for the Nuxt.js context provider."""
+
+from pathlib import Path
+
+import pytest
+
+from jcodemunch_mcp.parser.context.nuxt import (
+    NuxtContextProvider,
+    _nuxt_route_from_path,
+    _nuxt_api_route_from_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _make_nuxt_project(tmp_path: Path) -> None:
+    _write(tmp_path / "nuxt.config.ts", "export default defineNuxtConfig({})")
+    _write(tmp_path / "package.json", '{"dependencies": {"nuxt": "^3.0.0"}}')
+
+
+# ---------------------------------------------------------------------------
+# Route path conversion
+# ---------------------------------------------------------------------------
+
+class TestNuxtRouteFromPath:
+    def test_index(self):
+        assert _nuxt_route_from_path("pages/index.vue") == "/"
+
+    def test_simple_path(self):
+        assert _nuxt_route_from_path("pages/users/index.vue") == "/users"
+
+    def test_non_index_page(self):
+        assert _nuxt_route_from_path("pages/about.vue") == "/about"
+
+    def test_dynamic_param(self):
+        assert _nuxt_route_from_path("pages/users/[id].vue") == "/users/:id"
+
+    def test_catch_all(self):
+        assert _nuxt_route_from_path("pages/posts/[...slug].vue") == "/posts/*"
+
+    def test_nested(self):
+        assert _nuxt_route_from_path("pages/admin/users/[id].vue") == "/admin/users/:id"
+
+
+class TestNuxtApiRouteFromPath:
+    def test_simple_get(self):
+        result = _nuxt_api_route_from_path("server/api/users.get.ts")
+        assert result == {"method": "GET", "endpoint": "/api/users"}
+
+    def test_simple_post(self):
+        result = _nuxt_api_route_from_path("server/api/users.post.ts")
+        assert result == {"method": "POST", "endpoint": "/api/users"}
+
+    def test_dynamic_param(self):
+        result = _nuxt_api_route_from_path("server/api/users/[id].get.ts")
+        assert result == {"method": "GET", "endpoint": "/api/users/:id"}
+
+    def test_no_method_suffix(self):
+        result = _nuxt_api_route_from_path("server/api/health.ts")
+        assert result == {"method": "ALL", "endpoint": "/api/health"}
+
+    def test_nested_path(self):
+        result = _nuxt_api_route_from_path("server/api/admin/settings.put.ts")
+        assert result == {"method": "PUT", "endpoint": "/api/admin/settings"}
+
+
+# ---------------------------------------------------------------------------
+# NuxtContextProvider
+# ---------------------------------------------------------------------------
+
+class TestNuxtContextProvider:
+    def test_detect_nuxt_ts(self, tmp_path):
+        _make_nuxt_project(tmp_path)
+        provider = NuxtContextProvider()
+        assert provider.detect(tmp_path) is True
+
+    def test_detect_nuxt_js(self, tmp_path):
+        _write(tmp_path / "nuxt.config.js", "module.exports = {}")
+        provider = NuxtContextProvider()
+        assert provider.detect(tmp_path) is True
+
+    def test_detect_no_config(self, tmp_path):
+        provider = NuxtContextProvider()
+        assert provider.detect(tmp_path) is False
+
+    def test_page_routing(self, tmp_path):
+        _make_nuxt_project(tmp_path)
+        _write(tmp_path / "pages" / "index.vue", "<template><div/></template>")
+        _write(tmp_path / "pages" / "users" / "[id].vue", "<template><div/></template>")
+
+        provider = NuxtContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        ctx = provider.get_file_context("pages/index.vue")
+        assert ctx is not None
+        assert "nuxt-page" in ctx.tags
+        assert "/" in ctx.properties.get("route", "")
+
+        ctx2 = provider.get_file_context("pages/users/[id].vue")
+        assert ctx2 is not None
+        assert ":id" in ctx2.properties.get("route", "")
+
+    def test_server_api_routes(self, tmp_path):
+        _make_nuxt_project(tmp_path)
+        _write(tmp_path / "server" / "api" / "users.get.ts",
+               "export default defineEventHandler(() => [])")
+        _write(tmp_path / "server" / "api" / "users.post.ts",
+               "export default defineEventHandler(() => {})")
+
+        provider = NuxtContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        ctx = provider.get_file_context("server/api/users.get.ts")
+        assert ctx is not None
+        assert "nuxt-api" in ctx.tags
+        assert ctx.properties["method"] == "GET"
+        assert ctx.properties["endpoint"] == "/api/users"
+
+        meta = provider.get_metadata()
+        assert "nuxt_api" in meta
+        assert "GET /api/users" in meta["nuxt_api"]
+
+    def test_auto_import_composables(self, tmp_path):
+        _make_nuxt_project(tmp_path)
+        _write(tmp_path / "composables" / "useAuth.ts",
+               "export function useAuth() { return {} }")
+        _write(tmp_path / "composables" / "useCart.ts",
+               "export function useCart() { return {} }")
+        _write(tmp_path / "pages" / "index.vue", """
+<script setup>
+const { user } = useAuth()
+const { items } = useCart()
+</script>
+""")
+
+        provider = NuxtContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        page_imports = extras.get("pages/index.vue", [])
+        specifiers = {imp["specifier"] for imp in page_imports}
+        assert "composables/useAuth.ts" in specifiers
+        assert "composables/useCart.ts" in specifiers
+
+    def test_auto_import_utils(self, tmp_path):
+        _make_nuxt_project(tmp_path)
+        _write(tmp_path / "utils" / "formatDate.ts",
+               "export function formatDate() {}")
+        _write(tmp_path / "pages" / "index.vue",
+               "<script setup>\nconst d = formatDate(new Date())\n</script>")
+
+        provider = NuxtContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        page_imports = extras.get("pages/index.vue", [])
+        specifiers = {imp["specifier"] for imp in page_imports}
+        assert "utils/formatDate.ts" in specifiers
+
+    def test_no_auto_import_self(self, tmp_path):
+        """A composable should not create an auto-import edge to itself."""
+        _make_nuxt_project(tmp_path)
+        _write(tmp_path / "composables" / "useAuth.ts",
+               "export function useAuth() { return useAuth() }")
+
+        provider = NuxtContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        extras = provider.get_extra_imports()
+        # composables/useAuth.ts should NOT import itself
+        self_imports = extras.get("composables/useAuth.ts", [])
+        assert not any(i["specifier"] == "composables/useAuth.ts" for i in self_imports)
+
+    def test_stats(self, tmp_path):
+        _make_nuxt_project(tmp_path)
+        _write(tmp_path / "pages" / "index.vue", "<template><div/></template>")
+        _write(tmp_path / "server" / "api" / "health.ts", "export default () => 'ok'")
+        _write(tmp_path / "composables" / "useAuth.ts", "export function useAuth() {}")
+
+        provider = NuxtContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        stats = provider.stats()
+        assert stats["page_routes"] >= 1
+        assert stats["api_routes"] >= 1
+        assert stats["auto_import_symbols"] >= 1
+
+    def test_no_pages_is_safe(self, tmp_path):
+        _make_nuxt_project(tmp_path)
+        provider = NuxtContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+        assert provider.stats()["page_routes"] == 0
+
+    def test_metadata_has_routes(self, tmp_path):
+        _make_nuxt_project(tmp_path)
+        _write(tmp_path / "pages" / "users" / "index.vue", "<template/>")
+
+        provider = NuxtContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        meta = provider.get_metadata()
+        assert "nuxt_routes" in meta
+        assert "/users" in meta["nuxt_routes"]


### PR DESCRIPTION
## Summary

Implements Stages 4, 5, and 6 from the framework-aware intelligence roadmap (#201), building on Stages 1–3 shipped in v1.21.12.

### Stage 4: Cross-language dependency graph

- **Blade template imports** — `@extends`, `@include`, `@includeWhen`, `@component`, `view()`, `<x-component>` → resolved file paths as import edges
- **Eloquent relationship imports** — `hasMany`/`belongsTo`/etc create model→model edges
- **Facade resolution** — 40 built-in Laravel facades mapped to underlying `Illuminate\*` classes
- **Route → Controller imports** — route files reference their controllers
- **Inertia.js bridge** — `Inertia::render('Page')` / `inertia('Page')` → Vue/React page components with `.vue`/`.tsx`/`.jsx` resolution
- **fetch/axios → route matching** — frontend `fetch('/api/users')` matched to Laravel routes → controller files, with dynamic segment wildcard matching

All edges flow through a new `get_extra_imports()` provider hook + `collect_extra_imports()` merger (called in all 4 pipeline paths).

### Stage 5: Vue template parsing + Nuxt/Next.js providers

- **Vue `<template>` extraction** — PascalCase/kebab-case component tags parsed from `<template>` blocks; HTML/SVG/Vue builtins excluded; deduplicated with `<script>` imports
- **Nuxt.js provider** — file-based routing (`pages/`), server API routes (`server/api/`), auto-import resolution (`composables/`, `utils/` → synthetic import edges)
- **Next.js provider** — App Router pages, route groups `(auth)`, API route handlers with HTTP method extraction, middleware detection, error/loading boundaries

### Stage 6: FQN ↔ symbol_id translation (Phase 2)

- `symbol_to_fqn()` / `fqn_to_symbol()` in new `parser/fqn.py`
- Optional `fqn` parameter added to `get_symbol_source`, `get_blast_radius`, `search_symbols`, `get_context_bundle`
- Detailed error messages (no PSR-4 config, file not indexed, namespace mismatch)

## Test plan

- [x] 125 new tests across 6 test files
- [x] 1804 total passing, 0 regressions (`uv run pytest --tb=short -q`)
- [x] Tested on real Laravel project (fair-laravel): 96 files with extra import edges
- [x] FQN roundtrip verified: `symbol→fqn→symbol` identity
- [x] Integration tests: index_folder → stored index → verify edges for Blade, facades, Eloquent, Inertia, Vue templates
- [x] Coverage: new files 90-95%, all error paths tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)