### PR TITLE
fix: prevent test index folders from leaking into ~/.code-index/

### DIFF
--- a/tests/test_negative_evidence.py
+++ b/tests/test_negative_evidence.py
@@ -86,9 +86,9 @@ class TestGetRankedContextNegativeEvidence:
         src.mkdir()
         (src / "a.py").write_text("def real_function(): pass\n")
 
-        idx = index_folder(path=str(tmp_path), use_ai_summaries=False)
+        storage = str(tmp_path / "idx")
+        idx = index_folder(path=str(tmp_path), use_ai_summaries=False, storage_path=storage)
         repo = idx["repo"]
-        storage = idx.get("storage_path")
 
         result = get_ranked_context(
             repo=repo,
@@ -112,9 +112,9 @@ class TestGetRankedContextNegativeEvidence:
         src.mkdir()
         (src / "a.py").write_text("def real_function(): pass\n")
 
-        idx = index_folder(path=str(tmp_path), use_ai_summaries=False)
+        storage = str(tmp_path / "idx")
+        idx = index_folder(path=str(tmp_path), use_ai_summaries=False, storage_path=storage)
         repo = idx["repo"]
-        storage = idx.get("storage_path")
 
         result = get_ranked_context(
             repo=repo,
@@ -135,9 +135,9 @@ class TestGetRankedContextNegativeEvidence:
         src.mkdir()
         (src / "a.py").write_text("def my_special_function():\n    return 42\n")
 
-        idx = index_folder(path=str(tmp_path), use_ai_summaries=False)
+        storage = str(tmp_path / "idx")
+        idx = index_folder(path=str(tmp_path), use_ai_summaries=False, storage_path=storage)
         repo = idx["repo"]
-        storage = idx.get("storage_path")
 
         result = get_ranked_context(
             repo=repo,
@@ -159,9 +159,9 @@ class TestGetRankedContextNegativeEvidence:
         src.mkdir()
         (src / "auth_handler.py").write_text("def login(): pass\n")
 
-        idx = index_folder(path=str(tmp_path), use_ai_summaries=False)
+        storage = str(tmp_path / "idx")
+        idx = index_folder(path=str(tmp_path), use_ai_summaries=False, storage_path=storage)
         repo = idx["repo"]
-        storage = idx.get("storage_path")
 
         result = get_ranked_context(
             repo=repo,
@@ -188,9 +188,9 @@ class TestSearchSymbolsWarningString:
         src.mkdir()
         (src / "a.py").write_text("def real_function(): pass\n")
 
-        idx = index_folder(path=str(tmp_path), use_ai_summaries=False)
+        storage = str(tmp_path / "idx")
+        idx = index_folder(path=str(tmp_path), use_ai_summaries=False, storage_path=storage)
         repo = idx["repo"]
-        storage = idx.get("storage_path")
 
         result = search_symbols(
             repo=repo,
@@ -211,9 +211,9 @@ class TestSearchSymbolsWarningString:
         src.mkdir()
         (src / "a.py").write_text("def real_function(): pass\n")
 
-        idx = index_folder(path=str(tmp_path), use_ai_summaries=False)
+        storage = str(tmp_path / "idx")
+        idx = index_folder(path=str(tmp_path), use_ai_summaries=False, storage_path=storage)
         repo = idx["repo"]
-        storage = idx.get("storage_path")
 
         result = search_symbols(
             repo=repo,


### PR DESCRIPTION
## Summary
- Six `index_folder()` calls in `test_negative_evidence.py` were missing the `storage_path` parameter, writing indexes to the global `~/.code-index/` directory instead of pytest's temporary directory
- Each test run created unique `tmp_path` folders, producing a new hash via `_local_repo_name()` — so leaked entries accumulated across runs and were never cleaned up
- 264 out of 305 entries in `~/.code-index/` were orphaned test artifacts (`local-test_*` folders and `.db` files)

## Fix
Added `storage_path=str(tmp_path / "idx")` to all 6 affected `index_folder()` calls, matching the pattern used by `create_mini_index()` and every other test file.

## Affected tests
| Class | Test method |
|-------|------------|
| `TestGetRankedContextNegativeEvidence` | `test_negative_evidence_on_empty_result` |
| `TestGetRankedContextNegativeEvidence` | `test_warning_string_present_on_negative_evidence` |
| `TestGetRankedContextNegativeEvidence` | `test_no_negative_evidence_on_strong_match` |
| `TestGetRankedContextNegativeEvidence` | `test_related_existing_in_negative_evidence` |
| `TestSearchSymbolsWarningString` | `test_warning_on_negative_evidence` |
| `TestSearchSymbolsWarningString` | `test_no_warning_on_good_match` |

## Test plan
- [x] `pytest tests/test_negative_evidence.py -v` — all 11 tests pass
- [ ] Verify no new `local-test_*` entries appear in `~/.code-index/` after running tests
- [ ] Clean up existing leaked entries: `cd ~/.code-index && rm -rf local-test_*`