### PR TITLE
feat: audit_agent_config discovers .claude/rules/ directory

### DIFF
--- a/src/jcodemunch_mcp/tools/audit_agent_config.py
+++ b/src/jcodemunch_mcp/tools/audit_agent_config.py
@@ -56,7 +56,13 @@ _PROJECT_CONFIGS: list[tuple[str, str]] = [
 
 
 def _discover_files(project_path: Optional[str] = None) -> list[dict[str, Any]]:
-    """Find all agent config files and return metadata."""
+    """Find all agent config files and return metadata.
+
+    In addition to the fixed config paths, this discovers rule files in
+    directories that Claude Code loads automatically:
+      - .claude/rules/*.md  (project-level rules)
+      - ~/.claude/rules/*.md (global rules, applied to all projects)
+    """
     home = Path.home()
     project = Path(project_path) if project_path else None
     found: list[dict[str, Any]] = []
@@ -77,6 +83,23 @@ def _discover_files(project_path: Optional[str] = None) -> list[dict[str, Any]]:
             except OSError:
                 pass
 
+    # Global rules directory (~/.claude/rules/*.md)
+    global_rules_dir = home / ".claude" / "rules"
+    if global_rules_dir.is_dir():
+        for rule_file in sorted(global_rules_dir.glob("*.md")):
+            try:
+                text = rule_file.read_text(encoding="utf-8", errors="replace")
+                found.append({
+                    "path": str(rule_file),
+                    "description": f"global rule: {rule_file.stem}",
+                    "scope": "global",
+                    "content": text,
+                    "tokens": _estimate_tokens(text),
+                    "lines": text.count("\n") + 1,
+                })
+            except OSError:
+                pass
+
     if project:
         for rel, desc in _PROJECT_CONFIGS:
             p = project / rel
@@ -86,6 +109,23 @@ def _discover_files(project_path: Optional[str] = None) -> list[dict[str, Any]]:
                     found.append({
                         "path": str(p),
                         "description": desc,
+                        "scope": "project",
+                        "content": text,
+                        "tokens": _estimate_tokens(text),
+                        "lines": text.count("\n") + 1,
+                    })
+                except OSError:
+                    pass
+
+        # Project rules directory (.claude/rules/*.md)
+        project_rules_dir = project / ".claude" / "rules"
+        if project_rules_dir.is_dir():
+            for rule_file in sorted(project_rules_dir.glob("*.md")):
+                try:
+                    text = rule_file.read_text(encoding="utf-8", errors="replace")
+                    found.append({
+                        "path": str(rule_file),
+                        "description": f"project rule: {rule_file.stem}",
                         "scope": "project",
                         "content": text,
                         "tokens": _estimate_tokens(text),

--- a/tests/test_audit_agent_config.py
+++ b/tests/test_audit_agent_config.py
@@ -308,6 +308,23 @@ def test_discover_files_empty(tmp_path):
     assert len(project_files) == 0
 
 
+def test_discover_files_project_rules_dir(tmp_path):
+    """Rules in .claude/rules/*.md should be discovered as project-scoped."""
+    rules_dir = tmp_path / ".claude" / "rules"
+    rules_dir.mkdir(parents=True)
+    (rules_dir / "guardrails.md").write_text("# Guardrails\nNo destructive actions.", encoding="utf-8")
+    (rules_dir / "search-opsec.md").write_text("# Search OPSEC\nDon't leak strategy.", encoding="utf-8")
+    # Non-.md files should be ignored
+    (rules_dir / "notes.txt").write_text("not a rule", encoding="utf-8")
+
+    files = _discover_files(str(tmp_path))
+    project_rules = [f for f in files if f["scope"] == "project" and "rule:" in f["description"]]
+    assert len(project_rules) == 2
+    descriptions = {f["description"] for f in project_rules}
+    assert "project rule: guardrails" in descriptions
+    assert "project rule: search-opsec" in descriptions
+
+
 # ---------------------------------------------------------------------------
 # Full audit
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `.claude/rules/*.md` (project) and `~/.claude/rules/*.md` (global) to `audit_agent_config` file discovery
- All existing checks (token cost, stale symbols, dead paths, bloat, scope leaks, redundancy) now run against rule files
- Includes test for project rules directory discovery

## Context

Claude Code loads every `.md` file in `.claude/rules/` into every agent turn. In my setup, 17 rule files contain ~10,800 tokens — 60% more than the 3 files the audit currently scans. Stale file path references in rule files went undetected because they weren't in scope.

Closes #234

## Test plan

- [x] All 35 existing `test_audit_agent_config.py` tests pass
- [x] New `test_discover_files_project_rules_dir` verifies `.md` files are found, non-`.md` files are ignored
- [x] Verified on Windows 11 with 17 project rule files

🤖 Generated with [Claude Code](https://claude.com/claude-code)