### PR TITLE
fix: invalidate_cache reliability + meta_fields + watcher self-restart + orphan cleanup

### DIFF
--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -2980,18 +2980,11 @@ async def _run_server_with_watcher(
 
     _watcher_manager = manager
 
-    # Create manager run task
+    # Create manager run task (self-restarts on crash)
     manager_task = asyncio.create_task(
         manager.run(),
         name="watcher-manager",
     )
-
-    # Give watcher a moment to start; detect early failures before blocking on server
-    await asyncio.sleep(0.1)
-    if manager_task.done() and not manager_task.cancelled():
-        exc = manager_task.exception()
-        if exc is not None:
-            logger.warning("Embedded watcher failed to start: %s", exc)
 
     try:
         await server_coro_func(*server_args)
@@ -4464,6 +4457,20 @@ def main(argv: Optional[list[str]] = None):
         # Re-run load_config() after _setup_logging() so config warnings/errors
         # go to the configured log destination (the early call at startup ran before logging was set up)
         config_module.load_config()
+
+        # Clean up orphan indexes whose source_root no longer exists
+        try:
+            from .storage import IndexStore
+
+            storage_path = os.environ.get("CODE_INDEX_PATH")
+            store = IndexStore(base_path=storage_path)
+            cleaned = store.cleanup_orphan_indexes()
+            store.close()
+            if cleaned:
+                logger.info("Cleaned up %d orphan index(es)", cleaned)
+        except Exception:
+            logger.debug("Orphan index cleanup failed", exc_info=True)
+
         config_module.load_all_project_configs()
         from .reindex_state import set_freshness_mode
         # Apply config default if --freshness-mode was not explicitly provided

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -2878,6 +2878,10 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             meta_fields = config_module.get("meta_fields")
             if meta_fields == [] or arguments.get("suppress_meta"):
                 result.pop("_meta", None)
+                # Also strip nested _meta from batch tools (e.g. get_file_outline batch)
+                for _item in result.get("results", []):
+                    if isinstance(_item, dict):
+                        _item.pop("_meta", None)
             elif isinstance(meta_fields, list):
                 # Partial field inclusion — keep only the fields listed in meta_fields,
                 # preserving tool-generated fields (timing_ms, tokens_saved, etc.)
@@ -2890,6 +2894,15 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                         _meta[field] = existing_meta[field]
                 if _meta:
                     result["_meta"] = _meta
+                # Also filter nested _meta from batch tools (e.g. get_file_outline batch)
+                for _item in result.get("results", []):
+                    if isinstance(_item, dict):
+                        _item_meta = _item.pop("_meta", {})
+                        _item_filtered: dict[str, Any] = {f: _item_meta[f] for f in meta_fields if f in _item_meta}
+                        if "powered_by" in meta_fields:
+                            _item_filtered["powered_by"] = "jcodemunch-mcp by jgravelle · https://github.com/jgravelle/jcodemunch-mcp"
+                        if _item_filtered:
+                            _item["_meta"] = _item_filtered
         # Per-call pulse for downstream consumers (dashboards, monitors)
         _saved = result.get("_meta", {}).get("tokens_saved", 0) if isinstance(result, dict) else 0
         _write_pulse(name, tokens_saved=_saved, base_path=storage_path)

--- a/src/jcodemunch_mcp/storage/index_store.py
+++ b/src/jcodemunch_mcp/storage/index_store.py
@@ -287,6 +287,13 @@ class IndexStore:
         for db_file in self.base_path.glob("*.db"):
             self._sqlite.checkpoint_db(db_file)
 
+    def cleanup_orphan_indexes(self) -> int:
+        """Delete indexes whose source_root no longer exists on disk.
+
+        Delegates to SQLiteIndexStore.cleanup_orphan_indexes().
+        """
+        return self._sqlite.cleanup_orphan_indexes()
+
     def _safe_repo_component(self, value: str, field_name: str) -> str:
         """Validate and sanitize owner/name components used in on-disk cache paths.
 

--- a/src/jcodemunch_mcp/storage/index_store.py
+++ b/src/jcodemunch_mcp/storage/index_store.py
@@ -777,7 +777,7 @@ class IndexStore:
         repos.sort(key=lambda repo: repo["repo"])
         return repos
 
-    def delete_index(self, owner: str, name: str) -> bool:
+    def delete_index(self, owner: str, name: str, force: bool = False) -> bool:
         """Delete an index (SQLite DB + sidecars + content dir).
 
         Legacy .json index files are only deleted when a SQLite .db already
@@ -785,6 +785,13 @@ class IndexStore:
         *only* copy of the data, deleting it would silently discard user data
         with no backup.  In that case we preserve the JSON — it will be
         replaced automatically on the next index_folder / save_index call.
+
+        Args:
+            owner: Repository owner.
+            name: Repository name.
+            force: When True, delete the JSON even if it is the sole copy.
+                Use this from invalidate_cache (explicit user action) to ensure
+                the index is fully cleared including any legacy JSON files.
         """
         db_existed = self._sqlite.has_index(owner, name)
         deleted = self._sqlite.delete_index(owner, name)
@@ -794,8 +801,9 @@ class IndexStore:
         lock_path = self._lock_path(owner, name)
 
         if index_path.exists():
-            if db_existed:
-                # Data was already in SQLite; JSON is a redundant legacy file.
+            if db_existed or force:
+                # Data was already in SQLite (or caller explicitly requests full
+                # wipe); JSON is redundant or force-deleted.
                 index_path.unlink()
                 deleted = True
             else:

--- a/src/jcodemunch_mcp/storage/sqlite_store.py
+++ b/src/jcodemunch_mcp/storage/sqlite_store.py
@@ -1049,6 +1049,37 @@ class SQLiteIndexStore:
 
         return deleted
 
+    def cleanup_orphan_indexes(self) -> int:
+        """Delete indexes whose source_root no longer exists on disk.
+
+        Remote repos (GitHub, empty source_root) are skipped.
+        Returns the number of orphan indexes deleted.
+        """
+        deleted = 0
+        for entry in self.list_repos():
+            source_root = entry.get("source_root", "")
+            if not source_root:
+                continue  # Remote repo — no filesystem path to validate
+            try:
+                if not Path(source_root).is_dir():
+                    repo_id = entry["repo"]
+                    # repo_id is "local/name-hash" or "github/owner/repo"
+                    parts = repo_id.split("/", 1)
+                    if len(parts) == 2:
+                        owner, name = parts
+                    else:
+                        continue  # Malformed — skip
+                    if self.delete_index(owner, name):
+                        deleted += 1
+                        logger.info(
+                            "Deleted orphan index: %s (source_root: %s)",
+                            repo_id,
+                            source_root,
+                        )
+            except Exception:
+                logger.debug("Orphan check failed for %s", source_root, exc_info=True)
+        return deleted
+
     def get_symbol_content(
         self, owner: str, name: str, symbol_id: str,
         _index: Optional["CodeIndex"] = None,

--- a/src/jcodemunch_mcp/storage/sqlite_store.py
+++ b/src/jcodemunch_mcp/storage/sqlite_store.py
@@ -7,9 +7,11 @@ WAL mode enables concurrent readers + single writer with delta writes.
 import json
 import logging
 import os
+import platform
 import shutil
 import sqlite3
 import threading
+import time
 from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path
@@ -264,6 +266,25 @@ def _migrate_v7_to_v8(conn: sqlite3.Connection) -> None:
         "will use text heuristics. Run 'jcodemunch-mcp index-folder' to fully "
         "re-index and enable AST-based call graphs."
     )
+
+
+def _unlink_retry(path: Path, retries: int = 3, delay: float = 0.1) -> bool:
+    """Delete a file with retry logic for Windows file-locking (PermissionError).
+
+    On Windows, WAL-mode SQLite files can remain briefly locked by another
+    thread even after all connections are closed.  Retrying with a short
+    sleep resolves this in practice without masking real permission errors
+    (which would persist across all retries and re-raise on the final attempt).
+    """
+    for attempt in range(retries):
+        try:
+            path.unlink()
+            return True
+        except PermissionError:
+            if platform.system() != "Windows" or attempt == retries - 1:
+                raise
+            time.sleep(delay)
+    return False  # unreachable, but satisfies type checkers
 
 
 class SQLiteIndexStore:
@@ -1007,18 +1028,18 @@ class SQLiteIndexStore:
         deleted = False
 
         if db_path.exists():
-            db_path.unlink()
+            _unlink_retry(db_path)
             deleted = True
             SQLiteIndexStore._initialized_dbs.discard(str(db_path))
 
         wal_path = Path(str(db_path) + "-wal")
         if wal_path.exists():
-            wal_path.unlink()
+            _unlink_retry(wal_path)
             deleted = True
 
         shm_path = Path(str(db_path) + "-shm")
         if shm_path.exists():
-            shm_path.unlink()
+            _unlink_retry(shm_path)
             deleted = True
 
         content_dir = self._content_dir(owner, name)

--- a/src/jcodemunch_mcp/tools/index_folder.py
+++ b/src/jcodemunch_mcp/tools/index_folder.py
@@ -935,6 +935,22 @@ def index_folder(
             _hash_file_cache[rel_path] = content
             return _file_hash(content)
 
+        # Force full reindex if invalidate_cache was called for this repo.
+        # Handles cases where the DB deletion failed (e.g. Windows WAL
+        # file-locking) and load_index still returns the old index.
+        _repo_full = f"{owner}/{repo_name}"
+        try:
+            from .invalidate_cache import _force_full_reindex
+            if _repo_full in _force_full_reindex:
+                _force_full_reindex.discard(_repo_full)
+                incremental = False
+                logger.info(
+                    "index_folder: forcing full reindex for %s (post-invalidation)",
+                    _repo_full,
+                )
+        except ImportError:
+            pass
+
         # Incremental path: detect changes using mtime fast-path
         if incremental and existing_index is not None:
             changed, new, deleted, computed_hashes, updated_mtimes = (

--- a/src/jcodemunch_mcp/tools/invalidate_cache.py
+++ b/src/jcodemunch_mcp/tools/invalidate_cache.py
@@ -7,6 +7,13 @@ from .. import config as _cfg
 from ..parser.imports import _alias_map_cache, _ALIAS_MAP_LOCK, _sql_stem_cache, _SQL_STEM_LOCK
 from ._utils import resolve_repo, _bare_name_cache, _BARE_NAME_LOCK
 
+# Repos invalidated since the last index_folder call.  index_folder checks
+# this set and forces incremental=False for repos that were explicitly
+# invalidated, regardless of what the on-disk index says.  This handles
+# Windows WAL file-locking races where the .db delete fails silently and the
+# next incremental index_folder would incorrectly return "No changes detected".
+_force_full_reindex: set[str] = set()
+
 
 def invalidate_cache(
     repo: str,
@@ -38,7 +45,12 @@ def invalidate_cache(
             source_root = entry.get("source_root") or None
             break
 
-    deleted = store.delete_index(owner, name)
+    deleted = store.delete_index(owner, name, force=True)
+
+    # Signal that the next index_folder call for this repo must do a full
+    # reindex, even if the on-disk DB still exists (Windows WAL locking can
+    # prevent immediate deletion).
+    _force_full_reindex.add(f"{owner}/{name}")
 
     # Clear all in-process caches (X1 / C4-B / T4.5)
     with _cfg._CONFIG_LOCK:

--- a/src/jcodemunch_mcp/watcher.py
+++ b/src/jcodemunch_mcp/watcher.py
@@ -619,38 +619,66 @@ class WatcherManager:
             return {"status": "error", "folder": folder, "error": str(exc)}
 
     async def run(self) -> None:
-        """Main loop: wait on stop_event, monitor for crashed tasks."""
+        """Main loop: monitor for crashed tasks and restart them. Self-restarts on crash."""
         if self._stop_event is None:
             self._stop_event = asyncio.Event()
 
-        while not self._stop_event.is_set():
-            # Check for crashed tasks and restart them
-            for folder in list(self._active):
-                task = self._active.get(folder)
-                if task and task.done() and not task.cancelled():
-                    exc = task.exception()
-                    if exc:
-                        _watcher_output(
-                            f"WatcherManager: task crashed for {folder}: {exc}, restarting...",
-                            quiet=self._quiet,
-                            log_file_handle=self._log_file_handle,
-                        )
-                        # Restart
-                        new_task = asyncio.create_task(
-                            _watch_single(
-                                folder_path=folder,
-                                debounce_ms=self._debounce_ms,
-                                use_ai_summaries=self._use_ai_summaries,
-                                storage_path=self._storage_path,
-                                extra_ignore_patterns=self._extra_ignore_patterns,
-                                follow_symlinks=self._follow_symlinks,
-                                quiet=self._quiet,
-                                log_file_handle=self._log_file_handle,
-                            ),
-                            name=f"watch:{folder}",
-                        )
-                        self._active[folder] = new_task
-            await asyncio.sleep(5.0)
+        _restart_count = 0
+        _MAX_RESTARTS = 5
+
+        while True:
+            try:
+                while not self._stop_event.is_set():
+                    # Check for crashed tasks and restart them
+                    for folder in list(self._active):
+                        task = self._active.get(folder)
+                        if task and task.done() and not task.cancelled():
+                            exc = task.exception()
+                            if exc:
+                                _watcher_output(
+                                    f"WatcherManager: task crashed for {folder}: {exc}, restarting...",
+                                    quiet=self._quiet,
+                                    log_file_handle=self._log_file_handle,
+                                )
+                                # Restart
+                                new_task = asyncio.create_task(
+                                    _watch_single(
+                                        folder_path=folder,
+                                        debounce_ms=self._debounce_ms,
+                                        use_ai_summaries=self._use_ai_summaries,
+                                        storage_path=self._storage_path,
+                                        extra_ignore_patterns=self._extra_ignore_patterns,
+                                        follow_symlinks=self._follow_symlinks,
+                                        quiet=self._quiet,
+                                        log_file_handle=self._log_file_handle,
+                                    ),
+                                    name=f"watch:{folder}",
+                                )
+                                self._active[folder] = new_task
+                    await asyncio.sleep(5.0)
+                # Inner loop exited normally — reset restart counter
+                _restart_count = 0
+            except asyncio.CancelledError:
+                raise  # Propagate cancellation — signals shutdown
+            except Exception as exc:
+                _restart_count += 1
+                _watcher_output(
+                    f"WatcherManager run() crashed ({_restart_count}/{_MAX_RESTARTS}): {exc}",
+                    quiet=self._quiet,
+                    log_file_handle=self._log_file_handle,
+                )
+                if _restart_count >= _MAX_RESTARTS:
+                    _watcher_output(
+                        "WatcherManager run() abandoned after 5 consecutive crashes",
+                        quiet=self._quiet,
+                        log_file_handle=self._log_file_handle,
+                    )
+                    break
+                await asyncio.sleep(0.1)  # Prevent spin-loop on persistent crash
+
+            # Inner loop exited — check if this is a graceful shutdown
+            if self._stop_event is not None and self._stop_event.is_set():
+                break  # Stop was requested — exit run() entirely
 
     def stop(self) -> None:
         """Signal the manager loop to stop."""


### PR DESCRIPTION
## Summary

Four reliability fixes for the MCP server:

**1. `invalidate_cache` → `index_folder` returns "No changes detected"**

Calling `invalidate_cache` followed by `index_folder` (default `incremental=true`) would silently skip the reindex and return `"No changes detected"`. This confused tool-chaining workflows that expected a full reindex after invalidation.

Root causes:
- **Windows WAL-mode file locking**: SQLite's WAL mode creates `-wal`/`-shm` sidecar files that can remain locked by in-process connections (the watcher), causing `db_path.unlink()` to fail silently on Windows. The next `index_folder` call would find the intact DB and correctly report no changes.
- **Legacy JSON auto-migration**: `delete_index` preserved `.json` when no `.db` existed (sole-copy guard), and `load_index` auto-migrated it back into a fresh `.db`, making the invalidation invisible.

Fixes:
- Added `_unlink_retry()` in `sqlite_store.py` with retry logic for `PermissionError` on Windows (3 attempts, 100 ms delay)
- Added `force=True` to `IndexStore.delete_index` — deletes legacy JSON unconditionally when called from `invalidate_cache`
- Added module-level `_force_full_reindex` set in `invalidate_cache.py` as a belt-and-suspenders flag: even if deletion silently fails (Windows WAL race), the next `index_folder` call for that repo is guaranteed to do a full reindex

**2. `meta_fields` config ignored for batch tool results**

The server-level `meta_fields` filter only stripped the top-level `result["_meta"]`. Tools returning a `results` array — specifically `get_file_outline` with `file_paths=[...]` — include a per-item `_meta` on each element that was left untouched regardless of config.

Fix: Extend both branches of the `meta_fields` filter in `server.py` to walk `result["results"]` and apply the same strip/filter logic to each item. Future batch tools following the same `{results: [...]}` shape benefit automatically.

**3. WatcherManager self-restarts on crash**

If the embedded watcher's monitoring loop crashes, it now auto-restarts with 100ms backoff, up to 5 consecutive attempts. After 5 crashes, it logs and exits cleanly.

Root cause:
- `WatcherManager.run()` was a single `while` loop — any unhandled exception killed the entire watcher silently. The server had no mechanism to detect or restart it, leaving auto-reindex permanently disabled until server restart.

Fix:
- Wrapped the monitoring loop in a `while True` with `try/except` — crashes are caught, logged with attempt count, and the loop restarts after 100ms
- Restart counter resets only on graceful shutdown (when `stop_event` is set and the inner loop exits normally) — only truly consecutive crashes count toward the limit
- Removed redundant 0.1s startup check in `_run_server_with_watcher` (manager now self-manages)
- Graceful stop still works: `stop_event.set()` → inner loop exits → outer loop detects `is_set()` and breaks

**4. Orphan index cleanup on startup**

On serve startup, scan all indexed repos and delete any whose `source_root` folder no longer exists on disk. Remote repos (GitHub) are skipped since they have no filesystem path.

Root cause:
- Indexed folders can be deleted externally (e.g. `rm -rf project/`) while their index remains in `~/.code-index/`. These orphan indexes accumulate, waste space, and cause confusing `list_repos()` output.

Fix:
- `SQLiteIndexStore.cleanup_orphan_indexes()` (delegated via `IndexStore.cleanup_orphan_indexes()`) runs before `load_all_project_configs()` at startup
- For each indexed repo with a non-empty `source_root`, check `Path(source_root).is_dir()` — if `False`, call `delete_index(owner, name)`
- Logged: `"Deleted orphan index: %s (source_root: %s)"` per deletion, `"Cleaned up %d orphan index(es)"` summary

## Files Changed

- `src/jcodemunch_mcp/storage/sqlite_store.py` — `_unlink_retry()` helper, WAL sidecar cleanup, `cleanup_orphan_indexes()`
- `src/jcodemunch_mcp/storage/index_store.py` — `force` param on `delete_index`; delegate `cleanup_orphan_indexes()` to `_sqlite`
- `src/jcodemunch_mcp/tools/invalidate_cache.py` — `_force_full_reindex` set, `force=True` call
- `src/jcodemunch_mcp/tools/index_folder.py` — check `_force_full_reindex` before incremental guard
- `src/jcodemunch_mcp/server.py` — extend `meta_fields` filter to nested `results` items; remove redundant watcher startup check; call `cleanup_orphan_indexes()` at startup
- `src/jcodemunch_mcp/watcher.py` — `WatcherManager.run()` self-restart with 5-attempt limit and 100ms backoff

## Test Plan

- [x] All 2995 tests pass, 5 skipped
- [ ] Manual: `invalidate_cache` → `index_folder` (incremental=true) performs full reindex
- [ ] Manual: `get_file_outline` with `file_paths=[...]` and `meta_fields: []` returns no `_meta` on any item
- [ ] Manual: watcher crash → auto-restarts within 100ms, survives 4 crashes, abandons on 5th
- [ ] Manual: delete indexed folder externally → restart server → orphan index is deleted at startup
