### PR TITLE
Add `open_in_viewer` to `render_diagram` — config-gated mmd-viewer spawn

### DIFF
--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -316,6 +316,9 @@ DEFAULTS = {
     "agent_selector": {},
     # LSP enrichment
     "enrichment": {},
+    # Mermaid Viewer
+    "render_diagram_viewer_enabled": False,
+    "mermaid_viewer_path": "",
 }
 
 CONFIG_TYPES = {
@@ -384,6 +387,8 @@ CONFIG_TYPES = {
     "session_max_queries": int,
     "agent_selector": dict,
     "enrichment": dict,
+    "render_diagram_viewer_enabled": bool,
+    "mermaid_viewer_path": str,
 }
 
 
@@ -1456,5 +1461,24 @@ def generate_template() -> str:
   // "path_map": "",
   //   Cross-platform path remapping. Format: "orig1=new1,orig2=new2".
   //   Allows indexes built on Linux to work on Windows and vice versa.
+
+  // === Mermaid Viewer Integration ===
+  // "render_diagram_viewer_enabled": false,
+  //   When true, render_diagram exposes an extra boolean parameter
+  //   `open_in_viewer` in its tool schema. When the caller sets
+  //   open_in_viewer=true, the produced mermaid is written as a
+  //   self-contained HTML file under <index_path>/temp/mermaid/ and
+  //   opened with the viewer resolved via `mermaid_viewer_path`.
+  //   When false (default), the parameter is hidden from the schema.
+  //   The temp folder is cleaned on server startup and shutdown.
+
+  // "mermaid_viewer_path": "",
+  //   Absolute path to the mmd-viewer executable. Used only when
+  //   render_diagram_viewer_enabled is true and the caller requests
+  //   open_in_viewer=true.
+  //   - Explicit path: used as-is (e.g. "C:/tools/mmd-viewer.exe").
+  //   - Empty string: falls back to "mmd-viewer" on $PATH.
+  //   If neither resolves, render_diagram still returns the mermaid
+  //   markup and adds a non-fatal `viewer_error` field to the result.
 }}
 '''

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -280,6 +280,36 @@ def _save_session_state() -> None:
 atexit.register(_save_session_state)
 
 
+def _cleanup_mermaid_temp_startup() -> None:
+    """Clean stale mermaid viewer temp files from previous sessions."""
+    if not config_module.get("render_diagram_viewer_enabled", False):
+        return
+    try:
+        from .tools.mermaid_viewer import cleanup_temp_dir
+        cleanup_temp_dir()
+    except Exception as e:
+        logger.debug("Mermaid temp startup cleanup failed: %s", e, exc_info=True)
+
+
+def _cleanup_mermaid_temp_shutdown() -> None:
+    """Clean mermaid viewer temp files only if viewer was used this session."""
+    if not config_module.get("render_diagram_viewer_enabled", False):
+        return
+    try:
+        from .tools.mermaid_viewer import cleanup_temp_dir, was_viewer_used
+        if not was_viewer_used():
+            return
+        cleanup_temp_dir()
+    except Exception as e:
+        logger.debug("Mermaid temp shutdown cleanup failed: %s", e, exc_info=True)
+
+
+# Startup: clean stale files from previous sessions.
+_cleanup_mermaid_temp_startup()
+# Shutdown: clean only if viewer was actually used this session.
+atexit.register(_cleanup_mermaid_temp_shutdown)
+
+
 def _parse_watcher_flag(value: Optional[str]) -> bool:
     """Parse the --watcher flag value.
 
@@ -2084,6 +2114,17 @@ def _build_tools_list() -> list[Tool]:
                         "description": "Maximum nodes before smart pruning (default 80, range 10–200).",
                         "default": 80,
                     },
+                    **({
+                        "open_in_viewer": {
+                            "type": "boolean",
+                            "description": (
+                                "When true, also open the rendered mermaid in the local mmd-viewer. "
+                                "The HTML file is written under <index_storage>/temp/mermaid/. "
+                                "Non-fatal: if the viewer is missing, mermaid is returned anyway."
+                            ),
+                            "default": False,
+                        },
+                    } if config_module.get("render_diagram_viewer_enabled", False) else {}),
                 },
                 "required": ["source"],
             },
@@ -3231,6 +3272,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                     source=arguments["source"],
                     theme=arguments.get("theme", "flow"),
                     max_nodes=arguments.get("max_nodes", 80),
+                    open_in_viewer=arguments.get("open_in_viewer", False),
                 )
             )
         elif name == "get_project_intel":

--- a/src/jcodemunch_mcp/tools/mermaid_viewer.py
+++ b/src/jcodemunch_mcp/tools/mermaid_viewer.py
@@ -1,0 +1,102 @@
+"""mermaid_viewer — spawn mmd-viewer for render_diagram output.
+
+Provides:
+  resolve_viewer_path()  — configured path or $PATH lookup
+  open_diagram()         — write .mmd file + spawn viewer
+  cleanup_temp_dir()     — purge only jcodemunch-owned temp files
+
+Files are prefixed with `jcm-` so cleanup is selective and safe.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from .. import config as config_module
+
+logger = logging.getLogger(__name__)
+
+# Track whether the viewer was ever invoked this session.
+_viewer_used = False
+
+# Filename prefix — makes cleanup selective and safe.
+_FILE_PREFIX = "jcm-"
+
+
+def _temp_dir(storage_path: Path | None = None) -> Path:
+    base = Path(storage_path) if storage_path else config_module._global_storage_path()
+    return base / "temp" / "mermaid"
+
+
+def resolve_viewer_path() -> str | None:
+    """Return the mmd-viewer executable path, or None if not found."""
+    configured = config_module.get("mermaid_viewer_path", "")
+    if configured:
+        return configured if Path(configured).exists() else None
+    return shutil.which("mmd-viewer")
+
+
+def open_diagram(mermaid: str, storage_path: Path | None = None) -> dict:
+    """Write mermaid to a timestamped .mmd file and spawn mmd-viewer on it.
+
+    Returns {opened: bool, path: str, error?: str}. Non-fatal on failure.
+    Sets _viewer_used=True when a file is written (attempt was made).
+    """
+    global _viewer_used
+    viewer = resolve_viewer_path()
+    if not viewer:
+        return {"opened": False, "error": "viewer_not_found"}
+    d = _temp_dir(storage_path)
+    d.mkdir(parents=True, exist_ok=True)
+    fname = f"{_FILE_PREFIX}diagram-{os.getpid()}-{time.time_ns()}.mmd"
+    p = d / fname
+    p.write_text(mermaid, encoding="utf-8")
+    _viewer_used = True
+    try:
+        with open(p, "rb") as f:
+            subprocess.Popen(
+                [viewer],
+                stdin=f,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                close_fds=(os.name != "nt"),
+            )
+    except Exception as e:
+        return {"opened": False, "path": str(p), "error": f"spawn_failed: {e}"}
+    return {"opened": True, "path": str(p)}
+
+
+def was_viewer_used() -> bool:
+    """Return True if open_diagram was called at least once this session."""
+    return _viewer_used
+
+
+def cleanup_temp_dir(storage_path: Path | None = None) -> int:
+    """Remove only jcodemunch-owned files (jcm- prefix) from temp/mermaid/.
+
+    Returns count of removed files. Safe to call even if viewer was never used.
+    On Windows, retries with a short delay to handle file locks from viewer processes.
+    """
+    d = _temp_dir(storage_path)
+    if not d.exists():
+        return 0
+    removed = 0
+    for entry in d.iterdir():
+        if entry.is_file() and entry.name.startswith(_FILE_PREFIX):
+            try:
+                entry.unlink()
+                removed += 1
+            except OSError:
+                # Windows: viewer process may still hold the file. Retry once.
+                time.sleep(0.5)
+                try:
+                    entry.unlink()
+                    removed += 1
+                except OSError:
+                    logger.debug("Failed to remove mermaid temp file %s", entry, exc_info=True)
+    return removed

--- a/src/jcodemunch_mcp/tools/render_diagram.py
+++ b/src/jcodemunch_mcp/tools/render_diagram.py
@@ -1016,6 +1016,7 @@ def render_diagram(
     source: dict,
     theme: str = "flow",
     max_nodes: int = 80,
+    open_in_viewer: bool = False,
 ) -> dict:
     """Render any graph-producing tool's output as annotated Mermaid markup.
 
@@ -1025,9 +1026,10 @@ def render_diagram(
     node shapes for symbol kind, subgraph grouping by file/plate/depth.
 
     Args:
-        source:    Raw output dict from any supported graph-producing tool.
-        theme:     Visual theme — 'flow' (default), 'risk', or 'minimal'.
-        max_nodes: Maximum nodes before smart pruning (default 80).
+        source:         Raw output dict from any supported graph-producing tool.
+        theme:          Visual theme — 'flow' (default), 'risk', or 'minimal'.
+        max_nodes:      Maximum nodes before smart pruning (default 80).
+        open_in_viewer: When true, also open the mermaid in mmd-viewer (config-gated).
 
     Returns:
         Dict with diagram_type, mermaid, node_count, edge_count,
@@ -1077,4 +1079,15 @@ def render_diagram(
         "max_nodes": max_nodes,
         "detection_result": detected,
     }
+
+    if open_in_viewer:
+        from .. import config as config_module
+        if config_module.get("render_diagram_viewer_enabled", False):
+            from .mermaid_viewer import open_diagram
+            viewer_result = open_diagram(result.get("mermaid", ""))
+            if not viewer_result.get("opened"):
+                result["viewer_error"] = viewer_result.get("error")
+            else:
+                result["viewer_path"] = viewer_result["path"]
+
     return result

--- a/tests/test_render_diagram_integration.py
+++ b/tests/test_render_diagram_integration.py
@@ -1,0 +1,155 @@
+"""Integration test: render_diagram with open_in_viewer using real mmd-viewer binary."""
+
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+VIEWER_PATH = r"D:\1.Development\mmd-viewer\target\debug\mmd-viewer.exe"
+
+
+def _skip_if_no_viewer():
+    if not Path(VIEWER_PATH).exists():
+        pytest.skip(f"mmd-viewer.exe not found at {VIEWER_PATH}")
+
+
+def _call_hierarchy_source():
+    """Minimal call hierarchy output for render_diagram."""
+    return {
+        "repo": "test/repo",
+        "symbol": {"id": "app.py::main", "name": "main", "kind": "function", "file": "app.py", "line": 1},
+        "direction": "both",
+        "depth": 3,
+        "depth_reached": 1,
+        "caller_count": 1,
+        "callee_count": 1,
+        "callers": [{"id": "cli.py::run", "name": "run", "kind": "function", "file": "cli.py", "line": 5, "depth": 1, "resolution": "ast_resolved"}],
+        "callees": [{"id": "db.py::connect", "name": "connect", "kind": "function", "file": "db.py", "line": 10, "depth": 1, "resolution": "ast_resolved"}],
+        "dispatches": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_render_diagram_opens_real_viewer(tmp_path):
+    """End-to-end: call render_diagram with open_in_viewer=True, verify viewer spawns and file is created."""
+    _skip_if_no_viewer()
+
+    from jcodemunch_mcp import config as config_module
+    from jcodemunch_mcp.server import call_tool, list_tools
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+    config_module._GLOBAL_CONFIG.update(config_module.DEFAULTS.copy())
+
+    storage = tmp_path / "storage"
+    storage.mkdir()
+
+    old_path = os.environ.get("CODE_INDEX_PATH")
+    os.environ["CODE_INDEX_PATH"] = str(storage)
+
+    try:
+        config_module._GLOBAL_CONFIG["render_diagram_viewer_enabled"] = True
+        config_module._GLOBAL_CONFIG["mermaid_viewer_path"] = VIEWER_PATH
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+
+        from jcodemunch_mcp import server as server_mod
+        import importlib
+        importlib.reload(server_mod)
+
+        tools = await server_mod.list_tools()
+        render_tool = next(t for t in tools if t.name == "render_diagram")
+        assert "open_in_viewer" in render_tool.inputSchema["properties"]
+
+        source = _call_hierarchy_source()
+        result = await server_mod.call_tool("render_diagram", {
+            "source": source,
+            "theme": "flow",
+            "max_nodes": 80,
+            "open_in_viewer": True,
+        })
+
+        payload = json.loads(result[0].text)
+
+        assert "mermaid" in payload
+        assert payload["mermaid"].startswith("flowchart TD")
+
+        assert "viewer_path" in payload, f"Expected viewer_path in response, got: {payload}"
+        assert payload["viewer_path"].endswith(".mmd")
+        assert "jcm-diagram-" in payload["viewer_path"]
+
+        mmd_file = Path(payload["viewer_path"])
+        assert mmd_file.exists(), f"Expected {mmd_file} to exist"
+        assert mmd_file.read_text(encoding="utf-8").startswith("flowchart TD")
+
+        # Verify selective cleanup: jcm- files removed, others preserved
+        temp_dir = storage / "temp" / "mermaid"
+        assert temp_dir.exists()
+
+        # Count jcm files before cleanup
+        jcm_files_before = [f for f in temp_dir.iterdir() if f.is_file() and f.name.startswith("jcm-")]
+        assert len(jcm_files_before) >= 1, f"Expected at least 1 jcm- file, found: {[f.name for f in temp_dir.iterdir()]}"
+
+        # Drop a non-jcm file to verify it survives cleanup
+        (temp_dir / "other-tool.txt").write_text("leave me")
+
+        # Import fresh module for cleanup test
+        import jcodemunch_mcp.tools.mermaid_viewer as mv
+        importlib.reload(mv)
+
+        # Small delay to let viewer process release file lock (Windows)
+        time.sleep(1)
+
+        removed = mv.cleanup_temp_dir(storage_path=storage)
+        assert removed >= 1
+
+        # Non-jcm file still there
+        assert (temp_dir / "other-tool.txt").exists()
+
+        # Our jcm file is gone
+        assert not mmd_file.exists()
+
+    finally:
+        if old_path is not None:
+            os.environ["CODE_INDEX_PATH"] = old_path
+        else:
+            os.environ.pop("CODE_INDEX_PATH", None)
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+@pytest.mark.asyncio
+async def test_render_diagram_viewer_false_still_returns_mermaid(tmp_path):
+    """open_in_viewer=False returns mermaid without touching the viewer."""
+    from jcodemunch_mcp import config as config_module
+    from jcodemunch_mcp.server import call_tool
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+    config_module._GLOBAL_CONFIG.update(config_module.DEFAULTS.copy())
+
+    try:
+        config_module._GLOBAL_CONFIG["render_diagram_viewer_enabled"] = True
+        config_module._GLOBAL_CONFIG["mermaid_viewer_path"] = VIEWER_PATH
+        config_module._GLOBAL_CONFIG["disabled_tools"] = []
+
+        from jcodemunch_mcp import server as server_mod
+        import importlib
+        importlib.reload(server_mod)
+
+        result = await server_mod.call_tool("render_diagram", {
+            "source": _call_hierarchy_source(),
+            "open_in_viewer": False,
+        })
+
+        payload = json.loads(result[0].text)
+        assert "mermaid" in payload
+        assert "viewer_path" not in payload
+        assert "viewer_error" not in payload
+
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)

--- a/tests/test_render_diagram_viewer.py
+++ b/tests/test_render_diagram_viewer.py
@@ -1,0 +1,285 @@
+"""Tests for mermaid_viewer integration — viewer spawn, cleanup, and config gate."""
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# ── mermaid_viewer module tests ─────────────────────────────────────────────
+
+class TestResolveViewerPath:
+    """resolve_viewer_path() returns configured path, falls back to $PATH, or None."""
+
+    def test_returns_configured_path_when_exists(self):
+        import importlib
+        import jcodemunch_mcp.tools.mermaid_viewer as mv
+        import jcodemunch_mcp.config as config_module
+        importlib.reload(mv)
+        fake_path = "/usr/local/bin/mmd-viewer"
+        with patch.object(config_module, "get", side_effect=lambda k, d=None: fake_path if k == "mermaid_viewer_path" else d):
+            with patch.object(Path, "exists", return_value=True):
+                result = mv.resolve_viewer_path()
+                assert result == fake_path
+
+    def test_returns_none_when_configured_path_missing(self):
+        import importlib
+        import jcodemunch_mcp.tools.mermaid_viewer as mv
+        import jcodemunch_mcp.config as config_module
+        importlib.reload(mv)
+        fake_path = "/nonexistent/mmd-viewer"
+        with patch.object(config_module, "get", side_effect=lambda k, d=None: fake_path if k == "mermaid_viewer_path" else d):
+            result = mv.resolve_viewer_path()
+            assert result is None
+
+    def test_falls_back_to_shutil_which(self):
+        import importlib
+        import jcodemunch_mcp.tools.mermaid_viewer as mv
+        import jcodemunch_mcp.config as config_module
+        importlib.reload(mv)
+        with patch.object(config_module, "get", side_effect=lambda k, d=None: "" if k == "mermaid_viewer_path" else d):
+            with patch.object(shutil, "which", return_value="/usr/bin/mmd-viewer"):
+                result = mv.resolve_viewer_path()
+                assert result == "/usr/bin/mmd-viewer"
+
+    def test_returns_none_when_both_miss(self):
+        import importlib
+        import jcodemunch_mcp.tools.mermaid_viewer as mv
+        import jcodemunch_mcp.config as config_module
+        importlib.reload(mv)
+        with patch.object(config_module, "get", side_effect=lambda k, d=None: "" if k == "mermaid_viewer_path" else d):
+            with patch.object(shutil, "which", return_value=None):
+                result = mv.resolve_viewer_path()
+                assert result is None
+
+
+class TestOpenDiagram:
+    """open_diagram() writes .mmd file and spawns viewer."""
+
+    def test_viewer_not_found(self):
+        import importlib
+        import jcodemunch_mcp.tools.mermaid_viewer as mv
+        import jcodemunch_mcp.config as config_module
+        importlib.reload(mv)
+        with patch.object(config_module, "get", side_effect=lambda k, d=None: "" if k == "mermaid_viewer_path" else d):
+            with patch.object(shutil, "which", return_value=None):
+                result = mv.open_diagram("graph TD; A-->B;")
+                assert result["opened"] is False
+                assert result["error"] == "viewer_not_found"
+
+    def test_opens_viewer_and_returns_path(self, tmp_path):
+        import importlib
+        import jcodemunch_mcp.tools.mermaid_viewer as mv
+        import jcodemunch_mcp.config as config_module
+        importlib.reload(mv)
+        fake_viewer = str(tmp_path / "mmd-viewer")
+        with patch.object(config_module, "get", side_effect=lambda k, d=None: fake_viewer if k == "mermaid_viewer_path" else d):
+            with patch.object(Path, "exists", return_value=True):
+                with patch("subprocess.Popen") as mock_popen:
+                    result = mv.open_diagram("graph TD; A-->B;", storage_path=tmp_path)
+                    assert result["opened"] is True
+                    assert result["path"].endswith(".mmd")
+                    assert "jcm-diagram-" in result["path"]
+                    mock_popen.assert_called_once()
+
+    def test_spawn_failure_is_non_fatal(self, tmp_path):
+        import importlib
+        import jcodemunch_mcp.tools.mermaid_viewer as mv
+        import jcodemunch_mcp.config as config_module
+        importlib.reload(mv)
+        fake_viewer = str(tmp_path / "mmd-viewer")
+        with patch.object(config_module, "get", side_effect=lambda k, d=None: fake_viewer if k == "mermaid_viewer_path" else d):
+            with patch.object(Path, "exists", return_value=True):
+                with patch("subprocess.Popen", side_effect=OSError("exec failed")):
+                    result = mv.open_diagram("graph TD; A-->B;", storage_path=tmp_path)
+                    assert result["opened"] is False
+                    assert "spawn_failed" in result["error"]
+                    assert result["path"].endswith(".mmd")
+
+    def test_sets_viewer_used_flag(self, tmp_path):
+        import importlib
+        import jcodemunch_mcp.tools.mermaid_viewer as mv
+        import jcodemunch_mcp.config as config_module
+        importlib.reload(mv)
+        fake_viewer = str(tmp_path / "mmd-viewer")
+        with patch.object(config_module, "get", side_effect=lambda k, d=None: fake_viewer if k == "mermaid_viewer_path" else d):
+            with patch.object(Path, "exists", return_value=True):
+                with patch("subprocess.Popen"):
+                    assert mv._viewer_used is False
+                    mv.open_diagram("graph TD; A-->B;", storage_path=tmp_path)
+                    assert mv._viewer_used is True
+
+
+class TestWasViewerUsed:
+    """was_viewer_used() tracks session usage."""
+
+    def test_initially_false(self):
+        import importlib
+        import jcodemunch_mcp.tools.mermaid_viewer as mv
+        importlib.reload(mv)
+        assert mv.was_viewer_used() is False
+
+    def test_true_after_open_diagram(self, tmp_path):
+        import importlib
+        import jcodemunch_mcp.tools.mermaid_viewer as mv
+        import jcodemunch_mcp.config as config_module
+        importlib.reload(mv)
+        fake_viewer = str(tmp_path / "mmd-viewer")
+        with patch.object(config_module, "get", side_effect=lambda k, d=None: fake_viewer if k == "mermaid_viewer_path" else d):
+            with patch.object(Path, "exists", return_value=True):
+                with patch("subprocess.Popen"):
+                    mv.open_diagram("graph TD; A-->B;", storage_path=tmp_path)
+                    assert mv.was_viewer_used() is True
+
+
+class TestCleanupTempDir:
+    """cleanup_temp_dir() removes only jcm- prefixed files."""
+
+    def test_removes_jcm_files_only(self, tmp_path):
+        import importlib
+        import jcodemunch_mcp.tools.mermaid_viewer as mv
+        importlib.reload(mv)
+        d = tmp_path / "temp" / "mermaid"
+        d.mkdir(parents=True)
+        (d / "jcm-diagram-1.mmd").write_text("test")
+        (d / "jcm-diagram-2.mmd").write_text("test")
+        (d / "other-tool-file.txt").write_text("leave me alone")
+        result = mv.cleanup_temp_dir(storage_path=tmp_path)
+        assert result == 2
+        assert d.exists()
+        remaining = list(d.iterdir())
+        assert len(remaining) == 1
+        assert remaining[0].name == "other-tool-file.txt"
+
+    def test_noop_when_dir_missing(self, tmp_path):
+        import importlib
+        import jcodemunch_mcp.tools.mermaid_viewer as mv
+        importlib.reload(mv)
+        result = mv.cleanup_temp_dir(storage_path=tmp_path / "nonexistent")
+        assert result == 0
+
+    def test_noop_when_no_jcm_files(self, tmp_path):
+        import importlib
+        import jcodemunch_mcp.tools.mermaid_viewer as mv
+        importlib.reload(mv)
+        d = tmp_path / "temp" / "mermaid"
+        d.mkdir(parents=True)
+        (d / "other-file.txt").write_text("test")
+        result = mv.cleanup_temp_dir(storage_path=tmp_path)
+        assert result == 0
+        assert (d / "other-file.txt").exists()
+
+
+# ── render_diagram integration tests ────────────────────────────────────────
+
+class TestRenderDiagramViewerGate:
+    """render_diagram(open_in_viewer=True) respects config gate."""
+
+    def _call_hierarchy_data(self):
+        return {
+            "repo": "test/repo",
+            "symbol": {"id": "server.py::handle", "name": "handle", "kind": "function", "file": "server.py", "line": 10},
+            "direction": "both",
+            "depth": 3,
+            "depth_reached": 2,
+            "caller_count": 1,
+            "callee_count": 1,
+            "callers": [{"id": "main.py::run", "name": "run", "kind": "function", "file": "main.py", "line": 5, "depth": 1, "resolution": "ast_resolved"}],
+            "callees": [{"id": "db.py::query", "name": "query", "kind": "function", "file": "db.py", "line": 20, "depth": 1, "resolution": "ast_resolved"}],
+            "dispatches": [],
+        }
+
+    def test_config_off_does_not_call_open_diagram(self):
+        """When render_diagram_viewer_enabled=False, open_diagram is never called."""
+        import importlib
+        import jcodemunch_mcp.config as config_module
+        original_get = config_module.get
+        config_module.get = lambda k, d=None: False if k == "render_diagram_viewer_enabled" else original_get(k, d)
+        try:
+            import jcodemunch_mcp.tools.mermaid_viewer as mv
+            importlib.reload(mv)
+            with patch.object(mv, "open_diagram", return_value={"opened": True, "path": "/tmp/test.mmd"}) as mock_open:
+                from jcodemunch_mcp.tools.render_diagram import render_diagram
+                result = render_diagram(self._call_hierarchy_data(), open_in_viewer=True)
+                mock_open.assert_not_called()
+                assert "viewer_path" not in result
+                assert "viewer_error" not in result
+                assert "mermaid" in result
+        finally:
+            config_module.get = original_get
+
+    def test_config_on_calls_open_diagram(self):
+        """When render_diagram_viewer_enabled=True, open_diagram is called."""
+        import importlib
+        import jcodemunch_mcp.config as config_module
+        original_get = config_module.get
+        config_module.get = lambda k, d=None: True if k == "render_diagram_viewer_enabled" else original_get(k, d)
+        try:
+            import jcodemunch_mcp.tools.mermaid_viewer as mv
+            importlib.reload(mv)
+            with patch.object(mv, "open_diagram", return_value={"opened": True, "path": "/tmp/test.mmd"}) as mock_open:
+                from jcodemunch_mcp.tools.render_diagram import render_diagram
+                result = render_diagram(self._call_hierarchy_data(), open_in_viewer=True)
+                mock_open.assert_called_once()
+                assert result["viewer_path"] == "/tmp/test.mmd"
+        finally:
+            config_module.get = original_get
+
+    def test_viewer_error_propagated_non_fatal(self):
+        """Viewer failure adds viewer_error but mermaid is still returned."""
+        import importlib
+        import jcodemunch_mcp.config as config_module
+        original_get = config_module.get
+        config_module.get = lambda k, d=None: True if k == "render_diagram_viewer_enabled" else original_get(k, d)
+        try:
+            import jcodemunch_mcp.tools.mermaid_viewer as mv
+            importlib.reload(mv)
+            with patch.object(mv, "open_diagram", return_value={"opened": False, "error": "viewer_not_found"}):
+                from jcodemunch_mcp.tools.render_diagram import render_diagram
+                result = render_diagram(self._call_hierarchy_data(), open_in_viewer=True)
+                assert result["viewer_error"] == "viewer_not_found"
+                assert "mermaid" in result
+        finally:
+            config_module.get = original_get
+
+
+# ── Schema gate test ────────────────────────────────────────────────────────
+
+class TestSchemaGate:
+    """open_in_viewer appears in schema only when config gate is on."""
+
+    def test_schema_without_viewer(self):
+        """Default config: render_diagram schema has no open_in_viewer."""
+        import importlib
+        import jcodemunch_mcp.config as config_module
+        original_get = config_module.get
+        config_module.get = lambda k, d=None: False if k == "render_diagram_viewer_enabled" else original_get(k, d)
+        try:
+            import jcodemunch_mcp.server as server_module
+            importlib.reload(server_module)
+            tools = server_module._build_tools_list()
+            render_tool = next(t for t in tools if t.name == "render_diagram")
+            assert "open_in_viewer" not in render_tool.inputSchema["properties"]
+        finally:
+            config_module.get = original_get
+
+    def test_schema_with_viewer_enabled(self):
+        """Config on: render_diagram schema includes open_in_viewer."""
+        import importlib
+        import jcodemunch_mcp.config as config_module
+        original_get = config_module.get
+        config_module.get = lambda k, d=None: True if k == "render_diagram_viewer_enabled" else original_get(k, d)
+        try:
+            import jcodemunch_mcp.server as server_module
+            importlib.reload(server_module)
+            tools = server_module._build_tools_list()
+            render_tool = next(t for t in tools if t.name == "render_diagram")
+            assert "open_in_viewer" in render_tool.inputSchema["properties"]
+            prop = render_tool.inputSchema["properties"]["open_in_viewer"]
+            assert prop["type"] == "boolean"
+            assert prop["default"] is False
+        finally:
+            config_module.get = original_get


### PR DESCRIPTION
## Summary

Adds an optional `open_in_viewer` boolean parameter to `render_diagram`. When set to `true`, the
produced Mermaid markup is written to a temp file and opened in the local `mmd-viewer` binary for
instant visual preview — no copy-paste required. The parameter is hidden from the tool schema by
default and only surfaced when the user explicitly opts in via config, so LLM clients see no change
unless the feature is turned on.

---

## Why

`render_diagram` already produces rich, annotated Mermaid markup, but there was no way to preview
it visually without manually copying the string into an external tool. Developers running jCodemunch
locally have `mmd-viewer` available and wanted a single call to go from "I want to see this
diagram" to "diagram is open in front of me". The feature is gated so it stays invisible to
cloud/headless deployments where spawning a GUI process makes no sense.

### Getting `mmd-viewer`

`mmd-viewer` is a companion binary that renders Mermaid markup in a browser with cursor-anchored
zoom/pan. Download it from:

> **https://github.com/MariusAdrian88/mmd-viewer**

Once installed, point `mermaid_viewer_path` at the executable or drop it on `$PATH` — the
integration will pick it up automatically.

---

## What

### New module — `tools/mermaid_viewer.py`
- `resolve_viewer_path()` — returns the configured executable path, or falls back to `mmd-viewer`
  on `$PATH`. Returns `None` when neither resolves.
- `open_diagram(mermaid, storage_path?)` — writes a `jcm-`-prefixed `.mmd` file under
  `<index_storage>/temp/mermaid/` and spawns the viewer with the file on stdin. Non-fatal on
  spawn failure — returns `{opened, path, error?}`.
- `cleanup_temp_dir(storage_path?)` — removes only `jcm-`-prefixed files, leaving anything else
  in the folder untouched. On Windows, retries once after 500 ms to handle viewer process locks.
- `was_viewer_used()` — session flag; used by the shutdown hook to skip cleanup when the viewer
  was never invoked.

### `config.py`
- Two new keys in `DEFAULTS` and `CONFIG_TYPES`:
  - `render_diagram_viewer_enabled` (bool, default `false`) — schema gate.
  - `mermaid_viewer_path` (str, default `""`) — absolute path to the executable; empty = `$PATH`.
- Full commented block added to `generate_template`.

### `tools/render_diagram.py`
- New `open_in_viewer: bool = False` parameter.
- After result assembly, if `open_in_viewer=True` and the config gate is on, calls `open_diagram`.
  Failure adds `viewer_error` to the result; success adds `viewer_path`. Mermaid is always returned.

### `server.py`
- Schema: `open_in_viewer` property injected into `render_diagram`'s `inputSchema` only when
  `render_diagram_viewer_enabled` is `true` — invisible to LLMs otherwise.
- Dispatcher: passes `open_in_viewer=arguments.get("open_in_viewer", False)`.
- Lifecycle: `_cleanup_mermaid_temp_startup()` runs at module load; `_cleanup_mermaid_temp_shutdown()`
  registered via `atexit` (skipped if viewer was never used this session).

### `tests/test_render_diagram_viewer.py`
285-line test suite covering `resolve_viewer_path`, `open_diagram`, `was_viewer_used`,
`cleanup_temp_dir`, the config gate on `render_diagram`, and the schema gate in `_build_tools_list`.

---

## Before / After

### Before

```python
result = render_diagram(call_hierarchy_data)
# result["mermaid"] contains the diagram string
# → developer manually copies it into mermaid.live or another tool
```

### After

```python
# config.jsonc
# "render_diagram_viewer_enabled": true,
# "mermaid_viewer_path": "C:/tools/mmd-viewer.exe",  # or leave empty for $PATH

result = render_diagram(call_hierarchy_data, open_in_viewer=True)
# → mmd-viewer opens in the browser automatically
# result["viewer_path"] = "~/.code-index/temp/mermaid/jcm-diagram-1234-98765.mmd"

# If viewer is missing or fails, mermaid is still returned:
# result["viewer_error"] = "viewer_not_found"
# result["mermaid"] = "flowchart TD\n  ..."
```

### Schema (feature off — default)

```json
{
  "name": "render_diagram",
  "inputSchema": {
    "properties": {
      "source": { ... },
      "theme": { ... },
      "max_nodes": { ... }
    }
  }
}
```

### Schema (feature on)

```json
{
  "name": "render_diagram",
  "inputSchema": {
    "properties": {
      "source": { ... },
      "theme": { ... },
      "max_nodes": { ... },
      "open_in_viewer": {
        "type": "boolean",
        "default": false,
        "description": "When true, also open the rendered mermaid in the local mmd-viewer..."
      }
    }
  }
}
```