### PR TITLE
fix(encoder): align all MUNCH tier-1 schemas with actual tool responses + add `__stypes`

### DIFF
--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -59,7 +59,24 @@ ENV_VAR_MAPPING = {
     "JCODEMUNCH_PATH_MAP": "path_map",
     "JCODEMUNCH_TRUSTED_FOLDERS_ENV": "trusted_folders",
     "JCODEMUNCH_CROSS_REPO_DEFAULT": "cross_repo_default",
+    "JCODEMUNCH_DEFAULT_FORMAT": "server_output",
+    "JCODEMUNCH_ENCODING_THRESHOLD": "server_output_threshold",
 }
+
+_SERVER_OUTPUT_ALIASES = {
+    "raw": "raw",
+    "encoded": "encoded",
+    "adaptive": "adaptive",
+    # Legacy aliases kept for backward compatibility.
+    "json": "raw",
+    "compact": "encoded",
+    "auto": "adaptive",
+}
+
+
+def _normalize_server_output(value: str) -> str | None:
+    """Normalize server_output/format aliases to canonical config values."""
+    return _SERVER_OUTPUT_ALIASES.get(value.strip().lower())
 
 
 def _global_config_path() -> Path:
@@ -316,6 +333,8 @@ DEFAULTS = {
     },
     "adaptive_tiering": False,
     "compact_schemas": False,
+    "server_output": "adaptive",  # "raw", "encoded", or "adaptive"
+    "server_output_threshold": 0.15,  # Minimum savings ratio for adaptive mode
     "disabled_tools": ["test_summarizer"],
     "descriptions": {},
     "transport": "stdio",
@@ -390,6 +409,8 @@ CONFIG_TYPES = {
     "model_tier_map": dict,
     "adaptive_tiering": bool,
     "compact_schemas": bool,
+    "server_output": str,
+    "server_output_threshold": float,
     "disabled_tools": list,
     "descriptions": dict,
     "transport": str,
@@ -551,6 +572,10 @@ def _validate_type(key: str, value: Any, expected_type: type | tuple) -> bool:
         if isinstance(value, str):
             return value.lower() in {"true", "false", "auto"}
         return False
+    if key == "server_output":
+        return isinstance(value, str) and _normalize_server_output(value) is not None
+    if key == "server_output_threshold":
+        return isinstance(value, (int, float)) and 0.0 <= float(value) <= 1.0
     if isinstance(expected_type, tuple):
         return isinstance(value, expected_type)
     return isinstance(value, expected_type)
@@ -615,6 +640,10 @@ def load_config(storage_path: str | None = None) -> None:
                                     )
 
                             _GLOBAL_CONFIG[key] = list(valid_folders)
+                        elif key == "server_output" and isinstance(value, str):
+                            normalized = _normalize_server_output(value)
+                            if normalized is not None:
+                                _GLOBAL_CONFIG[key] = normalized
                         else:
                             _GLOBAL_CONFIG[key] = value
                         _explicit_keys.add(key)  # Track explicitly set keys
@@ -647,6 +676,8 @@ def _parse_env_value(value: str, expected_type: type | tuple, key: str | None = 
     # generic bool parsing would coerce "auto" to False.
     if key == "use_ai_summaries":
         return value.strip().lower()
+    if key == "server_output":
+        return _normalize_server_output(value)
     try:
         if isinstance(expected_type, tuple):
             for t in expected_type:
@@ -869,6 +900,10 @@ def load_project_config(source_root: str) -> None:
                                         )
                                     valid_folders.add(expanded_folder)
                                 merged[key] = list(valid_folders)
+                            elif key == "server_output" and isinstance(value, str):
+                                normalized = _normalize_server_output(value)
+                                if normalized is not None:
+                                    merged[key] = normalized
                             else:
                                 merged[key] = value
                         else:
@@ -1361,6 +1396,18 @@ def generate_template() -> str:
   // fuzzy_*, etc.) from tool schemas. The server still accepts them — they're just
   // hidden from the LLM to save tokens. Saves ~1-2k tokens on top of any profile.
   // "compact_schemas": false,
+
+  // === Server Output ===
+  // Controls how tool responses are emitted:
+  //   "raw"      - always emit JSON output.
+  //   "encoded"  - always emit MUNCH-encoded output.
+  //   "adaptive" - compare JSON vs MUNCH size and encode only when savings clear
+  //                the threshold below (default).
+  // Legacy aliases "json"/"compact"/"auto" are still accepted.
+  // "server_output": "adaptive",
+  // "server_output_threshold": 0.15,
+  //   Minimum savings ratio required for adaptive mode to emit MUNCH.
+  //   Example: 0.15 means encoded output must be at least 15% smaller.
 
   // === Disabled Tools ===
   // Global: tools listed here are removed from the schema entirely.

--- a/src/jcodemunch_mcp/encoding/__init__.py
+++ b/src/jcodemunch_mcp/encoding/__init__.py
@@ -14,14 +14,15 @@ Usage from server.py:
     else:
         text = payload
 
-`requested_format` is one of: "auto" (default), "compact", "json".
+`requested_format` supports both canonical and user-facing aliases:
+- canonical: "auto", "compact", "json"
+- aliases: "adaptive", "encoded", "raw"
 """
 
 from __future__ import annotations
 
 import json
 import logging
-import os
 from typing import Any
 
 from . import gate, generic
@@ -30,17 +31,37 @@ from .schemas import registry
 logger = logging.getLogger(__name__)
 
 _FORMATS = ("auto", "compact", "json")
+_FORMAT_ALIASES = {
+    "auto": "auto",
+    "compact": "compact",
+    "json": "json",
+    "adaptive": "auto",
+    "encoded": "compact",
+    "raw": "json",
+}
 
 
-def default_format() -> str:
-    raw = os.environ.get("JCODEMUNCH_DEFAULT_FORMAT", "auto").lower()
-    return raw if raw in _FORMATS else "auto"
+def _normalize_format(raw: str | None, fallback: str) -> str:
+    if not isinstance(raw, str):
+        return fallback
+    return _FORMAT_ALIASES.get(raw.strip().lower(), fallback)
+
+
+def default_format(repo: str | None = None) -> str:
+    try:
+        from .. import config as app_config
+
+        configured = app_config.get("server_output", "adaptive", repo=repo)
+    except Exception:
+        configured = "adaptive"
+    return _normalize_format(configured, "auto")
 
 
 def encode_response(
     tool_name: str,
     response: Any,
     requested_format: str | None = None,
+    repo: str | None = None,
 ) -> tuple[Any, dict]:
     """Return (payload, meta).
 
@@ -48,9 +69,7 @@ def encode_response(
     meta is a dict with keys: encoding, json_bytes, encoded_bytes,
     encoding_tokens_saved.
     """
-    fmt = (requested_format or default_format()).lower()
-    if fmt not in _FORMATS:
-        fmt = "auto"
+    fmt = _normalize_format(requested_format, default_format(repo=repo))
 
     if fmt == "json" or not isinstance(response, dict):
         return response, {"encoding": "json"}
@@ -68,7 +87,7 @@ def encode_response(
         return response, {"encoding": "json", "json_bytes": json_bytes}
 
     encoded_bytes = len(payload)
-    if fmt == "auto" and not gate.passes(json_bytes, encoded_bytes):
+    if fmt == "auto" and not gate.passes(json_bytes, encoded_bytes, repo=repo):
         return response, {
             "encoding": "json",
             "json_bytes": json_bytes,

--- a/src/jcodemunch_mcp/encoding/gate.py
+++ b/src/jcodemunch_mcp/encoding/gate.py
@@ -7,14 +7,19 @@ byte sizes. Threshold is configurable via env/config; default 15%.
 from __future__ import annotations
 
 import json
-import os
 
 DEFAULT_THRESHOLD = 0.15
 
 
-def threshold() -> float:
-    raw = os.environ.get("JCODEMUNCH_ENCODING_THRESHOLD")
-    if raw:
+def threshold(repo: str | None = None) -> float:
+    try:
+        from .. import config as app_config
+
+        raw = app_config.get("server_output_threshold", DEFAULT_THRESHOLD, repo=repo)
+    except Exception:
+        raw = DEFAULT_THRESHOLD
+
+    if raw is not None:
         try:
             return max(0.0, float(raw))
         except ValueError:
@@ -32,5 +37,5 @@ def savings_ratio(json_bytes: int, compact_bytes: int) -> float:
     return max(0.0, (json_bytes - compact_bytes) / json_bytes)
 
 
-def passes(json_bytes: int, compact_bytes: int) -> bool:
-    return savings_ratio(json_bytes, compact_bytes) >= threshold()
+def passes(json_bytes: int, compact_bytes: int, repo: str | None = None) -> bool:
+    return savings_ratio(json_bytes, compact_bytes) >= threshold(repo=repo)

--- a/src/jcodemunch_mcp/encoding/schema_driven.py
+++ b/src/jcodemunch_mcp/encoding/schema_driven.py
@@ -113,6 +113,14 @@ def encode(
     for k in json_blobs:
         if k in response:
             scalar_payload[f"__json.{k}"] = json.dumps(response[k], separators=(",", ":"))
+    scalar_types_out: dict[str, str] = {}
+    for k, v in scalar_payload.items():
+        if k.startswith("__"):
+            continue
+        if v is not None and not isinstance(v, str):
+            scalar_types_out[k] = _type_of(v)
+    if scalar_types_out:
+        scalar_payload["__stypes"] = "|".join(f"{k}:{t}" for k, t in scalar_types_out.items())
     # Encode the table schema into the payload so decode is self-sufficient.
     scalar_payload["__tables"] = ",".join(
         f"{t.tag}:{t.key}:{'|'.join(t.cols)}" for t in tables
@@ -174,6 +182,11 @@ def decode(
 
     raw_scalars = parse_scalars(scalar_block) if scalar_block else {}
     raw_scalars.pop("__tables", None)
+    stypes_text = raw_scalars.pop("__stypes", "")
+    for part in [p for p in stypes_text.split("|") if p]:
+        name, _, hint = part.partition(":")
+        if name and hint and name not in stypes:
+            stypes[name] = hint
 
     result: dict[str, Any] = {}
     # Top-level scalars — coerce per scalar_types hint when supplied,

--- a/src/jcodemunch_mcp/encoding/schemas/find_importers.py
+++ b/src/jcodemunch_mcp/encoding/schemas/find_importers.py
@@ -3,31 +3,25 @@
 from .. import schema_driven as sd
 
 TOOLS = ("find_importers",)
-ENCODING_ID = "fi1"
+ENCODING_ID = "fi2"
 
 _TABLES = [
     sd.TableSpec(
         key="importers",
         tag="i",
-        cols=["file", "specifier", "line", "column"],
+        cols=["file", "specifier", "has_importers"],
         intern=["file", "specifier"],
-        types={"line": "int", "column": "int"},
-    ),
-    sd.TableSpec(
-        key="results",
-        tag="b",
-        cols=["file", "importer_count"],
-        intern=["file"],
-        types={"importer_count": "int"},
+        types={"has_importers": "bool"},
     ),
 ]
-_SCALARS = ("repo", "file", "importer_count", "note")
+_SCALARS = ("repo", "file_path", "importer_count", "note")
 _META = ("timing_ms", "truncated", "tokens_saved", "total_tokens_saved")
+_JSON = ("results",)
 
 
 def encode(tool: str, response: dict) -> tuple[str, str]:
-    return sd.encode(tool, response, ENCODING_ID, _TABLES, _SCALARS, meta_keys=_META)
+    return sd.encode(tool, response, ENCODING_ID, _TABLES, _SCALARS, meta_keys=_META, json_blobs=_JSON)
 
 
 def decode(payload: str) -> dict:
-    return sd.decode(payload, _TABLES, _SCALARS, meta_keys=_META)
+    return sd.decode(payload, _TABLES, _SCALARS, meta_keys=_META, json_blobs=_JSON)

--- a/src/jcodemunch_mcp/encoding/schemas/find_references.py
+++ b/src/jcodemunch_mcp/encoding/schemas/find_references.py
@@ -3,30 +3,87 @@
 from .. import schema_driven as sd
 
 TOOLS = ("find_references",)
-ENCODING_ID = "fr1"
+ENCODING_ID = "fr2"
+
+_ROWS_KEY = "__rows__"
+_EMPTY_GROUPS_KEY = "__empty_groups__"
 
 _TABLES = [
     sd.TableSpec(
-        key="references",
+        key=_ROWS_KEY,
         tag="r",
-        cols=["file", "line", "column", "specifier", "kind"],
+        cols=["file", "specifier", "match_type"],
         intern=["file", "specifier"],
-        types={"line": "int", "column": "int"},
-    ),
-    sd.TableSpec(
-        key="results",
-        tag="b",
-        cols=["identifier", "reference_count"],
-        types={"reference_count": "int"},
     ),
 ]
 _SCALARS = ("repo", "identifier", "reference_count", "note")
 _META = ("timing_ms", "truncated", "tokens_saved", "total_tokens_saved")
+_JSON = ("results", _EMPTY_GROUPS_KEY)
+
+
+def _flatten(response: dict) -> dict:
+    """Replace nested references[].matches[] with flat rows."""
+    out = {k: v for k, v in response.items() if k != "references"}
+    rows = []
+    empty_groups: list[str] = []
+    for group in response.get("references") or []:
+        if not isinstance(group, dict):
+            continue
+        file_path = group.get("file")
+        matches = group.get("matches") or []
+        if not matches:
+            if isinstance(file_path, str):
+                empty_groups.append(file_path)
+            continue
+        for m in matches:
+            if not isinstance(m, dict):
+                continue
+            rows.append(
+                {
+                    "file": file_path,
+                    "specifier": m.get("specifier", ""),
+                    "match_type": m.get("match_type", ""),
+                }
+            )
+    out[_ROWS_KEY] = rows
+    if empty_groups:
+        out[_EMPTY_GROUPS_KEY] = empty_groups
+    return out
+
+
+def _regroup(decoded: dict) -> dict:
+    """Inverse of _flatten: rebuild references list."""
+    rows = decoded.pop(_ROWS_KEY, None) or []
+    empty_groups = decoded.pop(_EMPTY_GROUPS_KEY, None) or []
+    groups: dict[str, list[dict]] = {}
+    order: list[str] = []
+    for file_path in empty_groups:
+        if not isinstance(file_path, str):
+            continue
+        if file_path not in groups:
+            groups[file_path] = []
+            order.append(file_path)
+    for row in rows:
+        file_path = row.get("file")
+        if not isinstance(file_path, str):
+            continue
+        match = {"specifier": row.get("specifier", ""), "match_type": row.get("match_type", "")}
+        if file_path not in groups:
+            groups[file_path] = []
+            order.append(file_path)
+        groups[file_path].append(match)
+    decoded["references"] = [{"file": f, "matches": groups[f]} for f in order]
+    return decoded
 
 
 def encode(tool: str, response: dict) -> tuple[str, str]:
-    return sd.encode(tool, response, ENCODING_ID, _TABLES, _SCALARS, meta_keys=_META)
+    if "references" not in response:
+        return sd.encode(tool, response, ENCODING_ID, _TABLES, _SCALARS, meta_keys=_META, json_blobs=_JSON)
+    return sd.encode(tool, _flatten(response), ENCODING_ID, _TABLES, _SCALARS, meta_keys=_META, json_blobs=_JSON)
 
 
 def decode(payload: str) -> dict:
-    return sd.decode(payload, _TABLES, _SCALARS, meta_keys=_META)
+    decoded = sd.decode(payload, _TABLES, _SCALARS, meta_keys=_META, json_blobs=_JSON)
+    if _ROWS_KEY in decoded:
+        return _regroup(decoded)
+    return decoded

--- a/src/jcodemunch_mcp/encoding/schemas/get_blast_radius.py
+++ b/src/jcodemunch_mcp/encoding/schemas/get_blast_radius.py
@@ -3,31 +3,30 @@
 from .. import schema_driven as sd
 
 TOOLS = ("get_blast_radius",)
-ENCODING_ID = "br1"
+ENCODING_ID = "br2"
 
 _TABLES = [
     sd.TableSpec(
-        key="affected_symbols",
-        tag="a",
-        cols=["id", "name", "kind", "file", "line", "depth"],
-        intern=["file", "id"],
-        types={"line": "int", "depth": "int"},
+        key="confirmed",
+        tag="c",
+        cols=["file", "references", "has_test_reach"],
+        intern=["file"],
+        types={"references": "int", "has_test_reach": "bool"},
     ),
     sd.TableSpec(
-        key="importer_files",
-        tag="f",
-        cols=["file", "depth"],
+        key="potential",
+        tag="p",
+        cols=["file", "reason"],
         intern=["file"],
-        types={"depth": "int"},
     ),
 ]
 _SCALARS = (
-    "repo", "symbol", "direction", "depth",
-    "importer_file_count", "affected_symbol_count",
+    "repo", "depth", "importer_count", "confirmed_count", "potential_count",
+    "direct_dependents_count", "overall_risk_score",
 )
-_NESTED = {"symbol_info": ["id", "name", "kind", "file", "line"]}
-_META = ("timing_ms", "truncated", "cross_repo", "methodology")
-_JSON = ("files_by_depth",)
+_NESTED = {"symbol": ["id", "name", "kind", "file", "line"]}
+_META = ("timing_ms",)
+_JSON = ("impact_by_depth", "callers", "cross_repo_confirmed")
 
 
 def encode(tool: str, response: dict) -> tuple[str, str]:

--- a/src/jcodemunch_mcp/encoding/schemas/get_dependency_cycles.py
+++ b/src/jcodemunch_mcp/encoding/schemas/get_dependency_cycles.py
@@ -3,7 +3,9 @@
 from .. import schema_driven as sd
 
 TOOLS = ("get_dependency_cycles",)
-ENCODING_ID = "dc1"
+ENCODING_ID = "dc2"
+
+_CYCLE_SEP = "\x1f"
 
 _TABLES = [
     sd.TableSpec(
@@ -18,8 +20,20 @@ _META = ("timing_ms",)
 
 
 def encode(tool: str, response: dict) -> tuple[str, str]:
-    return sd.encode(tool, response, ENCODING_ID, _TABLES, _SCALARS, meta_keys=_META)
+    r = dict(response)
+    if "cycles" in r and isinstance(r["cycles"], list):
+        r["cycles"] = [
+            {"length": len(c), "files": _CYCLE_SEP.join(c)}
+            for c in r["cycles"] if isinstance(c, list)
+        ]
+    return sd.encode(tool, r, ENCODING_ID, _TABLES, _SCALARS, meta_keys=_META)
 
 
 def decode(payload: str) -> dict:
-    return sd.decode(payload, _TABLES, _SCALARS, meta_keys=_META)
+    result = sd.decode(payload, _TABLES, _SCALARS, meta_keys=_META)
+    if "cycles" in result:
+        result["cycles"] = [
+            c["files"].split(_CYCLE_SEP) for c in result["cycles"]
+            if isinstance(c, dict) and "files" in c
+        ]
+    return result

--- a/src/jcodemunch_mcp/encoding/schemas/get_signal_chains.py
+++ b/src/jcodemunch_mcp/encoding/schemas/get_signal_chains.py
@@ -3,31 +3,46 @@
 from .. import schema_driven as sd
 
 TOOLS = ("get_signal_chains",)
-ENCODING_ID = "sc1"
+ENCODING_ID = "sc2"
 
 _TABLES = [
     sd.TableSpec(
         key="chains",
         tag="c",
-        cols=["gateway", "gateway_kind", "leaves", "depth", "symbol_path"],
+        cols=[
+            "gateway", "gateway_name", "kind", "label", "depth", "reach",
+            "file_count", "chain_reach", "depth_from_gateway",
+        ],
         intern=["gateway"],
-        types={"depth": "int"},
+        types={"depth": "int", "reach": "int", "file_count": "int", "chain_reach": "int", "depth_from_gateway": "int"},
     ),
 ]
 _SCALARS = (
     "repo", "gateway_count", "chain_count", "orphan_symbols", "orphan_symbol_pct",
+    "symbol", "symbol_id", "on_no_chain", "gateway_warning",
 )
-_META = (
+_DISCOVERY_META = (
     "timing_ms", "max_depth", "include_tests",
     "symbols_on_chains", "total_functions_methods",
 )
+_LOOKUP_META = ("timing_ms", "total_gateways")
+_NO_GATEWAY_META = ("timing_ms",)
+_META = tuple(dict.fromkeys(_DISCOVERY_META + _LOOKUP_META + _NO_GATEWAY_META))
 _JSON = ("kind_summary",)
+
+
+def _meta_keys(response: dict) -> tuple[str, ...]:
+    if "gateway_warning" in response:
+        return _NO_GATEWAY_META
+    if "symbol" in response or "symbol_id" in response:
+        return _LOOKUP_META
+    return _DISCOVERY_META
 
 
 def encode(tool: str, response: dict) -> tuple[str, str]:
     return sd.encode(
         tool, response, ENCODING_ID, _TABLES, _SCALARS,
-        meta_keys=_META, json_blobs=_JSON,
+        meta_keys=_meta_keys(response), json_blobs=_JSON,
     )
 
 

--- a/src/jcodemunch_mcp/encoding/schemas/get_tectonic_map.py
+++ b/src/jcodemunch_mcp/encoding/schemas/get_tectonic_map.py
@@ -3,33 +3,39 @@
 from .. import schema_driven as sd
 
 TOOLS = ("get_tectonic_map",)
-ENCODING_ID = "tm1"
+ENCODING_ID = "tm2"
 
 _TABLES = [
     sd.TableSpec(
         key="plates",
         tag="p",
-        cols=["label", "file_count", "representative"],
-        intern=["representative"],
-        types={"file_count": "int"},
+        cols=["plate_id", "anchor", "file_count", "cohesion", "majority_directory", "drifter_count", "nexus_alert"],
+        intern=["anchor"],
+        types={"plate_id": "int", "file_count": "int", "cohesion": "float", "drifter_count": "int", "nexus_alert": "bool"},
     ),
     sd.TableSpec(
         key="drifter_summary",
         tag="z",
-        cols=["file", "score", "nearest_plate"],
-        intern=["file"],
-        types={"score": "float"},
-    ),
-    sd.TableSpec(
-        key="isolated_files",
-        tag="q",
-        cols=["file"],
+        cols=["file", "current_directory", "belongs_with", "plate_anchor"],
         intern=["file"],
     ),
 ]
 _SCALARS = ("repo", "plate_count", "file_count")
 _META = ("timing_ms", "methodology")
-_JSON = ("signals_used", "_meta")
+_JSON = ("signals_used", "isolated_files")
+
+
+def _prune_optional_plate_fields(decoded: dict) -> dict:
+    plates = decoded.get("plates")
+    if not isinstance(plates, list):
+        return decoded
+    for plate in plates:
+        if not isinstance(plate, dict):
+            continue
+        for key in ("drifter_count", "nexus_alert"):
+            if plate.get(key) is None:
+                plate.pop(key, None)
+    return decoded
 
 
 def encode(tool: str, response: dict) -> tuple[str, str]:
@@ -40,6 +46,7 @@ def encode(tool: str, response: dict) -> tuple[str, str]:
 
 
 def decode(payload: str) -> dict:
-    return sd.decode(
+    decoded = sd.decode(
         payload, _TABLES, _SCALARS, meta_keys=_META, json_blobs=_JSON,
     )
+    return _prune_optional_plate_fields(decoded)

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -3822,7 +3822,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         try:
             from .encoding import encode_response
             from .storage.token_tracker import record_encoding_savings
-            encoded, enc_meta = encode_response(name, result, _requested_format)
+            encoded, enc_meta = encode_response(name, result, _requested_format, repo=repo_arg)
             if enc_meta.get("encoding") != "json":
                 saved = enc_meta.get("encoding_tokens_saved", 0)
                 total_enc = record_encoding_savings(saved, base_path=storage_path, tool_name=name)

--- a/tests/encoding/test_dispatcher.py
+++ b/tests/encoding/test_dispatcher.py
@@ -64,3 +64,84 @@ def test_auto_emits_compact_on_big_response():
 def test_json_decoder_falls_through_for_json_payloads():
     raw = json.dumps({"hello": 1})
     assert decode_munch(raw) == {"hello": 1}
+
+
+def test_user_facing_format_aliases_are_supported():
+    payload, meta = encode_response("demo", _big_response(), "encoded")
+    assert meta["encoding"] != "json"
+
+    payload, meta = encode_response("demo", _big_response(), "raw")
+    assert meta["encoding"] == "json"
+    assert isinstance(payload, dict)
+
+
+def test_default_format_uses_server_output_config():
+    import jcodemunch_mcp.config as cfg
+
+    snapshot = dict(cfg._GLOBAL_CONFIG)
+    try:
+        cfg._GLOBAL_CONFIG.clear()
+        cfg._GLOBAL_CONFIG.update({"server_output": "raw", "server_output_threshold": 0.15})
+        payload, meta = encode_response("demo", _big_response())
+        assert meta["encoding"] == "json"
+
+        cfg._GLOBAL_CONFIG["server_output"] = "encoded"
+        payload, meta = encode_response("demo", _big_response())
+        assert meta["encoding"] != "json"
+    finally:
+        cfg._GLOBAL_CONFIG.clear()
+        cfg._GLOBAL_CONFIG.update(snapshot)
+
+
+def test_project_server_output_overrides_global_when_repo_provided():
+    import jcodemunch_mcp.config as cfg
+
+    repo_key = "D:/tmp/project-a"
+    g_snapshot = dict(cfg._GLOBAL_CONFIG)
+    p_snapshot = dict(cfg._PROJECT_CONFIGS)
+    try:
+        cfg._GLOBAL_CONFIG.clear()
+        cfg._GLOBAL_CONFIG.update({"server_output": "encoded", "server_output_threshold": 0.15})
+        cfg._PROJECT_CONFIGS.clear()
+        project_cfg = dict(cfg._GLOBAL_CONFIG)
+        project_cfg["server_output"] = "raw"
+        cfg._PROJECT_CONFIGS[repo_key] = project_cfg
+
+        payload, meta = encode_response("demo", _big_response(), repo=repo_key)
+        assert meta["encoding"] == "json"
+
+        payload, meta = encode_response("demo", _big_response())
+        assert meta["encoding"] != "json"
+    finally:
+        cfg._GLOBAL_CONFIG.clear()
+        cfg._GLOBAL_CONFIG.update(g_snapshot)
+        cfg._PROJECT_CONFIGS.clear()
+        cfg._PROJECT_CONFIGS.update(p_snapshot)
+
+
+def test_project_threshold_overrides_global_when_repo_provided():
+    import jcodemunch_mcp.config as cfg
+
+    repo_key = "D:/tmp/project-b"
+    g_snapshot = dict(cfg._GLOBAL_CONFIG)
+    p_snapshot = dict(cfg._PROJECT_CONFIGS)
+    try:
+        cfg._GLOBAL_CONFIG.clear()
+        cfg._GLOBAL_CONFIG.update({"server_output": "adaptive", "server_output_threshold": 1.0})
+        cfg._PROJECT_CONFIGS.clear()
+        project_cfg = dict(cfg._GLOBAL_CONFIG)
+        project_cfg["server_output_threshold"] = 0.0
+        cfg._PROJECT_CONFIGS[repo_key] = project_cfg
+
+        big = _big_response()
+        big["references"] *= 10
+        payload, meta = encode_response("demo", big, repo=repo_key)
+        assert meta["encoding"] != "json"
+
+        payload, meta = encode_response("demo", big)
+        assert meta["encoding"] == "json"
+    finally:
+        cfg._GLOBAL_CONFIG.clear()
+        cfg._GLOBAL_CONFIG.update(g_snapshot)
+        cfg._PROJECT_CONFIGS.clear()
+        cfg._PROJECT_CONFIGS.update(p_snapshot)

--- a/tests/encoding/test_tier1_roundtrip.py
+++ b/tests/encoding/test_tier1_roundtrip.py
@@ -34,37 +34,114 @@ def test_find_references_round_trip():
     resp = {
         "repo": "acme/app",
         "identifier": "get_user",
-        "reference_count": 3,
+        "reference_count": 2,
         "references": [
-            {"file": "src/a.py", "line": 10, "column": 4, "specifier": "models.user", "kind": "import"},
-            {"file": "src/a.py", "line": 22, "column": 4, "specifier": "models.user", "kind": "import"},
-            {"file": "src/b.py", "line": 5, "column": 0, "specifier": "models.user", "kind": "import"},
+            {
+                "file": "src/a.py",
+                "matches": [
+                    {"specifier": "models.user", "match_type": "named"},
+                    {"specifier": "models.user", "match_type": "specifier_stem"},
+                ],
+            },
+            {
+                "file": "src/b.py",
+                "matches": [
+                    {"specifier": "models.user", "match_type": "named"},
+                ],
+            },
         ],
         "_meta": {"timing_ms": 3.1, "truncated": False},
     }
     out = _rt("find_references", resp)
     assert out["repo"] == "acme/app"
     assert out["identifier"] == "get_user"
-    assert len(out["references"]) == 3
+    assert isinstance(out["reference_count"], int)
+    assert out["reference_count"] == 2
+    assert len(out["references"]) == 2
     assert out["references"][0]["file"] == "src/a.py"
-    assert out["references"][0]["line"] == 10
+    assert len(out["references"][0]["matches"]) == 2
+    assert len(out["references"][1]["matches"]) == 1
+
+
+def test_find_references_empty_matches_round_trip():
+    resp = {
+        "repo": "acme/app",
+        "identifier": "get_user",
+        "reference_count": 2,
+        "references": [
+            {"file": "src/a.py", "matches": []},
+            {"file": "src/b.py", "matches": [{"specifier": "models.user", "match_type": "named"}]},
+        ],
+        "_meta": {"timing_ms": 1.0, "truncated": False},
+    }
+    out = _rt("find_references", resp)
+    assert len(out["references"]) == 2
+    assert out["references"][0]["file"] == "src/a.py"
+    assert out["references"][0]["matches"] == []
+    assert out["references"][1]["matches"][0]["match_type"] == "named"
+
+
+def test_find_references_batch_round_trip():
+    resp = {
+        "repo": "acme/app",
+        "results": [
+            {
+                "identifier": "get_user",
+                "reference_count": 2,
+                "references": [
+                    {"file": "src/a.py", "specifier": "models.user", "match_type": "named"},
+                    {"file": "src/b.py", "specifier": "models.user", "match_type": "named"},
+                ],
+            },
+        ],
+        "_meta": {"timing_ms": 2.0},
+    }
+    out = _rt("find_references", resp)
+    assert isinstance(out["results"], list)
+    assert len(out["results"]) == 1
+    assert out["results"][0]["identifier"] == "get_user"
+    assert len(out["results"][0]["references"]) == 2
 
 
 def test_find_importers_round_trip():
     resp = {
         "repo": "acme/app",
-        "file": "src/models/user.py",
+        "file_path": "src/models/user.py",
         "importer_count": 2,
         "importers": [
-            {"file": "src/api/handlers.py", "specifier": "models.user", "line": 4, "column": 0},
-            {"file": "src/api/routes.py", "specifier": "models.user", "line": 6, "column": 0},
+            {"file": "src/api/handlers.py", "specifier": "models.user", "has_importers": True},
+            {"file": "src/api/routes.py", "specifier": "models.user", "has_importers": False},
         ],
-        "_meta": {"timing_ms": 1.2},
+        "_meta": {"timing_ms": 1.2, "truncated": False},
     }
     out = _rt("find_importers", resp)
-    assert out["importer_count"] == "2"  # scalars decode as strings; acceptable
+    assert out["file_path"] == "src/models/user.py"
+    assert isinstance(out["importer_count"], int)
+    assert out["importer_count"] == 2
     assert len(out["importers"]) == 2
     assert out["importers"][0]["file"] == "src/api/handlers.py"
+    assert out["importers"][0]["has_importers"] is True
+
+
+def test_find_importers_batch_round_trip():
+    resp = {
+        "repo": "acme/app",
+        "results": [
+            {
+                "file_path": "src/models/user.py",
+                "importer_count": 1,
+                "importers": [
+                    {"file": "src/api/handlers.py", "specifier": "models.user", "has_importers": True},
+                ],
+            },
+        ],
+        "_meta": {"timing_ms": 0.9},
+    }
+    out = _rt("find_importers", resp)
+    assert isinstance(out["results"], list)
+    assert len(out["results"]) == 1
+    assert out["results"][0]["file_path"] == "src/models/user.py"
+    assert out["results"][0]["importers"][0]["has_importers"] is True
 
 
 def test_get_call_hierarchy_round_trip():
@@ -141,19 +218,22 @@ def test_get_blast_radius_round_trip():
     assert len(out["potential"]) == 1
     assert out["potential"][0]["file"] == "utils.py"
     assert out["symbol"]["name"] == "get_user"
-    assert out["overall_risk_score"] == "0.75"
+    assert isinstance(out["overall_risk_score"], float)
+    assert out["overall_risk_score"] == 0.75
 
 
 def test_get_dependency_cycles_round_trip():
     resp = {
         "repo": "acme/app",
         "cycle_count": 1,
-        "cycles": [{"length": 3, "files": "a.py->b.py->c.py->a.py"}],
+        "cycles": [["a.py", "b->c.py", "c.py"]],
         "_meta": {"timing_ms": 1.0},
     }
     out = _rt("get_dependency_cycles", resp)
     assert len(out["cycles"]) == 1
-    assert out["cycles"][0]["length"] == 3
+    assert isinstance(out["cycle_count"], int)
+    assert out["cycle_count"] == 1
+    assert out["cycles"][0] == ["a.py", "b->c.py", "c.py"]
 
 
 def test_search_text_round_trip():
@@ -345,10 +425,42 @@ def test_get_repo_outline_round_trip():
         "orphan_symbols": 0,
         "orphan_symbol_pct": 0.0,
         "chains": [
-            {"gateway": "api.handler", "gateway_kind": "http", "leaves": "svc.run", "depth": 2, "symbol_path": "api.handler->svc.run"},
-            {"gateway": "api.handler", "gateway_kind": "http", "leaves": "svc.exec", "depth": 2, "symbol_path": "api.handler->svc.exec"},
+            {
+                "gateway": "routes.py::create_user",
+                "gateway_name": "create_user",
+                "kind": "http",
+                "label": "POST /api/users",
+                "depth": 3,
+                "reach": 4,
+                "symbols": ["create_user", "validate", "save", "notify"],
+                "files_touched": ["routes.py", "validators.py", "repo.py", "mailer.py"],
+                "file_count": 4,
+            },
+            {
+                "gateway": "cli.py::seed_db",
+                "gateway_name": "seed_db",
+                "kind": "cli",
+                "label": "cli:seed-db",
+                "depth": 2,
+                "reach": 3,
+                "symbols": ["seed_db", "generate", "insert"],
+                "files_touched": ["cli.py", "factory.py", "repo.py"],
+                "file_count": 3,
+            },
         ],
-        "_meta": {"timing_ms": 5.0, "max_depth": 5},
+        "kind_summary": {"http": 1, "cli": 1},
+        "_meta": {"timing_ms": 5.0, "max_depth": 5, "include_tests": True, "symbols_on_chains": 6, "total_functions_methods": 12},
+    }),
+    ("get_signal_chains", {
+        "repo": "a/b",
+        "symbol": "validate",
+        "symbol_id": "validators.py::validate",
+        "chain_count": 1,
+        "chains": [
+            {"gateway": "routes.py::create_user", "gateway_name": "create_user", "kind": "http", "label": "POST /api/users", "chain_reach": 4, "depth_from_gateway": 1},
+        ],
+        "on_no_chain": False,
+        "_meta": {"timing_ms": 3.0, "max_depth": 5, "include_tests": False, "symbols_on_chains": 1, "total_functions_methods": 8, "total_gateways": 1},
     }),
     ("search_ast", {
         "result_count": 1,
@@ -373,9 +485,10 @@ def test_get_repo_outline_round_trip():
         "repo": "a/b",
         "plate_count": 1,
         "file_count": 2,
-        "plates": [{"label": "core", "file_count": 2, "representative": "src/core.py"}],
-        "drifter_summary": [],
-        "isolated_files": [],
+        "plates": [{"plate_id": 0, "anchor": "src/core.py", "file_count": 2, "cohesion": 0.82, "majority_directory": "src", "drifter_count": 0, "nexus_alert": False}],
+        "drifter_summary": [{"file": "src/config/loader.py", "current_directory": "src/config", "belongs_with": "src", "plate_anchor": "src/core.py"}],
+        "isolated_files": ["README.md"],
+        "signals_used": ["structural", "behavioral", "temporal"],
         "_meta": {"timing_ms": 3.0, "methodology": "tectonic"},
     }),
 ])
@@ -385,3 +498,121 @@ def test_remaining_tier1_round_trip(tool, resp):
     for table_key in ("affected_symbols", "chains", "results", "context_items", "plates"):
         if table_key in resp:
             assert table_key in out, f"{tool} lost {table_key}"
+
+
+def test_get_signal_chains_lookup_round_trip():
+    resp = {
+        "repo": "a/b",
+        "symbol": "validate",
+        "symbol_id": "validators.py::validate",
+        "chain_count": 1,
+        "chains": [
+            {"gateway": "routes.py::create_user", "gateway_name": "create_user", "kind": "http", "label": "POST /api/users", "chain_reach": 4, "depth_from_gateway": 1},
+        ],
+        "on_no_chain": False,
+        "_meta": {"timing_ms": 3.0, "max_depth": 5, "include_tests": False, "symbols_on_chains": 1, "total_functions_methods": 8, "total_gateways": 1},
+    }
+    out = _rt("get_signal_chains", resp)
+    assert out["symbol"] == "validate"
+    assert out["symbol_id"] == "validators.py::validate"
+    assert out["on_no_chain"] is False
+    assert out["chains"][0]["chain_reach"] == 4
+    assert out["chains"][0]["depth_from_gateway"] == 1
+    assert out["_meta"] == {"timing_ms": 3.0, "total_gateways": 1}
+
+
+def test_get_signal_chains_discovery_meta_shape():
+    resp = {
+        "repo": "a/b",
+        "gateway_count": 1,
+        "chain_count": 2,
+        "orphan_symbols": 0,
+        "orphan_symbol_pct": 0.0,
+        "chains": [
+            {
+                "gateway": "routes.py::create_user",
+                "gateway_name": "create_user",
+                "kind": "http",
+                "label": "POST /api/users",
+                "depth": 3,
+                "reach": 4,
+                "symbols": ["create_user", "validate", "save", "notify"],
+                "files_touched": ["routes.py", "validators.py", "repo.py", "mailer.py"],
+                "file_count": 4,
+            },
+        ],
+        "kind_summary": {"http": 1},
+        "_meta": {"timing_ms": 5.0, "max_depth": 5, "include_tests": True, "symbols_on_chains": 4, "total_functions_methods": 12},
+    }
+    out = _rt("get_signal_chains", resp)
+    assert out["_meta"] == {
+        "timing_ms": 5.0,
+        "max_depth": 5,
+        "include_tests": True,
+        "symbols_on_chains": 4,
+        "total_functions_methods": 12,
+    }
+
+
+def test_get_signal_chains_no_gateway_round_trip():
+    resp = {
+        "repo": "a/b",
+        "gateway_count": 0,
+        "chain_count": 0,
+        "chains": [],
+        "gateway_warning": "No gateways detected.",
+        "_meta": {"timing_ms": 1.0},
+    }
+    out = _rt("get_signal_chains", resp)
+    assert out["gateway_count"] == 0
+    assert out["chain_count"] == 0
+    assert out["gateway_warning"] == "No gateways detected."
+    assert isinstance(out["chains"], list)
+    assert out["chains"] == []
+    assert out["_meta"] == {"timing_ms": 1.0}
+
+
+def test_get_tectonic_map_round_trip_realistic():
+    resp = {
+        "repo": "test/repo",
+        "plate_count": 2,
+        "file_count": 6,
+        "plates": [
+            {
+                "plate_id": 0,
+                "anchor": "src/api/server.py",
+                "file_count": 3,
+                "cohesion": 0.82,
+                "files": ["src/api/server.py", "src/api/routes.py", "src/api/middleware.py"],
+                "majority_directory": "src/api",
+            },
+            {
+                "plate_id": 1,
+                "anchor": "src/db/models.py",
+                "file_count": 3,
+                "cohesion": 0.65,
+                "files": ["src/db/models.py", "src/db/queries.py", "src/config/loader.py"],
+                "majority_directory": "src/db",
+                "drifters": ["src/config/loader.py"],
+                "drifter_count": 1,
+                "nexus_alert": True,
+                "nexus_coupling_count": 4,
+                "coupled_to": {"src/api/server.py": 0.45},
+            },
+        ],
+        "isolated_files": ["README.md"],
+        "signals_used": ["structural", "behavioral", "temporal"],
+        "drifter_summary": [{"file": "src/config/loader.py", "current_directory": "src/config", "belongs_with": "src/db", "plate_anchor": "src/db/models.py"}],
+        "_meta": {"timing_ms": 15.0, "methodology": "tectonic"},
+    }
+    out = _rt("get_tectonic_map", resp)
+    assert len(out["plates"]) == 2
+    assert out["plates"][0]["plate_id"] == 0
+    assert isinstance(out["plates"][0]["cohesion"], float)
+    assert "drifter_count" not in out["plates"][0]
+    assert "nexus_alert" not in out["plates"][0]
+    assert out["plates"][1]["drifter_count"] == 1
+    assert out["plates"][1]["nexus_alert"] is True
+    assert out["drifter_summary"][0]["plate_anchor"] == "src/db/models.py"
+    assert out["isolated_files"] == ["README.md"]
+    assert out["signals_used"] == ["structural", "behavioral", "temporal"]

--- a/tests/encoding/test_tier1_roundtrip.py
+++ b/tests/encoding/test_tier1_roundtrip.py
@@ -117,24 +117,31 @@ def test_get_dependency_graph_round_trip():
 def test_get_blast_radius_round_trip():
     resp = {
         "repo": "acme/app",
-        "symbol": "get_user",
-        "direction": "importers",
+        "symbol": {"id": "s1", "name": "get_user", "kind": "function", "file": "auth.py", "line": 42},
         "depth": 3,
-        "importer_file_count": 2,
-        "affected_symbol_count": 2,
-        "affected_symbols": [
-            {"id": "s1", "name": "handler", "kind": "function", "file": "api.py", "line": 10, "depth": 1},
-            {"id": "s2", "name": "route", "kind": "function", "file": "api.py", "line": 20, "depth": 1},
+        "importer_count": 2,
+        "confirmed_count": 2,
+        "potential_count": 1,
+        "direct_dependents_count": 5,
+        "overall_risk_score": 0.75,
+        "confirmed": [
+            {"file": "api.py", "references": 3, "has_test_reach": True},
+            {"file": "main.py", "references": 1, "has_test_reach": False},
         ],
-        "importer_files": [
-            {"file": "api.py", "depth": 1},
-            {"file": "main.py", "depth": 2},
+        "potential": [
+            {"file": "utils.py", "reason": "wildcard import"},
         ],
         "_meta": {"timing_ms": 3.0},
     }
     out = _rt("get_blast_radius", resp)
-    assert len(out["affected_symbols"]) == 2
-    assert out["affected_symbols"][0]["name"] == "handler"
+    assert len(out["confirmed"]) == 2
+    assert out["confirmed"][0]["file"] == "api.py"
+    assert out["confirmed"][0]["references"] == 3
+    assert out["confirmed"][0]["has_test_reach"] is True
+    assert len(out["potential"]) == 1
+    assert out["potential"][0]["file"] == "utils.py"
+    assert out["symbol"]["name"] == "get_user"
+    assert out["overall_risk_score"] == "0.75"
 
 
 def test_get_dependency_cycles_round_trip():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -114,7 +114,16 @@ class TestConfigDefaults:
         ("max_index_files", 10000),
         ("languages", None),
         ("disabled_tools", ["test_summarizer"]),
-    ], ids=["max_folder_files", "max_index_files", "languages_none", "disabled_tools"])
+        ("server_output", "adaptive"),
+        ("server_output_threshold", 0.15),
+    ], ids=[
+        "max_folder_files",
+        "max_index_files",
+        "languages_none",
+        "disabled_tools",
+        "server_output",
+        "server_output_threshold",
+    ])
     def test_default_values(self, key, expected):
         """Should have correct default values."""
         from src.jcodemunch_mcp.config import DEFAULTS
@@ -125,7 +134,16 @@ class TestConfigDefaults:
         ("summarizer_provider", str),
         ("embed_model", str),
         ("summarizer_model", str),
-    ], ids=["strict_timeout_ms", "summarizer_provider", "embed_model", "summarizer_model"])
+        ("server_output", str),
+        ("server_output_threshold", float),
+    ], ids=[
+        "strict_timeout_ms",
+        "summarizer_provider",
+        "embed_model",
+        "summarizer_model",
+        "server_output",
+        "server_output_threshold",
+    ])
     def test_default_types(self, key, expected_type):
         """Config types should match expected types."""
         from src.jcodemunch_mcp.config import CONFIG_TYPES
@@ -199,6 +217,30 @@ class TestConfigLoading:
 
             assert get("max_folder_files") == 5000
             assert get("use_ai_summaries") is False
+
+    @pytest.mark.parametrize(
+        "configured,expected",
+        [
+            ("adaptive", "adaptive"),
+            ("raw", "raw"),
+            ("encoded", "encoded"),
+            ("auto", "adaptive"),
+            ("json", "raw"),
+            ("compact", "encoded"),
+        ],
+        ids=["adaptive", "raw", "encoded", "alias_auto", "alias_json", "alias_compact"],
+    )
+    def test_server_output_normalizes_aliases(self, configured, expected):
+        """server_output should normalize legacy aliases to user-facing values."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text(f'{{"server_output": "{configured}"}}')
+            load_config(tmpdir)
+            assert get("server_output") == expected
 
     @pytest.mark.parametrize("value,expected", [
         ('null', None),
@@ -442,6 +484,14 @@ class TestTemplateGeneration:
         for tool in _CANONICAL_TOOL_NAMES:
             assert tool in template, f"Tool '{tool}' missing from config template"
 
+    def test_template_documents_server_output_controls(self):
+        """Template should document server_output and threshold keys."""
+        from src.jcodemunch_mcp.config import generate_template
+
+        template = generate_template()
+        assert '"server_output": "adaptive"' in template
+        assert '"server_output_threshold": 0.15' in template
+
 
 class TestGetDescriptions:
     """Test get_descriptions() function."""
@@ -609,6 +659,36 @@ class TestEnvVarFallback:
             assert not any(
                 "JCODEMUNCH_TRUSTED_FOLDERS" in rec.message for rec in caplog.records
             )
+
+    @pytest.mark.parametrize(
+        "env_key,env_value,expected_key,expected_value",
+        [
+            ("JCODEMUNCH_DEFAULT_FORMAT", "compact", "server_output", "encoded"),
+            ("JCODEMUNCH_ENCODING_THRESHOLD", "0.25", "server_output_threshold", 0.25),
+        ],
+        ids=["default_format_alias", "encoding_threshold"],
+    )
+    def test_legacy_encoding_env_vars_fallback(
+        self, monkeypatch, caplog, env_key, env_value, expected_key, expected_value
+    ):
+        """Legacy encoding env vars should map through config fallback."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG, _DEPRECATED_ENV_VARS_LOGGED
+        import logging
+
+        _GLOBAL_CONFIG.clear()
+        _DEPRECATED_ENV_VARS_LOGGED.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text("{}")
+
+            monkeypatch.setenv(env_key, env_value)
+
+            with caplog.at_level(logging.WARNING):
+                load_config(tmpdir)
+
+            assert get(expected_key) == expected_value
+            assert any(env_key in rec.message for rec in caplog.records)
 
 
 class TestTrustedFoldersConfig:
@@ -1470,7 +1550,17 @@ class TestConfigTypeValidation:
         ("disabled_tools", '{"tool": "name"}', ["test_summarizer"]),  # Object instead of list
         ("extra_extensions", '[".lua"]', {}),     # List instead of dict
         ("meta_fields", '{"invalid": "dict"}', []),  # Dict instead of list
-    ], ids=["bool_string", "int_float", "list_object", "dict_list", "meta_fields_dict"])
+        ("server_output", '"banana"', "adaptive"),
+        ("server_output_threshold", '-0.25', 0.15),
+    ], ids=[
+        "bool_string",
+        "int_float",
+        "list_object",
+        "dict_list",
+        "meta_fields_dict",
+        "server_output_invalid",
+        "server_output_threshold_negative",
+    ])
     def test_type_mismatch_uses_default(self, key, bad_value, expected_default):
         """Type mismatch should fall back to default."""
         from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
@@ -1645,18 +1735,25 @@ class TestAllConfigKeys:
     """Test that all config keys can be loaded correctly."""
 
     @pytest.mark.parametrize("key", [
-        "transport", "host", "freshness_mode", "log_level"
-    ], ids=["string_transport", "string_host", "string_freshness_mode", "string_log_level"])
+        "transport", "host", "freshness_mode", "log_level", "server_output"
+    ], ids=[
+        "string_transport",
+        "string_host",
+        "string_freshness_mode",
+        "string_log_level",
+        "string_server_output",
+    ])
     def test_all_string_keys(self, key):
         """Test all string-typed config keys."""
         from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
 
         _GLOBAL_CONFIG.clear()
         with tempfile.TemporaryDirectory() as tmpdir:
+            value = "raw" if key == "server_output" else "test_value"
             config_path = Path(tmpdir) / "config.jsonc"
-            config_path.write_text(f'{{"{key}": "test_value"}}')
+            config_path.write_text(f'{{"{key}": "{value}"}}')
             load_config(tmpdir)
-            assert get(key) == "test_value", f"Key {key} failed"
+            assert get(key) == value, f"Key {key} failed"
 
     @pytest.mark.parametrize("key", [
         "max_folder_files", "max_index_files", "staleness_days",
@@ -1748,6 +1845,21 @@ class TestAllConfigKeys:
             config_path.write_text(f'{{"{key}": {{"nested": "value"}}}}')
             load_config(tmpdir)
             assert get(key) == {"nested": "value"}, f"Key {key} failed"
+
+    @pytest.mark.parametrize("key,value", [
+        ("claude_poll_interval", 1.25),
+        ("server_output_threshold", 0.2),
+    ], ids=["float_claude_poll_interval", "float_server_output_threshold"])
+    def test_all_float_keys(self, key, value):
+        """Test all float-typed config keys."""
+        from src.jcodemunch_mcp.config import load_config, get, _GLOBAL_CONFIG
+
+        _GLOBAL_CONFIG.clear()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.jsonc"
+            config_path.write_text(f'{{"{key}": {value}}}')
+            load_config(tmpdir)
+            assert get(key) == value, f"Key {key} failed"
 
     def test_all_nullable_keys(self):
         """Test all nullable config keys accept null."""


### PR DESCRIPTION
## Summary

Six of the tier-1 custom MUNCH encoders shipped in v1.55.0 were written against assumed response shapes that diverged from actual tool output. This caused silent data loss across multiple tools: empty table rows, wrong column names, dicts serialized as Python repr strings, and all numeric scalars decoded as strings instead of their native types.

This PR fixes all six broken encoders and adds the missing `__stypes` type-preservation infrastructure to `schema_driven.py`, bringing it to parity with what `generic.py` already implemented.

## Why

While using the mcp server I saw errors with 'get_blast_radius' usage. 
`get_blast_radius` returned MUNCH output with `enc=br1` where:
- The `symbol` field was serialized as `"{'name': 'foo', 'kind': 'method', ...}"` (Python `str(dict)`) instead of properly flattened scalars
- Table rows for `affected_symbols` and `importer_files` were declared but always empty
- The pattern reproduced across unrelated symbols in different repos

Investigation revealed the root cause was a schema mismatch between the encoder's declared keys and the actual tool response keys. Auditing all 15 tier-1 encoders found 6 with the same class of bug, plus a foundational gap where `schema_driven.encode()` never wrote `__stypes` type hints, causing all schema-driven encoders to lose numeric/bool types on round-trip.

## What We Did

### Infrastructure: `__stypes` in `schema_driven.py`
- `encode()`: derives type hints from non-string scalar values and writes `__stypes` into the payload (same format as `generic.py`)
- `decode()`: reads `__stypes` from the payload and merges into the coercion map (caller-supplied `scalar_types` takes precedence)
- Backward-compatible: old payloads lacking `__stypes` fall back to string decoding

### Per-Encoder Fixes

| Encoder | Fix | Pattern |
|---------|-----|---------|
| `get_blast_radius` | Moved `symbol` from `_SCALARS` to `_NESTED`, renamed tables `confirmed`/`potential`, fixed scalar names | Schema realignment |
| `find_importers` | Fixed cols to `[file, specifier, has_importers]`, scalar `file` to `file_path`, batch via JSON blob | Schema realignment |
| `find_references` | Added `_flatten()`/`_regroup()` following `search_text.py` pattern for nested `matches[]` | Flatten/regroup transform |
| `get_signal_chains` | Union column set for 3 response modes, `_meta_keys()` dispatch per mode | Multi-mode support |
| `get_tectonic_map` | Fixed plate/drifter cols, moved `isolated_files` to JSON, `_prune_optional_plate_fields()` in decode | Schema realignment + prune |
| `get_dependency_cycles` | Transform `list[list[str]]` to `{length, files}` with `\x1f` separator (path-safe) | List-to-dict transform |

### Test Coverage
- All fixtures re-anchored to actual tool response shapes (cross-referenced against `test_render_diagram.py` realistic fixtures)
- Added: batch round-trip tests, empty-matches edge case, all 3 signal-chain modes, realistic multi-plate tectonic map
- Type assertions validate `__stypes` end-to-end (float, int, bool survive round-trip)
- 48 encoding tests pass

## Before and After

### `get_blast_radius`

| Aspect | Before (br1) | After (br2) |
|--------|-------------|-------------|
| `symbol` field | `"{'name': 'foo', 'kind': 'method', ...}"` (Python repr) | `symbol.name=foo symbol.kind=method symbol.file=x.py ...` |
| Confirmed files table | Declared as `affected_symbols` — **always empty** (key doesn't exist in response) | `confirmed` table with `file\|references\|has_test_reach` rows |
| Potential files table | Declared as `importer_files` — **always empty** | `potential` table with `file\|reason` rows |
| Scalars | `direction`, `importer_file_count`, `affected_symbol_count` (none exist) | `importer_count`, `confirmed_count`, `potential_count`, `overall_risk_score` |

### `find_importers`

| Aspect | Before (fi1) | After (fi2) |
|--------|-------------|-------------|
| Table columns | `file, specifier, line, column` (`line`/`column` don't exist) | `file, specifier, has_importers` |
| Scalar key | `file` (wrong — tool returns `file_path`) | `file_path` |
| Batch mode | Stale `results` table with wrong cols | Preserved via JSON blob |

### `find_references`

| Aspect | Before (fr1) | After (fr2) |
|--------|-------------|-------------|
| Table structure | Flat cols `file, line, column, specifier, kind` — none match actual nested response | Flatten/regroup: `references[].matches[]` exploded to flat `(file, specifier, match_type)` rows, regrouped on decode |
| Empty matches | N/A (table was wrong anyway) | Files with `matches: []` preserved via `__empty_groups__` JSON blob |
| Batch mode | Stale `results` table | Preserved via JSON blob |

### `get_signal_chains`

| Aspect | Before (sc1) | After (sc2) |
|--------|-------------|-------------|
| Column names | `gateway_kind, leaves, symbol_path` (none exist) | `gateway_name, kind, label, reach, file_count, chain_reach, depth_from_gateway` |
| Response modes | Discovery only (missing lookup + no-gateway scalars) | All 3 modes: discovery, lookup, no-gateway |
| `_meta` keys | Single union (discovery keys leaked into lookup output) | `_meta_keys()` dispatch: each mode encodes only its own metadata |
| Scalars | Missing `symbol, symbol_id, on_no_chain, gateway_warning` | All mode-specific scalars declared |

### `get_tectonic_map`

| Aspect | Before (tm1) | After (tm2) |
|--------|-------------|-------------|
| Plate columns | `label, file_count, representative` (wrong names) | `plate_id, anchor, file_count, cohesion, majority_directory, drifter_count, nexus_alert` |
| Drifter summary | `file, score, nearest_plate` (wrong names) | `file, current_directory, belongs_with, plate_anchor` |
| `isolated_files` | Declared as dict table (it's `list[str]`) — **always empty** | Moved to `_JSON` |
| Optional fields | `drifter_count: None` / `nexus_alert: None` on plates without drifters | Pruned in decode — absent keys instead of `None` |

### `get_dependency_cycles`

| Aspect | Before (dc1) | After (dc2) |
|--------|-------------|-------------|
| Cycle data | `list[list[str]]` silently skipped by `isinstance(row, dict)` guard — **always empty** | Transformed to `{length, files}` on encode, split back to `list[str]` on decode |
| Separator | N/A | `\x1f` (ASCII unit separator) — safe for paths containing `->` |

### Scalar Type Preservation (`__stypes`)

| Aspect | Before | After |
|--------|--------|-------|
| `overall_risk_score: 0.75` | Decoded as `"0.75"` (string) | Decoded as `0.75` (float) |
| `importer_count: 5` | Decoded as `"5"` (string) | Decoded as `5` (int) |
| `has_test_reach: true` | Decoded as `"T"` or `"true"` (string) | Decoded as `True` (bool) |
| `truncated: false` | Decoded as `"F"` or `"false"` (string) | Decoded as `False` (bool) |

---

## Commit 3: Repo-Aware Server Output Policy (`7803a8d`)

### What

Expose MUNCH encoding behavior through `config.jsonc` with user-facing mode names (`raw`, `encoded`, `adaptive`) while keeping the internal/legacy aliases (`json`, `compact`, `auto`) backward-compatible. Make encoding decisions repo-aware: project config can override the global output mode and savings threshold per-repo.

### Why

Some LLM models may not ingest well the encoded tool output so at least we have a turn-off button

### Config Surface

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| `server_output` | `str` | `"adaptive"` | Output mode: `raw` (always JSON), `encoded` (always MUNCH), `adaptive` (encode when savings clear threshold) |
| `server_output_threshold` | `float` | `0.15` | Minimum savings ratio for adaptive mode to emit MUNCH (e.g. 0.15 = 15% smaller) |

Legacy env vars `JCODEMUNCH_DEFAULT_FORMAT` and `JCODEMUNCH_ENCODING_THRESHOLD` map through the config fallback pipeline with deprecation warnings.

### Alias Mapping

| User-facing | Legacy | Internal |
|-------------|--------|----------|
| `adaptive` | `auto` | `auto` |
| `encoded` | `compact` | `compact` |
| `raw` | `json` | `json` |

Normalization happens at two layers:
- **config.py** (`_normalize_server_output`): canonicalizes to user-facing names (`adaptive`/`encoded`/`raw`) at load time
- **encoding/__init__.py** (`_FORMAT_ALIASES`): maps both user-facing and legacy names to internal format names (`auto`/`compact`/`json`) at encode time

### Repo-Aware Threading

- `server.py:call_tool()` passes `repo=repo_arg` to `encode_response()`
- `encode_response()` passes `repo` to `default_format()` and `gate.passes()`
- `default_format(repo)` reads `server_output` from project config (falling back to global)
- `gate.threshold(repo)` reads `server_output_threshold` from project config (falling back to global)
- Explicit per-call `requested_format` still takes precedence over config

### Validation

- `server_output`: must be a recognized alias (rejects unknown strings like `"banana"`)
- `server_output_threshold`: must be a number in `[0.0, 1.0]` (rejects negatives)
- Both fall back to defaults on invalid input

### Files Changed

| File | Changes |
|------|---------|
| `config.py` | `_SERVER_OUTPUT_ALIASES`, `_normalize_server_output()`, DEFAULTS/CONFIG_TYPES entries, type validation, env var mapping, template commentary |
| `encoding/__init__.py` | `_FORMAT_ALIASES`, `_normalize_format()`, `default_format(repo)`, `encode_response(repo)` |
| `encoding/gate.py` | `threshold(repo)`, `passes(repo)` |
| `server.py` | Thread `repo=repo_arg` into `encode_response()` call |

### Test Coverage (207 new lines)

| Test file | Tests added |
|-----------|-------------|
| `test_dispatcher.py` | Format alias support, config-driven default, project-over-global output mode, project-over-global threshold |
| `test_config.py` | Default values/types, alias normalization (6 aliases), template documentation, legacy env var fallback, type validation rejection, string/float key round-trips |