### PR TITLE
Add generic tsconfig discovery walker with extends-chain support

### DIFF
--- a/src/jcodemunch_mcp/parser/imports.py
+++ b/src/jcodemunch_mcp/parser/imports.py
@@ -700,6 +700,12 @@ def _clear_python_roots_cache() -> None:
 _alias_map_cache: dict[str, dict[str, list[str]]] = {}
 _ALIAS_MAP_LOCK = threading.Lock()
 
+# Directories to skip when walking for tsconfig files.
+_TSCONFIG_SKIP_DIRS = frozenset({
+    "node_modules", ".git", "dist", "build", "out", ".cache",
+    ".next", ".nuxt", ".svelte-kit",
+})
+
 
 def _norm_alias_replacement(rep: str, tsconfig_dir_rel: str = "") -> str:
     """Normalize one tsconfig paths replacement to a repo-root-relative prefix.
@@ -777,6 +783,70 @@ def _load_tsconfig_aliases(source_root: str) -> dict[str, list[str]]:
     if svelte_cfg.is_file():
         data = _load_json(svelte_cfg)
         _ingest(data.get("compilerOptions", {}).get("paths", {}), tsconfig_dir_rel=".svelte-kit")
+
+    # Generic discovery: walk all tsconfig*.json / jsconfig*.json files in the
+    # repo tree (depth ≤ 4, skipping build/dependency dirs), following each
+    # file's `extends` chain.  This covers any workspace layout — apps/, libs/,
+    # services/, Nx/Turborepo — and repos that centralise aliases in a shared
+    # tsconfig.base.json or tsconfig.paths.json at any level.
+    seen_cfg: set[Path] = {
+        root / "tsconfig.json",
+        root / "jsconfig.json",
+        root / ".svelte-kit" / "tsconfig.json",
+    }
+
+    def _ingest_tsconfig_file(cfg_path: Path) -> None:
+        if cfg_path in seen_cfg:
+            return
+        seen_cfg.add(cfg_path)
+        if not cfg_path.is_file():
+            return
+        data = _load_json(cfg_path)
+        try:
+            cfg_dir_rel = cfg_path.parent.relative_to(root).as_posix()
+            if cfg_dir_rel == ".":
+                cfg_dir_rel = ""
+        except ValueError:
+            return  # outside repo root
+        paths = data.get("compilerOptions", {}).get("paths", {})
+        if paths:
+            _ingest(paths, tsconfig_dir_rel=cfg_dir_rel)
+        # Follow extends chain — handles tsconfig.base.json / tsconfig.paths.json pattern.
+        # TypeScript 5+ allows extends to be an array; normalise to list.
+        extends_val = data.get("extends")
+        if not extends_val:
+            return
+        if isinstance(extends_val, str):
+            extends_val = [extends_val]
+        for ref in extends_val:
+            if not isinstance(ref, str):
+                continue
+            ref_path = ref if ref.endswith(".json") else ref + ".json"
+            extended = (cfg_path.parent / ref_path).resolve()
+            try:
+                extended.relative_to(root)  # must stay inside the repo
+            except ValueError:
+                continue  # skip package references like "@tsconfig/recommended"
+            _ingest_tsconfig_file(extended)
+
+    def _walk_tsconfigs(directory: Path, depth: int) -> None:
+        if depth > 4:
+            return
+        try:
+            for entry in sorted(directory.iterdir()):
+                if entry.is_dir():
+                    if entry.name not in _TSCONFIG_SKIP_DIRS and not entry.name.startswith("."):
+                        _walk_tsconfigs(entry, depth + 1)
+                elif (
+                    entry.is_file()
+                    and entry.suffix == ".json"
+                    and (entry.name.startswith("tsconfig") or entry.name.startswith("jsconfig"))
+                ):
+                    _ingest_tsconfig_file(entry)
+        except PermissionError:
+            pass
+
+    _walk_tsconfigs(root, 0)
 
     with _ALIAS_MAP_LOCK:
         _alias_map_cache[source_root] = alias_map

--- a/src/jcodemunch_mcp/parser/imports.py
+++ b/src/jcodemunch_mcp/parser/imports.py
@@ -703,7 +703,7 @@ _ALIAS_MAP_LOCK = threading.Lock()
 # Directories to skip when walking for tsconfig files.
 _TSCONFIG_SKIP_DIRS = frozenset({
     "node_modules", ".git", "dist", "build", "out", ".cache",
-    ".next", ".nuxt", ".svelte-kit",
+    ".next", ".nuxt", ".svelte-kit", ".turbo", ".vercel",
 })
 
 
@@ -830,7 +830,8 @@ def _load_tsconfig_aliases(source_root: str) -> dict[str, list[str]]:
             _ingest_tsconfig_file(extended)
 
     def _walk_tsconfigs(directory: Path, depth: int) -> None:
-        if depth > 4:
+        # Depth 5 covers layouts up to apps/x/frontend/packages/bar/tsconfig.json.
+        if depth > 5:
             return
         try:
             for entry in sorted(directory.iterdir()):

--- a/tests/test_find_importers.py
+++ b/tests/test_find_importers.py
@@ -470,6 +470,135 @@ class TestResolveSpecifier:
         assert "app/components/Header.tsx" in files
 
 
+class TestTsconfigWalker:
+    """Tests for the generic tsconfig/jsconfig discovery walker in _load_tsconfig_aliases."""
+
+    def _load(self, tmp_path):
+        from jcodemunch_mcp.parser.imports import _load_tsconfig_aliases, _alias_map_cache
+        _alias_map_cache.pop(str(tmp_path), None)
+        return _load_tsconfig_aliases(str(tmp_path))
+
+    def test_extends_chain_resolves_hidden_base(self, tmp_path):
+        """Aliases from a base config the walker cannot reach directly are found via extends.
+
+        .config/ starts with '.' so the walker skips it entirely.  The alias is
+        ONLY reachable by following the extends pointer from apps/web/tsconfig.json.
+        Without extends-chain following this test fails with KeyError on '@shared/*'.
+        """
+        import json
+        hidden = tmp_path / ".config"
+        hidden.mkdir()
+        (hidden / "tsconfig.base.json").write_text(json.dumps({
+            "compilerOptions": {"paths": {"@shared/*": ["./src/*"]}},
+        }))
+        (tmp_path / "apps" / "web").mkdir(parents=True)
+        (tmp_path / "apps" / "web" / "tsconfig.json").write_text(json.dumps({
+            "extends": "../../.config/tsconfig.base.json",
+        }))
+        result = self._load(tmp_path)
+        assert "@shared/*" in result
+        assert result["@shared/*"] == [".config/src/*"]
+
+    def test_extends_array_ts5_all_entries_followed(self, tmp_path):
+        """Array-form extends (TS 5+): every entry is followed, not just the first.
+
+        Both base configs live in hidden dirs so the walker cannot find them
+        directly.  The test would fail for either missing alias if the array
+        iteration stopped after the first entry.
+        """
+        import json
+        (tmp_path / ".base-a").mkdir()
+        (tmp_path / ".base-a" / "tsconfig.json").write_text(json.dumps({
+            "compilerOptions": {"paths": {"@a/*": ["./src/a/*"]}},
+        }))
+        (tmp_path / ".base-b").mkdir()
+        (tmp_path / ".base-b" / "tsconfig.json").write_text(json.dumps({
+            "compilerOptions": {"paths": {"@b/*": ["./src/b/*"]}},
+        }))
+        (tmp_path / "apps" / "web").mkdir(parents=True)
+        (tmp_path / "apps" / "web" / "tsconfig.json").write_text(json.dumps({
+            "extends": ["../../.base-a/tsconfig.json", "../../.base-b/tsconfig.json"],
+        }))
+        result = self._load(tmp_path)
+        assert "@a/*" in result
+        assert "@b/*" in result
+
+    def test_circular_extends_no_recursion_error(self, tmp_path):
+        """Circular extends chain (A extends B extends A) terminates cleanly.
+
+        Both files are visible to the walker; the seen_cfg deduplication must
+        block the cycle.  Without it Python would hit RecursionError.
+        """
+        import json
+        (tmp_path / "tsconfig.a.json").write_text(json.dumps({
+            "extends": "./tsconfig.b.json",
+            "compilerOptions": {"paths": {"@a/*": ["./src/a/*"]}},
+        }))
+        (tmp_path / "tsconfig.b.json").write_text(json.dumps({
+            "extends": "./tsconfig.a.json",
+            "compilerOptions": {"paths": {"@b/*": ["./src/b/*"]}},
+        }))
+        result = self._load(tmp_path)  # must not raise
+        assert "@a/*" in result
+        assert "@b/*" in result
+
+    def test_out_of_root_extends_blocked(self, tmp_path):
+        """extends pointing at a real file outside the repo root is silently blocked.
+
+        The guard is relative_to(root): if the resolved path escapes tmp_path
+        the alias must NOT appear in the result.  Using a non-existent path
+        would pass for the wrong reason (is_file() → False before the guard).
+        """
+        import json
+        import shutil
+        outside = tmp_path.parent / (tmp_path.name + "_external")
+        outside.mkdir(exist_ok=True)
+        (outside / "tsconfig.json").write_text(json.dumps({
+            "compilerOptions": {"paths": {"@outside/*": ["src/*"]}},
+        }))
+        try:
+            (tmp_path / "apps" / "web").mkdir(parents=True)
+            (tmp_path / "apps" / "web" / "tsconfig.json").write_text(json.dumps({
+                # Absolute path → resolved path is outside tmp_path
+                "extends": str(outside / "tsconfig.json"),
+                "compilerOptions": {"paths": {"@/*": ["./src/*"]}},
+            }))
+            result = self._load(tmp_path)
+            assert "@/*" in result           # own paths still resolved
+            assert "@outside/*" not in result  # out-of-root alias blocked
+        finally:
+            shutil.rmtree(outside, ignore_errors=True)
+
+    def test_precedence_first_alphabetical_wins(self, tmp_path):
+        """When two workspaces define the same alias, the first one found (alphabetical) wins.
+
+        Pins walk order so that a future refactor silently changing resolution
+        order produces a visible test failure instead of a silent behaviour change.
+        mobile/ sorts before web/ so its normalised replacement must win.
+        """
+        import json
+        (tmp_path / "apps" / "mobile").mkdir(parents=True)
+        (tmp_path / "apps" / "mobile" / "tsconfig.json").write_text(json.dumps({
+            "compilerOptions": {"paths": {"@/*": ["./src/*"]}},
+        }))
+        (tmp_path / "apps" / "web").mkdir(parents=True)
+        (tmp_path / "apps" / "web" / "tsconfig.json").write_text(json.dumps({
+            "compilerOptions": {"paths": {"@/*": ["./src/*"]}},
+        }))
+        result = self._load(tmp_path)
+        assert result.get("@/*") == ["apps/mobile/src/*"]
+
+    def test_nx_libs_layout(self, tmp_path):
+        """Nx-style libs/ workspace layout is discovered without any hardcoded globs."""
+        import json
+        (tmp_path / "libs" / "shared" / "ui").mkdir(parents=True)
+        (tmp_path / "libs" / "shared" / "ui" / "tsconfig.json").write_text(json.dumps({
+            "compilerOptions": {"paths": {"@myorg/ui/*": ["./src/*"]}},
+        }))
+        result = self._load(tmp_path)
+        assert result.get("@myorg/ui/*") == ["libs/shared/ui/src/*"]
+
+
 class TestResolveSpecifierPython:
     """Resolve Python module-style absolute imports against detected source roots.
 


### PR DESCRIPTION
## Summary
Adds generic depth-limited tsconfig discovery with `extends`-chain following to `_load_tsconfig_aliases`, so path aliases resolve correctly in any monorepo layout. Previously only the root `tsconfig.json`/`jsconfig.json` and `.svelte-kit/tsconfig.json` were scanned.

## What Changed
- Added `_TSCONFIG_SKIP_DIRS` module-level constant (node_modules, dist, build, .git, .turbo, .vercel, framework caches)
- Added a recursive walker (depth ≤ 5) that finds all `tsconfig*.json` / `jsconfig*.json` files in the repo tree
- Walker follows each file's `extends` chain, picking up aliases from `tsconfig.base.json` / `tsconfig.paths.json` shared configs
- Handles TypeScript 5+ array-form `extends`
- `seen_cfg` set prevents double-ingestion and circular `extends` loops
- Package references like `@tsconfig/recommended` are safely skipped via `relative_to(root)` boundary check

## Why
Without this, any monorepo using path aliases defined in sub-app tsconfigs (or centralised in a root `tsconfig.base.json`) gets empty alias maps. Import graph tools (`get_blast_radius`, `find_importers`, `get_dependency_graph`) then fail to resolve aliased imports, returning incomplete or empty results.

## Test Coverage
6 new tests in `TestTsconfigWalker`:
- **extends chain** — base config in hidden dir (`.config/`), only reachable via extends
- **array extends (TS 5+)** — both entries in hidden dirs, verifies all array elements are followed
- **circular extends** — A→B→A terminates cleanly via `seen_cfg` deduplication
- **out-of-root extends** — real file outside repo root, blocked by `relative_to` guard
- **precedence** — pins first-alphabetical-wins walk order so future refactors are visible
- **Nx libs/ layout** — `libs/shared/ui/tsconfig.json` at depth 3, asserts normalised path value

## Risk Assessment

| Category | Risk | Notes |
|----------|------|-------|
| Backwards Compatibility | Low | First-definition-wins logic unchanged; existing repos gain more aliases, never lose them |

**Overall Risk**: Low