### PR TITLE
fix: restore exact-match identity scoring and v8 SQLite metadata

### DIFF
--- a/src/jcodemunch_mcp/retrieval/signal_fusion.py
+++ b/src/jcodemunch_mcp/retrieval/signal_fusion.py
@@ -186,7 +186,7 @@ def build_identity_channel(
     query_lower = query.lower()
     scored: list[tuple[float, str]] = []
     for sym in symbols:
-        s = _identity_score(sym, query_lower)
+        s = _identity_score(sym, query_lower, raw_query=query_lower)
         if s > 0:
             scored.append((s, sym["id"]))
 

--- a/src/jcodemunch_mcp/storage/sqlite_store.py
+++ b/src/jcodemunch_mcp/storage/sqlite_store.py
@@ -1662,11 +1662,13 @@ class SQLiteIndexStore:
                 try:
                     decorators = json.loads(deco_raw) if deco_raw and deco_raw != "[]" else []
                 except (json.JSONDecodeError, ValueError):
+                    logger.warning("Corrupted decorators JSON for symbol %s", row["name"])
                     decorators = []
                 kw_raw = row["keywords"]
                 try:
                     keywords = json.loads(kw_raw) if kw_raw and kw_raw != "[]" else []
                 except (json.JSONDecodeError, ValueError):
+                    logger.warning("Corrupted keywords JSON for symbol %s", row["name"])
                     keywords = []
                 content_hash = row["content_hash"] or ""
                 ecosystem_context = row["ecosystem_context"] or ""

--- a/src/jcodemunch_mcp/storage/sqlite_store.py
+++ b/src/jcodemunch_mcp/storage/sqlite_store.py
@@ -1646,7 +1646,6 @@ class SQLiteIndexStore:
     def _row_to_symbol_dict(self, row: sqlite3.Row) -> dict:
         """Convert a database row to a symbol dict (matches CodeIndex.symbols format)."""
         call_references: list[str] = []
-        # v5: read directly from columns. Fallback to data JSON for mid-migration rows.
         if row["data"]:
             try:
                 data = json.loads(row["data"])
@@ -1655,15 +1654,30 @@ class SQLiteIndexStore:
                 data = {}
             if isinstance(data, list):
                 # v8: data column contains call_references as JSON array
+                # Read metadata from row columns (not from data, which is an array)
                 call_references = data
-                data = {}
-            # else: legacy v4 row (data is a JSON object)
-            qualified_name = data.get("qualified_name", row["name"])
-            language = data.get("language", "")
-            decorators = data.get("decorators", [])
-            keywords = data.get("keywords", [])
-            content_hash = data.get("content_hash", "")
-            ecosystem_context = data.get("ecosystem_context", "")
+                qualified_name = row["qualified_name"] or row["name"]
+                language = row["language"] or ""
+                deco_raw = row["decorators"]
+                try:
+                    decorators = json.loads(deco_raw) if deco_raw and deco_raw != "[]" else []
+                except (json.JSONDecodeError, ValueError):
+                    decorators = []
+                kw_raw = row["keywords"]
+                try:
+                    keywords = json.loads(kw_raw) if kw_raw and kw_raw != "[]" else []
+                except (json.JSONDecodeError, ValueError):
+                    keywords = []
+                content_hash = row["content_hash"] or ""
+                ecosystem_context = row["ecosystem_context"] or ""
+            else:
+                # legacy v4 row (data is a JSON object)
+                qualified_name = data.get("qualified_name", row["name"])
+                language = data.get("language", "")
+                decorators = data.get("decorators", [])
+                keywords = data.get("keywords", [])
+                content_hash = data.get("content_hash", "")
+                ecosystem_context = data.get("ecosystem_context", "")
         else:
             # v5/v6/v7 row — direct column reads, no JSON parsing
             qualified_name = row["qualified_name"] or row["name"]

--- a/src/jcodemunch_mcp/tools/get_ranked_context.py
+++ b/src/jcodemunch_mcp/tools/get_ranked_context.py
@@ -197,7 +197,7 @@ def get_ranked_context(
         if scope and not fnmatch(sym.get("file", ""), scope):
             continue
 
-        bm25 = _bm25_score(sym, query_terms, idf, avgdl)
+        bm25 = _bm25_score(sym, query_terms, idf, avgdl, raw_query=query)
         if bm25 <= 0 and strategy != "centrality":
             continue
         pr_raw = pagerank.get(sym.get("file", ""), 0.0)
@@ -296,12 +296,7 @@ def get_ranked_context(
         pass
 
     negative_evidence = None
-    # For semantic-only mode, BM25 score can legitimately be 0 even with valid
-    # semantic matches — skip the max_bm25 threshold check to avoid false negatives.
-    _check_bm25_threshold = True  # will be overridden below for semantic_only
-    if strategy == "semantic_only":
-        _check_bm25_threshold = False
-    if not context_items or (_check_bm25_threshold and max_bm25 < _ne_threshold):
+    if not context_items or max_bm25 < _ne_threshold:
         verdict = "no_implementation_found" if not context_items else "low_confidence_matches"
         related_existing = [
             f for f in index.source_files

--- a/src/jcodemunch_mcp/tools/plan_turn.py
+++ b/src/jcodemunch_mcp/tools/plan_turn.py
@@ -95,7 +95,7 @@ def plan_turn(
     hits = 0
 
     for sym in candidates:
-        score = _bm25_score(sym, query_terms, idf, avgdl, centrality)
+        score = _bm25_score(sym, query_terms, idf, avgdl, centrality, raw_query=query)
         if score <= 0:
             continue
         hits += 1

--- a/src/jcodemunch_mcp/tools/search_symbols.py
+++ b/src/jcodemunch_mcp/tools/search_symbols.py
@@ -266,7 +266,7 @@ def _compute_centrality(
     return {f: math.log(1 + c) * _CENTRALITY_WEIGHT for f, c in counts.items()}
 
 
-def _identity_score(sym: dict, query_joined: str) -> float:
+def _identity_score(sym: dict, query_joined: str, raw_query: str = "") -> float:
     """Identity channel: exact or prefix match on symbol name/ID.
 
     Returns a high score for exact matches and a decreasing score for
@@ -279,29 +279,31 @@ def _identity_score(sym: dict, query_joined: str) -> float:
       - ID contains query segment → 20.0
       - No match                  →  0.0
     """
-    if not query_joined:
+    # raw_query takes precedence for exact matching (preserves snake_case/camelCase)
+    match_query = raw_query.lower() if raw_query else query_joined
+    if not match_query:
         return 0.0
     name_lower = sym.get("name", "").lower()
     sym_id_lower = sym.get("id", "").lower()
 
-    # Exact match on name or ID
-    if query_joined == name_lower or query_joined == sym_id_lower:
+    # Exact match on name or ID (prefer raw_query if provided)
+    if match_query == name_lower or match_query == sym_id_lower:
         return 50.0
 
     # Prefix match on name (e.g. query "get_sym" matches "get_symbol_source")
-    if name_lower.startswith(query_joined):
+    if name_lower.startswith(match_query):
         return 30.0
 
     # Qualified ID segment match (e.g. query "storage.indexstore" matches
     # "src/storage/index_store.py::IndexStore")
-    if query_joined in sym_id_lower:
+    if match_query in sym_id_lower:
         return 20.0
 
     return 0.0
 
 
 def _bm25_score(sym: dict, query_terms: list[str], idf: dict[str, float], avgdl: float,
-                centrality: Optional[dict] = None) -> float:
+                centrality: Optional[dict] = None, raw_query: str = "") -> float:
     """BM25 score for a single symbol.
 
     Uses pre-cached _tf and _dl from _sym_tokens() to avoid rebuilding
@@ -313,7 +315,7 @@ def _bm25_score(sym: dict, query_terms: list[str], idf: dict[str, float], avgdl:
 
     # Identity channel: exact/prefix match on symbol name or ID
     query_joined = " ".join(query_terms)
-    score: float = _identity_score(sym, query_joined)
+    score: float = _identity_score(sym, query_joined, raw_query)
 
     K = _BM25_K1 * (1 - _BM25_B + _BM25_B * dl / max(avgdl, 1.0))
     for term in set(query_terms):
@@ -331,7 +333,7 @@ def _bm25_score(sym: dict, query_terms: list[str], idf: dict[str, float], avgdl:
     return score
 
 
-def _bm25_breakdown(sym: dict, query_terms: list[str], idf: dict[str, float], avgdl: float) -> dict:
+def _bm25_breakdown(sym: dict, query_terms: list[str], idf: dict[str, float], avgdl: float, raw_query: str = "") -> dict:
     """Per-field BM25 contribution breakdown (for debug mode).
 
     Uses cached _dl from _sym_tokens() for K computation but re-tokenizes
@@ -362,7 +364,7 @@ def _bm25_breakdown(sym: dict, query_terms: list[str], idf: dict[str, float], av
                 field_score += idf[term] * (tf * (_BM25_K1 + 1)) / (tf + K)
         out[fname] = round(field_score, 3)
     query_joined = " ".join(query_terms)
-    identity = _identity_score(sym, query_joined)
+    identity = _identity_score(sym, query_joined, raw_query)
     out["identity"] = identity
     if identity >= 50.0:
         out["identity_type"] = "exact"
@@ -719,7 +721,7 @@ def search_symbols(
             if decorator and not any(decorator.lower() in d.lower() for d in (sym.get("decorators") or [])):
                 continue
 
-        score = _bm25_score(sym, query_terms, idf, avgdl, centrality)
+        score = _bm25_score(sym, query_terms, idf, avgdl, centrality, raw_query=query)
         if score <= 0:
             continue
 
@@ -760,7 +762,7 @@ def search_symbols(
             entry["decorators"] = decs
         if debug:
             entry["score"] = round(score, 3)
-            entry["score_breakdown"] = _bm25_breakdown(sym, query_terms, idf, avgdl)
+            entry["score_breakdown"] = _bm25_breakdown(sym, query_terms, idf, avgdl, raw_query=query)
 
         # Bounded heap: O(N log K) instead of O(N log N)
         if len(heap) < effective_limit:
@@ -1064,7 +1066,7 @@ def _search_symbols_semantic(
             if decorator and not any(decorator.lower() in d.lower() for d in (sym.get("decorators") or [])):
                 continue
 
-        bm25 = 0.0 if semantic_only else _bm25_score(sym, query_terms, idf, avgdl, centrality)
+        bm25 = 0.0 if semantic_only else _bm25_score(sym, query_terms, idf, avgdl, centrality, raw_query=query)
         if bm25 > max_bm25:
             max_bm25 = bm25
 

--- a/src/jcodemunch_mcp/tools/search_symbols.py
+++ b/src/jcodemunch_mcp/tools/search_symbols.py
@@ -279,24 +279,31 @@ def _identity_score(sym: dict, query_joined: str, raw_query: str = "") -> float:
       - ID contains query segment → 20.0
       - No match                  →  0.0
     """
-    # raw_query takes precedence for exact matching (preserves snake_case/camelCase)
-    match_query = raw_query.lower() if raw_query else query_joined
-    if not match_query:
+    raw_lower = raw_query.lower() if raw_query else ""
+    if not raw_lower and not query_joined:
         return 0.0
     name_lower = sym.get("name", "").lower()
     sym_id_lower = sym.get("id", "").lower()
 
-    # Exact match on name or ID (prefer raw_query if provided)
-    if match_query == name_lower or match_query == sym_id_lower:
+    # Raw query preserves snake_case/camelCase for exact matches.
+    if raw_lower and (raw_lower == name_lower or raw_lower == sym_id_lower):
+        return 50.0
+
+    # Tokenized fallback preserves previous semantics for callers that only have terms.
+    if query_joined == name_lower or query_joined == sym_id_lower:
         return 50.0
 
     # Prefix match on name (e.g. query "get_sym" matches "get_symbol_source")
-    if name_lower.startswith(match_query):
+    if query_joined and name_lower.startswith(query_joined):
+        return 30.0
+    if raw_lower and name_lower.startswith(raw_lower):
         return 30.0
 
     # Qualified ID segment match (e.g. query "storage.indexstore" matches
     # "src/storage/index_store.py::IndexStore")
-    if match_query in sym_id_lower:
+    if query_joined and query_joined in sym_id_lower:
+        return 20.0
+    if raw_lower and raw_lower in sym_id_lower:
         return 20.0
 
     return 0.0

--- a/tests/conftest_helpers.py
+++ b/tests/conftest_helpers.py
@@ -24,6 +24,36 @@ def create_mini_index(tmp_path: Path, filename: str = "test_module.py") -> tuple
     return result["repo"], sp
 
 
+def create_exact_match_index(tmp_path: Path, filename: str = "ui_builder.py") -> tuple[str, str]:
+    """Create an indexed repo with exact snake_case/camelCase method names.
+
+    The methods intentionally contain call references so the SQLite loader must
+    reconstruct v8 array-style ``data`` rows before search tools apply the
+    ``language='python'`` filter.
+    """
+    from jcodemunch_mcp.tools.index_folder import index_folder
+
+    _write(tmp_path / filename, (
+        "class UiBuilder:\n"
+        "    def helper(self):\n"
+        "        return 1\n\n"
+        "    def _build_left_pane_cache(self):\n"
+        "        self.helper()\n"
+        "        return {}\n\n"
+        "    def renderRow(self):\n"
+        "        self.helper()\n"
+        "        return 1\n\n"
+        "    def set_ui(self):\n"
+        "        return None\n\n"
+        "    def build_ui(self):\n"
+        "        self.helper()\n"
+        "        return self.set_ui()\n"
+    ))
+    sp = str(tmp_path / "idx")
+    result = index_folder(path=str(tmp_path), use_ai_summaries=False, storage_path=sp)
+    return result["repo"], sp
+
+
 def get_index(repo: str, storage_path: str):
     """Load the CodeIndex for a test repo."""
     from jcodemunch_mcp.storage.sqlite_store import SQLiteIndexStore

--- a/tests/test_bm25_correctness.py
+++ b/tests/test_bm25_correctness.py
@@ -191,6 +191,14 @@ class TestIdentityChannel:
         sym = {"name": "ProcessData", "id": "src/utils.py::ProcessData"}
         assert _identity_score(sym, "processdata") == 50.0
 
+    def test_raw_query_exact_snake_case_match(self):
+        sym = {"name": "build_ui", "id": "src/ui.py::build_ui"}
+        assert _identity_score(sym, "build ui", raw_query="build_ui") == 50.0
+
+    def test_raw_query_exact_camel_case_match(self):
+        sym = {"name": "ProcessData", "id": "src/utils.py::ProcessData"}
+        assert _identity_score(sym, "process data", raw_query="ProcessData") == 50.0
+
     def test_exact_beats_prefix(self):
         """Exact match (50) must score higher than prefix match (30)."""
         sym = {"name": "get_symbol", "id": "src/tools.py::get_symbol"}
@@ -236,6 +244,20 @@ class TestIdentityChannel:
         breakdown = _bm25_breakdown(sym, ["unrelated"], idf, avgdl)
         assert breakdown["identity"] == 0.0
         assert breakdown["identity_type"] == "none"
+
+    def test_breakdown_uses_raw_query_for_snake_case_exact_match(self):
+        sym = {
+            "name": "_build_left_pane_cache",
+            "signature": "_build_left_pane_cache()",
+            "summary": "",
+            "docstring": "",
+            "keywords": [],
+        }
+        _sym_tokens(sym)
+        idf, avgdl, _ = _compute_bm25([sym])
+        breakdown = _bm25_breakdown(sym, ["build", "left", "pane", "cache"], idf, avgdl, raw_query="_build_left_pane_cache")
+        assert breakdown["identity"] == 50.0
+        assert breakdown["identity_type"] == "exact"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bm25_correctness.py
+++ b/tests/test_bm25_correctness.py
@@ -236,3 +236,65 @@ class TestIdentityChannel:
         breakdown = _bm25_breakdown(sym, ["unrelated"], idf, avgdl)
         assert breakdown["identity"] == 0.0
         assert breakdown["identity_type"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# Identity channel on BM25 path (raw_query regression tests)
+# ---------------------------------------------------------------------------
+
+class TestIdentityChannelBM25Path:
+    """Tests that BM25 path preserves exact snake_case/camelCase matching via raw_query."""
+
+    def _make_sym(self, name: str, summary: str = "") -> dict:
+        return {"name": name, "signature": "", "summary": summary, "docstring": "", "keywords": []}
+
+    def test_bm25_score_exact_snake_case_match(self):
+        """BM25 path should use raw_query for exact snake_case identity match."""
+        from jcodemunch_mcp.tools.search_symbols import _bm25_score, _tokenize
+
+        sym = self._make_sym("_build_left_pane_cache")
+        _sym_tokens(sym)
+        idf, avgdl, _ = _compute_bm25([sym])
+
+        # Tokenize the raw query as the BM25 path would
+        raw_query = "_build_left_pane_cache"
+        query_terms = _tokenize(raw_query)
+        # The bug: _identity_score gets " ".join(query_terms) which loses underscore structure
+        # After fix: _identity_score should also receive raw_query="_build_left_pane_cache"
+        score = _bm25_score(sym, query_terms, idf, avgdl, raw_query=raw_query)
+        # Without raw_query fix, identity score is 0 (no exact match)
+        # With raw_query fix, identity score should be 50 (exact name match)
+        assert score >= 50.0, f"Expected exact identity match (50+), got {score}"
+
+    def test_bm25_score_exact_camel_case_match(self):
+        """BM25 path should use raw_query for exact camelCase identity match."""
+        from jcodemunch_mcp.tools.search_symbols import _bm25_score, _tokenize
+
+        sym = self._make_sym("renderRow")
+        _sym_tokens(sym)
+        idf, avgdl, _ = _compute_bm25([sym])
+
+        raw_query = "renderRow"
+        query_terms = _tokenize(raw_query)
+        score = _bm25_score(sym, query_terms, idf, avgdl, raw_query=raw_query)
+        # After fix: should get exact match bonus
+        assert score >= 50.0, f"Expected exact identity match (50+), got {score}"
+
+    def test_exact_name_beats_partial_in_bm25(self):
+        """Exact name match should score higher than partial match in BM25 path."""
+        from jcodemunch_mcp.tools.search_symbols import _bm25_score, _tokenize
+
+        sym_exact = self._make_sym("build_ui")
+        sym_partial = self._make_sym("set_ui")
+        for sym in [sym_exact, sym_partial]:
+            _sym_tokens(sym)
+        idf, avgdl, _ = _compute_bm25([sym_exact, sym_partial])
+
+        raw_query = "build_ui"
+        query_terms = _tokenize(raw_query)
+        exact_score = _bm25_score(sym_exact, query_terms, idf, avgdl, raw_query=raw_query)
+        partial_score = _bm25_score(sym_partial, query_terms, idf, avgdl, raw_query=raw_query)
+        # After fix: exact match should outrank non-matching
+        assert exact_score > partial_score, (
+            f"Exact 'build_ui' ({exact_score}) should beat 'set_ui' ({partial_score})"
+        )

--- a/tests/test_call_references_model.py
+++ b/tests/test_call_references_model.py
@@ -468,6 +468,58 @@ class TestSQLiteCallReferencesRoundTrip:
             assert result["name"] == "build_pane"
             assert result["call_references"] == ["helper"]
 
+    def test_v8_row_logs_invalid_decorators_and_keywords_json(self, tmp_path, caplog):
+        """v8 rows should log warnings when decorators/keywords JSON is corrupted."""
+        from jcodemunch_mcp.storage.sqlite_store import SQLiteIndexStore
+
+        store = SQLiteIndexStore(base_path=str(tmp_path / "store"))
+        db_path = tmp_path / "test.db"
+        conn = store._connect(db_path)
+
+        conn.execute(
+            "INSERT INTO symbols (id, file, name, kind, signature, summary, docstring, "
+            "line, end_line, byte_offset, byte_length, parent, qualified_name, language, "
+            "decorators, keywords, content_hash, ecosystem_context, data, cyclomatic, "
+            "max_nesting, param_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "src/ui.py::UIContainer.build_pane#method",
+                "src/ui.py",
+                "build_pane",
+                "method",
+                "def build_pane(self)",
+                "",
+                "",
+                10,
+                20,
+                0,
+                100,
+                "UIContainer",
+                "UIContainer.build_pane",
+                "python",
+                "[not valid json",
+                "{not valid json",
+                "",
+                "",
+                '["helper"]',
+                None,
+                None,
+                None,
+            ),
+        )
+        conn.commit()
+
+        rows = conn.execute("SELECT * FROM symbols").fetchall()
+        col_names = [description[0] for description in conn.execute("SELECT * FROM symbols").description]
+
+        with caplog.at_level("WARNING"):
+            row_dict = dict(zip(col_names, rows[0]))
+            result = store._row_to_symbol_dict(row_dict)
+
+        assert result["decorators"] == []
+        assert result["keywords"] == []
+        assert "Corrupted decorators JSON for symbol build_pane" in caplog.text
+        assert "Corrupted keywords JSON for symbol build_pane" in caplog.text
+
     def test_v7_index_loads_with_call_references_defaulting_to_empty(self, tmp_path):
         """Old v7 index (no call_references field) loads with call_references=[]."""
         from jcodemunch_mcp.storage.sqlite_store import SQLiteIndexStore

--- a/tests/test_call_references_model.py
+++ b/tests/test_call_references_model.py
@@ -1,4 +1,4 @@
-"""Tests for Task 1: call_references data model — Symbol field, INDEX_VERSION 8, SQLite storage."""
+"""Tests for Task 1: call_references data model — Symbol field, INDEX_VERSION 9, SQLite storage."""
 
 import json
 import pytest
@@ -56,10 +56,10 @@ class TestCallReferencesSymbolField:
 
 
 class TestIndexVersionBump:
-    """INDEX_VERSION is bumped to 8."""
+    """INDEX_VERSION is bumped to 9."""
 
-    def test_index_version_is_8(self):
-        """INDEX_VERSION constant must be 8 after this change."""
+    def test_index_version_is_9(self):
+        """INDEX_VERSION constant must be 9 after this change."""
         assert INDEX_VERSION == 9
 
 
@@ -360,6 +360,113 @@ class TestSQLiteCallReferencesRoundTrip:
         d = store._symbol_to_dict(sym)
         assert "call_references" in d
         assert d["call_references"] == ["bar"]
+
+    def test_v8_row_preserves_metadata(self, tmp_path):
+        """v8 row (data as JSON array) preserves qualified_name, language, decorators, keywords, content_hash, ecosystem_context from row columns."""
+        from jcodemunch_mcp.storage.sqlite_store import SQLiteIndexStore
+
+        store = SQLiteIndexStore(base_path=str(tmp_path / "store"))
+        db_path = tmp_path / "test.db"
+        conn = store._connect(db_path)
+
+        # Insert a raw v8 row: data column is a JSON array (call_references)
+        conn.execute(
+            "INSERT INTO symbols (id, file, name, kind, signature, summary, docstring, "
+            "line, end_line, byte_offset, byte_length, parent, qualified_name, language, "
+            "decorators, keywords, content_hash, ecosystem_context, data, cyclomatic, "
+            "max_nesting, param_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "src/orders.py::AppToolOrders._build_left_pane_cache#method",
+                "src/orders.py",
+                "_build_left_pane_cache",
+                "method",
+                "def _build_left_pane_cache(self, request)",
+                "Builds the left pane cache.",
+                "",
+                50,
+                75,
+                100,
+                500,
+                "AppToolOrders",
+                "AppToolOrders._build_left_pane_cache",
+                "python",
+                '["@cache", "@logged"]',
+                '["cache", "pane"]',
+                "abc123def456",
+                '{"cache": "redis"}',
+                '["_render_row", "helper"]',  # v8: data is JSON array of call_references
+                None,
+                None,
+                None,
+            ),
+        )
+        conn.commit()
+
+        rows = conn.execute("SELECT * FROM symbols").fetchall()
+        col_names = [description[0] for description in conn.execute("SELECT * FROM symbols").description]
+        for row in rows:
+            row_dict = dict(zip(col_names, row))
+            result = store._row_to_symbol_dict(row_dict)
+            # These fields must come from row columns, NOT from data JSON (which is an array)
+            assert result["qualified_name"] == "AppToolOrders._build_left_pane_cache", f"qualified_name mismatch: {result['qualified_name']}"
+            assert result["language"] == "python", f"language mismatch: {result['language']}"
+            assert result["decorators"] == ["@cache", "@logged"], f"decorators mismatch: {result['decorators']}"
+            assert result["keywords"] == ["cache", "pane"], f"keywords mismatch: {result['keywords']}"
+            assert result["content_hash"] == "abc123def456", f"content_hash mismatch: {result['content_hash']}"
+            assert result["ecosystem_context"] == '{"cache": "redis"}', f"ecosystem_context mismatch: {result['ecosystem_context']}"
+            # call_references must be deserialized from the data array
+            assert result["call_references"] == ["_render_row", "helper"], f"call_references mismatch: {result['call_references']}"
+
+    def test_v8_row_qualified_name_from_row_not_name(self, tmp_path):
+        """When data is a JSON array, qualified_name must come from row['qualified_name'], not row['name']."""
+        from jcodemunch_mcp.storage.sqlite_store import SQLiteIndexStore
+
+        store = SQLiteIndexStore(base_path=str(tmp_path / "store"))
+        db_path = tmp_path / "test.db"
+        conn = store._connect(db_path)
+
+        # Insert a v8 row where name differs from qualified_name
+        conn.execute(
+            "INSERT INTO symbols (id, file, name, kind, signature, summary, docstring, "
+            "line, end_line, byte_offset, byte_length, parent, qualified_name, language, "
+            "decorators, keywords, content_hash, ecosystem_context, data, cyclomatic, "
+            "max_nesting, param_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "src/ui.py::UIContainer.build_pane#method",
+                "src/ui.py",
+                "build_pane",  # short name
+                "method",
+                "def build_pane(self)",
+                "",
+                "",
+                10,
+                20,
+                0,
+                100,
+                "UIContainer",
+                "UIContainer.build_pane",  # fully qualified name
+                "python",
+                "[]",
+                "[]",
+                "",
+                "",
+                '["helper"]',  # v8: call_references in data array
+                None,
+                None,
+                None,
+            ),
+        )
+        conn.commit()
+
+        rows = conn.execute("SELECT * FROM symbols").fetchall()
+        col_names = [description[0] for description in conn.execute("SELECT * FROM symbols").description]
+        for row in rows:
+            row_dict = dict(zip(col_names, row))
+            result = store._row_to_symbol_dict(row_dict)
+            # qualified_name must be the full path, not just "build_pane"
+            assert result["qualified_name"] == "UIContainer.build_pane", f"qualified_name should be 'UIContainer.build_pane', got: {result['qualified_name']}"
+            assert result["name"] == "build_pane"
+            assert result["call_references"] == ["helper"]
 
     def test_v7_index_loads_with_call_references_defaulting_to_empty(self, tmp_path):
         """Old v7 index (no call_references field) loads with call_references=[]."""

--- a/tests/test_plan_turn.py
+++ b/tests/test_plan_turn.py
@@ -198,6 +198,20 @@ class TestPlanTurn:
         result = plan_turn(repo=repo, query="zzz_totally_fake_query", storage_path=storage_path)
         assert result["confidence"] in ("none", "low")
 
+    def test_exact_camel_case_query_ranks_matching_symbol_first(self, tmp_path: Path):
+        """Exact camelCase queries should surface the matching method first."""
+        from jcodemunch_mcp.storage.sqlite_store import _cache_clear
+        from jcodemunch_mcp.tools.plan_turn import plan_turn
+        from tests.conftest_helpers import create_exact_match_index
+
+        repo, storage_path = create_exact_match_index(tmp_path)
+        _cache_clear()
+
+        result = plan_turn(repo=repo, query="renderRow", storage_path=storage_path)
+
+        assert result["recommended_symbols"]
+        assert result["recommended_symbols"][0]["name"] == "renderRow"
+
 
 class TestPlanTurnActionField:
     """Tests for action field in plan_turn on low/none confidence."""

--- a/tests/test_search_symbols_defaults.py
+++ b/tests/test_search_symbols_defaults.py
@@ -208,3 +208,28 @@ def test_search_symbols_cache_key_distinguishes_auto_from_explicit_compact(tmp_p
     ids_1 = [e["id"] for e in r1["results"]]
     ids_2 = [e["id"] for e in r2["results"]]
     assert ids_1 == ids_2
+
+
+def test_search_symbols_exact_snake_case_survives_sqlite_reload_with_language_filter(tmp_path):
+    """Exact snake_case method search should survive v8 SQLite reload + language filtering."""
+    from jcodemunch_mcp.storage.sqlite_store import _cache_clear
+    from tests.conftest_helpers import create_exact_match_index
+
+    repo, storage = create_exact_match_index(tmp_path)
+    _cache_clear()  # force row-based reload instead of pre-warmed in-memory index
+
+    result = search_symbols(
+        repo=repo,
+        query="_build_left_pane_cache",
+        kind="method",
+        language="python",
+        file_pattern="*.py",
+        detail_level="standard",
+        debug=True,
+        storage_path=storage,
+    )
+
+    assert result.get("result_count", 0) > 0
+    first = result["results"][0]
+    assert first["name"] == "_build_left_pane_cache"
+    assert first["score_breakdown"]["identity"] == 50.0

--- a/tests/test_token_budget_context.py
+++ b/tests/test_token_budget_context.py
@@ -253,6 +253,20 @@ class TestGetRankedContext:
         assert "timing_ms" in meta
         assert "tokens_saved" in meta
 
+    def test_exact_snake_case_query_ranks_matching_symbol_first(self, tmp_path):
+        """Exact snake_case queries should rank the matching method first on BM25 path."""
+        from jcodemunch_mcp.storage.sqlite_store import _cache_clear
+        from tests.conftest_helpers import create_exact_match_index
+
+        repo, storage = create_exact_match_index(tmp_path)
+        _cache_clear()
+
+        result = get_ranked_context(repo, query="build_ui", strategy="bm25", storage_path=storage)
+
+        assert "error" not in result
+        assert result["context_items"]
+        assert result["context_items"][0]["symbol_id"].endswith("UiBuilder.build_ui#method")
+
 
 # ---------------------------------------------------------------------------
 # Diversity-aware budget packing


### PR DESCRIPTION
## Summary

- **Identity score channel was dead** for all snake_case and camelCase queries on the main BM25 path — exact name matches got zero identity bonus (should be 50 points)
- **v8 SQLite rows lost metadata** (language, decorators, keywords) on reload — symbols silently dropped by kind/language filters
- Both bugs combined produced false negatives in `search_symbols`, `plan_turn`, and `get_ranked_context` across all indexed repos

## Why

I saw the search_symbols fail and after investigation, there were three failures on an indexed Python repo:

1. `search_symbols(query="_build_left_pane_cache", kind="method", language="python")` returned **0 results** — the method exists in source
2. `search_symbols(query="_render_row", kind="method", language="python")` returned **0 results** — same
3. `search_symbols(query="build_ui")` returned `set_ui` instead of `build_ui` — **wrong match**
4. `search_symbols(query="filter_keys_by_page")` worked correctly — **control case**

Investigation revealed two independent bugs that conspired:

**Bug A — Identity score compared tokenized query against raw name:**
`_bm25_score` tokenizes the query (`_build_left_pane_cache` → `["build", "left", "pane", "cache"]`), joins with spaces (`"build left pane cache"`), and passes that to `_identity_score`. The function then compared `"build left pane cache"` against the raw symbol name `"_build_left_pane_cache"` — guaranteed mismatch. Every snake_case and camelCase exact match scored 0 on the identity channel.

**Bug B — v8 `_row_to_symbol_dict` read metadata from an empty dict:**
When the `data` column is a JSON array (v8 call_references format), the old code did `data = {}` then `data.get("language", "")` — always returning empty strings. After SQLite reload, symbols had `language=""`, so a `language="python"` filter silently excluded them.

## What Changed

### `_identity_score` — raw query threading (search_symbols.py:269-302)

Added `raw_query` parameter. Checks raw query first (preserves underscores/case), falls back to tokenized `query_joined` for backward compat. Both prefix and ID-segment checks now test both forms.

### `_bm25_score` / `_bm25_breakdown` — parameter threading (search_symbols.py:305, 336)

Added `raw_query` keyword, forwarded to `_identity_score`.

### All call sites updated

| File | Function | Line |
|------|----------|------|
| `search_symbols.py` | `search_symbols` (main BM25 path) | ~728 |
| `search_symbols.py` | `_search_symbols_semantic` (hybrid path) | ~1073 |
| `search_symbols.py` | debug breakdown in main loop | ~769 |
| `get_ranked_context.py` | `get_ranked_context` | ~200 |
| `plan_turn.py` | `plan_turn` | ~98 |
| `signal_fusion.py` | `build_identity_channel` (consistency) | ~189 |

### `_row_to_symbol_dict` v8 metadata fix (sqlite_store.py:1655-1680)

When `data` is a JSON array, read `language`, `qualified_name`, `decorators`, `keywords`, `content_hash`, `ecosystem_context` from row columns instead of the empty-dict fallback. Added `logger.warning` for corrupted JSON in the v8 path (matching existing v5+ behavior).

### Dead code removal (get_ranked_context.py:296-301)

Removed `semantic_only` strategy guard around negative-evidence threshold. `get_ranked_context` only accepts `"combined"`, `"bm25"`, `"centrality"` — the guard was unreachable.

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| `search_symbols(query="_build_left_pane_cache", kind="method", language="python")` | 0 results (v8 metadata: `language=""` → filtered out) | Correct result, identity score = 50.0 |
| `search_symbols(query="_render_row", kind="method", language="python")` | 0 results (same cause) | Correct result, identity score = 50.0 |
| `search_symbols(query="build_ui")` | Returns `set_ui` (identity bonus = 0 for both; BM25 noise decides) | Returns `build_ui` first (identity = 50.0 vs 0.0 for `set_ui`) |
| `search_symbols(query="ProcessData")` | Identity score = 0 (`"process data" != "processdata"`) | Identity score = 50.0 (raw query `"ProcessData"` matches) |
| `plan_turn(query="renderRow")` | `renderRow` may not rank first (no identity bonus) | `renderRow` ranks first (identity = 50.0) |
| `get_ranked_context(query="build_ui", strategy="bm25")` | `build_ui` may not rank first | `build_ui` ranks first |
| v8 SQLite reload with decorators `["@cache"]` | `decorators = []` (read from `{}`) | `decorators = ["@cache"]` (read from row column) |
| v8 SQLite reload with `language="python"` | `language = ""` (read from `{}`) | `language = "python"` (read from row column) |
| Corrupted decorators/keywords JSON in v8 row | Silent empty fallback | `logger.warning` + empty fallback |

## Test Coverage

| Test | File | What it verifies |
|------|------|------------------|
| `test_raw_query_exact_snake_case_match` | test_bm25_correctness.py | `_identity_score` with `raw_query` on snake_case |
| `test_raw_query_exact_camel_case_match` | test_bm25_correctness.py | `_identity_score` with `raw_query` on camelCase |
| `test_breakdown_uses_raw_query_for_snake_case_exact_match` | test_bm25_correctness.py | `_bm25_breakdown` with `raw_query` shows identity=50.0 |
| `test_bm25_score_exact_snake_case_match` | test_bm25_correctness.py | BM25 integration: `_bm25_score` with `raw_query` scores >= 50 |
| `test_bm25_score_exact_camel_case_match` | test_bm25_correctness.py | BM25 integration: camelCase via `raw_query` |
| `test_exact_name_beats_partial_in_bm25` | test_bm25_correctness.py | `build_ui` outranks `set_ui` with identity bonus |
| `test_search_symbols_exact_snake_case_survives_sqlite_reload_with_language_filter` | test_search_symbols_defaults.py | End-to-end: snake_case + SQLite reload + language filter |
| `test_exact_snake_case_query_ranks_matching_symbol_first` | test_token_budget_context.py | `get_ranked_context` ranks `build_ui` first |
| `test_exact_camel_case_query_ranks_matching_symbol_first` | test_plan_turn.py | `plan_turn` ranks `renderRow` first |
| `test_v8_row_preserves_metadata` | test_call_references_model.py | v8 row columns read correctly for all metadata fields |
| `test_v8_row_qualified_name_from_row_not_name` | test_call_references_model.py | qualified_name comes from row, not fallback to name |
| `test_v8_row_logs_invalid_decorators_and_keywords_json` | test_call_references_model.py | Corrupted JSON produces warning + empty fallback |

---
Co-Authored-By: GPT 5.4 XHIGH <noreply@openai.com>