### PR TITLE
fix: preserve v8 symbol metadata when data JSON is corrupt

### DIFF
--- a/src/jcodemunch_mcp/storage/sqlite_store.py
+++ b/src/jcodemunch_mcp/storage/sqlite_store.py
@@ -1651,6 +1651,7 @@ class SQLiteIndexStore:
                 data = json.loads(row["data"])
             except (json.JSONDecodeError, ValueError):
                 logger.warning("Corrupted JSON in symbol data column for row %s, skipping legacy fields", row["name"])
+                # Keep corrupt v8 rows on the array path so row-backed metadata still loads.
                 data = []
             if isinstance(data, list):
                 # v8: data column contains call_references as JSON array

--- a/src/jcodemunch_mcp/storage/sqlite_store.py
+++ b/src/jcodemunch_mcp/storage/sqlite_store.py
@@ -1651,7 +1651,7 @@ class SQLiteIndexStore:
                 data = json.loads(row["data"])
             except (json.JSONDecodeError, ValueError):
                 logger.warning("Corrupted JSON in symbol data column for row %s, skipping legacy fields", row["name"])
-                data = {}
+                data = []
             if isinstance(data, list):
                 # v8: data column contains call_references as JSON array
                 # Read metadata from row columns (not from data, which is an array)

--- a/tests/test_call_references_model.py
+++ b/tests/test_call_references_model.py
@@ -520,6 +520,62 @@ class TestSQLiteCallReferencesRoundTrip:
         assert "Corrupted decorators JSON for symbol build_pane" in caplog.text
         assert "Corrupted keywords JSON for symbol build_pane" in caplog.text
 
+    def test_v8_row_with_corrupt_data_json_keeps_row_metadata(self, tmp_path, caplog):
+        """Corrupt v8 data JSON should still fall back to row metadata columns."""
+        from jcodemunch_mcp.storage.sqlite_store import SQLiteIndexStore
+
+        store = SQLiteIndexStore(base_path=str(tmp_path / "store"))
+        db_path = tmp_path / "test.db"
+        conn = store._connect(db_path)
+
+        conn.execute(
+            "INSERT INTO symbols (id, file, name, kind, signature, summary, docstring, "
+            "line, end_line, byte_offset, byte_length, parent, qualified_name, language, "
+            "decorators, keywords, content_hash, ecosystem_context, data, cyclomatic, "
+            "max_nesting, param_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "src/ui.py::UIContainer.build_pane#method",
+                "src/ui.py",
+                "build_pane",
+                "method",
+                "def build_pane(self)",
+                "",
+                "",
+                10,
+                20,
+                0,
+                100,
+                "UIContainer",
+                "UIContainer.build_pane",
+                "python",
+                '["@cached"]',
+                '["pane"]',
+                "abc123",
+                '{"ui": "left-pane"}',
+                "{not valid json",
+                None,
+                None,
+                None,
+            ),
+        )
+        conn.commit()
+
+        rows = conn.execute("SELECT * FROM symbols").fetchall()
+        col_names = [description[0] for description in conn.execute("SELECT * FROM symbols").description]
+
+        with caplog.at_level("WARNING"):
+            row_dict = dict(zip(col_names, rows[0]))
+            result = store._row_to_symbol_dict(row_dict)
+
+        assert result["qualified_name"] == "UIContainer.build_pane"
+        assert result["language"] == "python"
+        assert result["decorators"] == ["@cached"]
+        assert result["keywords"] == ["pane"]
+        assert result["content_hash"] == "abc123"
+        assert result["ecosystem_context"] == '{"ui": "left-pane"}'
+        assert result["call_references"] == []
+        assert "Corrupted JSON in symbol data column for row build_pane" in caplog.text
+
     def test_v7_index_loads_with_call_references_defaulting_to_empty(self, tmp_path):
         """Old v7 index (no call_references field) loads with call_references=[]."""
         from jcodemunch_mcp.storage.sqlite_store import SQLiteIndexStore


### PR DESCRIPTION
## Summary
- Preserve row-backed v8 symbol metadata when `symbols.data` contains corrupt JSON.
- Add a regression test covering malformed v8 rows and the expected fallback behavior.

## Why
Malformed v8 `data` payloads were falling back to `{}`, which made the loader treat the row like a legacy dict row and discard metadata that was still present in dedicated columns. That turned a recoverable corruption case into silent data loss for fields the row still had intact.

## What We Did
- Changed the corrupt-JSON fallback in `SQLiteIndexStore._row_to_symbol_dict` from `{}` to `[]` so the loader stays on the v8 array code path.
- Added a regression test that inserts a malformed v8 row and asserts metadata preservation, empty `call_references`, and warning emission.

## Before / After
| Scenario | Before | After |
| --- | --- | --- |
| Corrupt v8 `symbols.data` JSON | Loader fell back to `{}` and was treated like a legacy dict row | Loader falls back to `[]` and is still treated like a v8 row |
| Row-backed metadata (`qualified_name`, `language`, `decorators`, `keywords`, `content_hash`, `ecosystem_context`) | Could be dropped during recovery | Preserved from dedicated columns |
| `call_references` recovery | Recovery followed the wrong row shape | Explicitly defaults to `[]` while keeping the remaining metadata |
| Warning behavior | Warning was emitted, but recovery could still lose metadata | Warning is still emitted and recovery keeps intact metadata |

## Test Plan
- `& ".venv\\Scripts\\python.exe" -m pytest tests/ -v --tb=short --cov=src --cov-report=term-missing`