### PR TITLE
fix(parser): extract Scala 3 abstract defs, vals, vars, and type aliases

### DIFF
--- a/src/jcodemunch_mcp/parser/languages.py
+++ b/src/jcodemunch_mcp/parser/languages.py
@@ -1197,26 +1197,36 @@ SCALA_SPEC = LanguageSpec(
         "object_definition": "class",
         "trait_definition": "type",
         "enum_definition": "type",
+        "type_definition": "type",
         "function_definition": "function",
+        "function_declaration": "function",
+        "val_definition": "constant",
+        "var_definition": "constant",
     },
     name_fields={
         "class_definition": "name",
         "object_definition": "name",
         "trait_definition": "name",
         "enum_definition": "name",
+        "type_definition": "name",
         "function_definition": "name",
+        "function_declaration": "name",
+        "val_definition": "pattern",
+        "var_definition": "pattern",
     },
     param_fields={
         "function_definition": "parameters",
+        "function_declaration": "parameters",
     },
     return_type_fields={
         "function_definition": "return_type",
+        "function_declaration": "return_type",
     },
     docstring_strategy="preceding_comment",
     decorator_node_type="annotation",
-    container_node_types=["class_definition", "object_definition", "trait_definition"],
+    container_node_types=["class_definition", "object_definition", "trait_definition", "enum_definition"],
     constant_patterns=["val_definition", "var_definition"],
-    type_patterns=["trait_definition", "enum_definition"],
+    type_patterns=["trait_definition", "enum_definition", "type_definition"],
 )
 
 

--- a/tests/test_scala_parser.py
+++ b/tests/test_scala_parser.py
@@ -1,0 +1,120 @@
+"""Tests for Scala 3 parsing with significant indentation."""
+
+import pytest
+from jcodemunch_mcp.parser import parse_file, LANGUAGE_REGISTRY
+
+
+SCALA3_SOURCE = '''
+package com.example
+
+import scala.compiletime.uninitialized
+
+/** Feed repository trait. */
+@Repository
+trait FeedRepository extends JpaRepository[Feed, UUID]:
+  /** Find by link. */
+  def findByLink(link: String): Option[Feed]
+  def findByTitle(title: String): List[Feed]
+
+/** Feed service. */
+@Service
+class FeedService(repo: FeedRepository):
+  val batchSize: Int = 100
+  var mutableCount: Int = 0
+
+  def fetchAll(): List[Feed] =
+    repo.findAll().asScala.toList
+
+type MyAlias = List[String]
+
+object Constants:
+  val MaxRetries = 3
+  var Counter: Int = 0
+
+enum Status:
+  case Active, Inactive
+
+  def isActive: Boolean = this == Active
+'''
+
+
+def test_parse_scala3():
+    """Test Scala 3 significant-indentation parsing."""
+    symbols = parse_file(SCALA3_SOURCE, "test.scala", "scala")
+
+    # Trait
+    trait = next((s for s in symbols if s.name == "FeedRepository"), None)
+    assert trait is not None
+    assert trait.kind == "type"
+
+    # Abstract method in trait (function_declaration)
+    abstract = next((s for s in symbols if s.name == "findByLink"), None)
+    assert abstract is not None
+    assert abstract.kind == "method"
+    assert "Option[Feed]" in abstract.signature
+
+    # Second abstract method
+    abstract2 = next((s for s in symbols if s.name == "findByTitle"), None)
+    assert abstract2 is not None
+    assert abstract2.kind == "method"
+
+    # Class
+    cls = next((s for s in symbols if s.name == "FeedService"), None)
+    assert cls is not None
+    assert cls.kind == "class"
+
+    # Concrete method in class (function_definition)
+    concrete = next((s for s in symbols if s.name == "fetchAll"), None)
+    assert concrete is not None
+    assert concrete.kind == "method"
+
+    # val field
+    val_field = next((s for s in symbols if s.name == "batchSize"), None)
+    assert val_field is not None
+    assert val_field.kind == "constant"
+
+    # var field
+    var_field = next((s for s in symbols if s.name == "mutableCount"), None)
+    assert var_field is not None
+    assert var_field.kind == "constant"
+
+    # type alias
+    alias = next((s for s in symbols if s.name == "MyAlias"), None)
+    assert alias is not None
+    assert alias.kind == "type"
+
+    # object
+    obj = next((s for s in symbols if s.name == "Constants"), None)
+    assert obj is not None
+    assert obj.kind == "class"
+
+    # val in object
+    obj_val = next((s for s in symbols if s.name == "MaxRetries"), None)
+    assert obj_val is not None
+    assert obj_val.kind == "constant"
+
+    # var in object
+    obj_var = next((s for s in symbols if s.name == "Counter"), None)
+    assert obj_var is not None
+    assert obj_var.kind == "constant"
+
+    # enum
+    enum_type = next((s for s in symbols if s.name == "Status"), None)
+    assert enum_type is not None
+    assert enum_type.kind == "type"
+
+    # method inside enum
+    enum_method = next((s for s in symbols if s.name == "isActive"), None)
+    assert enum_method is not None
+    assert enum_method.kind == "method"
+
+
+def test_scala_spec_registered():
+    """Verify the Scala language spec is registered."""
+    assert "scala" in LANGUAGE_REGISTRY
+    spec = LANGUAGE_REGISTRY["scala"]
+    assert spec.ts_language == "scala"
+    assert "function_declaration" in spec.symbol_node_types
+    assert "val_definition" in spec.symbol_node_types
+    assert "var_definition" in spec.symbol_node_types
+    assert "type_definition" in spec.symbol_node_types


### PR DESCRIPTION
The Scala extractor only recognized function_definition nodes, missing:
- function_declaration (abstract defs in traits/classes)
- val_definition / var_definition (fields)
- type_definition (type aliases)

tree-sitter-scala names the identifier field 'pattern' for val/var nodes, not 'name'.

Fixes SCALA_SPEC symbol_node_types, name_fields, param_fields, return_type_fields, container_node_types, and type_patterns.

Adds tests/test_scala_parser.py covering Scala 3 significant- indentation syntax: traits, classes, objects, enums, vals, vars, type aliases, and nested methods.

Symbol count on a real Scala 3 + Spring Boot project went from 734 -> 1,475 after this fix.