### PR TITLE
Add text-only Markdown indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to jcodemunch-mcp are documented here.
 
+## Unreleased
+
+### Added
+- Markdown documentation files (`.md`, `.markdown`, `.mdx`) are now indexed
+  as text-only files. They are available to `search_text`, `get_file_content`,
+  `get_file_tree`, and file summaries without emitting heading symbols or
+  affecting code graph analysis.
+
 ## [1.80.1] — 2026-04-26 — Scala 3 parser fix (PR #262)
 
 ### Fixed

--- a/LANGUAGE_SUPPORT.md
+++ b/LANGUAGE_SUPPORT.md
@@ -79,6 +79,7 @@ These languages are fully indexed and searchable via `search_text`. Symbol extra
 
 | Language | Extensions     | Notes                                                              |
 | -------- | -------------- | ------------------------------------------------------------------ |
+| Markdown | `.md`, `.markdown`, `.mdx` | Documentation is indexed for `search_text`, `get_file_content`, `get_file_tree`, and file summaries; headings are not emitted as symbols |
 | TOML     | `.toml`        | Tables indexed; key-as-symbol extractor planned                    |
 
 ---
@@ -186,6 +187,6 @@ JCODEMUNCH_EXTRA_EXTENSIONS=".cgi:perl,.psgi:perl,.mjs:javascript"
 - Comma-separated `.ext:lang` pairs
 - Overrides built-in mappings on collision
 - Unknown languages and malformed entries are skipped with a warning
-- Valid language names: `ada`, `al`, `ansible`, `apex`, `arduino`, `asm`, `autohotkey`, `bash`, `blade`, `c`, `clojure`, `cobol`, `commonlisp`, `cpp`, `csharp`, `css`, `dart`, `dlang`, `ejs`, `elisp`, `elixir`, `erlang`, `fortran`, `fsharp`, `gdscript`, `gleam`, `go`, `graphql`, `groovy`, `haskell`, `hcl`, `java`, `javascript`, `json`, `julia`, `kotlin`, `less`, `lua`, `luau`, `matlab`, `nim`, `nix`, `objc`, `ocaml`, `openapi`, `pascal`, `perl`, `php`, `powershell`, `proto`, `python`, `r`, `razor`, `ruby`, `rust`, `sass`, `scala`, `scss`, `solidity`, `sql`, `styl`, `swift`, `tcl`, `toml`, `tsx`, `typescript`, `verilog`, `verse`, `vhdl`, `vue`, `xml`, `yaml`, `zig`
+- Valid language names: `ada`, `al`, `ansible`, `apex`, `arduino`, `asm`, `autohotkey`, `bash`, `blade`, `c`, `clojure`, `cobol`, `commonlisp`, `cpp`, `csharp`, `css`, `dart`, `dlang`, `ejs`, `elisp`, `elixir`, `erlang`, `fortran`, `fsharp`, `gdscript`, `gleam`, `go`, `graphql`, `groovy`, `haskell`, `hcl`, `java`, `javascript`, `json`, `julia`, `kotlin`, `less`, `lua`, `luau`, `markdown`, `matlab`, `nim`, `nix`, `objc`, `ocaml`, `openapi`, `pascal`, `perl`, `php`, `powershell`, `proto`, `python`, `r`, `razor`, `ruby`, `rust`, `sass`, `scala`, `scss`, `solidity`, `sql`, `styl`, `swift`, `tcl`, `toml`, `tsx`, `typescript`, `verilog`, `verse`, `vhdl`, `vue`, `xml`, `yaml`, `zig`
 
 Set via `.mcp.json` `env` block or any environment mechanism supported by your MCP client.

--- a/src/jcodemunch_mcp/parser/extractor.py
+++ b/src/jcodemunch_mcp/parser/extractor.py
@@ -324,7 +324,7 @@ def parse_file(content: str, filename: str, language: str, source_bytes: Optiona
         symbols = _parse_tcl_symbols(source_bytes, filename)
     elif language == "dlang":
         symbols = _parse_dlang_symbols(source_bytes, filename)
-    elif language in ("sass", "less", "styl"):
+    elif language in ("sass", "less", "styl", "markdown"):
         symbols = []  # No tree-sitter grammar; files indexed for text search only
     elif language == "json":
         symbols = _parse_json_symbols(source_bytes, filename)

--- a/src/jcodemunch_mcp/parser/languages.py
+++ b/src/jcodemunch_mcp/parser/languages.py
@@ -234,6 +234,10 @@ LANGUAGE_EXTENSIONS = {
     ".yml": "yaml",
     # JSON (compound .openapi.json / .swagger.json checked first via LANGUAGE_EXTENSIONS key order)
     ".json": "json",
+    # Markdown docs (indexed for text search; no symbol extraction)
+    ".md": "markdown",
+    ".markdown": "markdown",
+    ".mdx": "markdown",
     # OpenAPI / Swagger (compound extensions; basenames handled in get_language_for_path)
     ".openapi.yaml": "openapi",
     ".openapi.yml": "openapi",
@@ -1377,6 +1381,23 @@ STYL_SPEC = LanguageSpec(
 )
 
 
+# Markdown specification
+# Files are indexed as raw text for search_text, get_file_content, get_file_tree,
+# and file-level summaries. Headings are intentionally not symbols.
+MARKDOWN_SPEC = LanguageSpec(
+    ts_language="markdown",
+    symbol_node_types={},
+    name_fields={},
+    param_fields={},
+    return_type_fields={},
+    docstring_strategy="preceding_comment",
+    decorator_node_type=None,
+    container_node_types=[],
+    constant_patterns=[],
+    type_patterns=[],
+)
+
+
 # TOML specification
 # NOTE: TOML tables are the closest analogue to symbols. Custom extraction
 # deferred. Files are indexed for text search.
@@ -1936,6 +1957,7 @@ LANGUAGE_REGISTRY = {
     "sass": SASS_SPEC,
     "less": LESS_SPEC,
     "styl": STYL_SPEC,
+    "markdown": MARKDOWN_SPEC,
     "toml": TOML_SPEC,
     "groovy": GROOVY_SPEC,
     "objc": OBJC_SPEC,

--- a/src/jcodemunch_mcp/storage/sqlite_store.py
+++ b/src/jcodemunch_mcp/storage/sqlite_store.py
@@ -2002,7 +2002,8 @@ class SQLiteIndexStore:
                 ".sql": "sql", ".xml": "xml", ".html": "html",
                 ".css": "css", ".scss": "scss", ".less": "less",
                 ".json": "json", ".yaml": "yaml", ".yml": "yaml",
-                ".toml": "toml", ".md": "markdown", ".rst": "rst",
+                ".toml": "toml", ".md": "markdown", ".markdown": "markdown",
+                ".mdx": "markdown", ".rst": "rst",
                 ".sh": "bash", ".ps1": "powershell",
             }
             for path in paths:

--- a/tests/test_markdown_language.py
+++ b/tests/test_markdown_language.py
@@ -1,0 +1,87 @@
+"""Tests for Markdown text-only indexing."""
+
+from pathlib import Path
+
+from jcodemunch_mcp.parser.extractor import parse_file
+from jcodemunch_mcp.parser.languages import LANGUAGE_EXTENSIONS, get_language_for_path
+from jcodemunch_mcp.tools.index_folder import discover_local_files, index_folder
+from jcodemunch_mcp.tools.index_repo import discover_source_files
+from jcodemunch_mcp.tools.search_text import search_text
+
+
+def test_markdown_extensions_detected():
+    assert get_language_for_path("README.md") == "markdown"
+    assert get_language_for_path("docs/guide.markdown") == "markdown"
+    assert get_language_for_path("docs/page.mdx") == "markdown"
+    assert LANGUAGE_EXTENSIONS[".md"] == "markdown"
+    assert LANGUAGE_EXTENSIONS[".markdown"] == "markdown"
+    assert LANGUAGE_EXTENSIONS[".mdx"] == "markdown"
+
+
+def test_markdown_parse_file_is_text_only():
+    content = "# Architecture\n\nUse `search_text` for documentation lookup.\n"
+
+    assert parse_file(content, "README.md", "markdown") == []
+
+
+def test_discover_source_files_includes_markdown_docs():
+    tree_entries = [
+        {"path": "src/main.py", "type": "blob", "size": 100},
+        {"path": "README.md", "type": "blob", "size": 100},
+        {"path": "docs/guide.mdx", "type": "blob", "size": 100},
+        {"path": "notes.txt", "type": "blob", "size": 100},
+    ]
+
+    files, _, truncated, total = discover_source_files(tree_entries)
+
+    assert "src/main.py" in files
+    assert "README.md" in files
+    assert "docs/guide.mdx" in files
+    assert "notes.txt" not in files
+    assert truncated is False
+    assert total == 3
+
+
+def test_discover_local_files_includes_markdown_docs(tmp_path):
+    (tmp_path / "README.md").write_text("# Project\n", encoding="utf-8")
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "guide.markdown").write_text("# Guide\n", encoding="utf-8")
+    (docs / "page.mdx").write_text("# Page\n", encoding="utf-8")
+    (tmp_path / "notes.txt").write_text("not indexed by default\n", encoding="utf-8")
+
+    files, warnings, skip_counts = discover_local_files(tmp_path)
+    paths = {Path(f).relative_to(tmp_path).as_posix() for f in files}
+
+    assert warnings == []
+    assert "README.md" in paths
+    assert "docs/guide.markdown" in paths
+    assert "docs/page.mdx" in paths
+    assert "notes.txt" not in paths
+    assert skip_counts["wrong_extension"] == 1
+
+
+def test_indexed_markdown_is_searchable_text(tmp_path):
+    (tmp_path / "README.md").write_text(
+        "# Project\n\nDocumentation lookup should find this sentence.\n",
+        encoding="utf-8",
+    )
+
+    result = index_folder(
+        str(tmp_path),
+        use_ai_summaries=False,
+        storage_path=str(tmp_path / ".index"),
+        context_providers=False,
+    )
+    assert result["success"] is True
+    assert "README.md" in result["files"]
+    assert result["languages"]["markdown"] == 1
+
+    matches = search_text(
+        result["repo"],
+        "Documentation lookup",
+        file_pattern="*.md",
+        storage_path=str(tmp_path / ".index"),
+    )
+    assert matches["result_count"] == 1
+    assert matches["results"][0]["file"] == "README.md"

--- a/tests/test_plan_refactoring.py
+++ b/tests/test_plan_refactoring.py
@@ -1719,7 +1719,7 @@ class TestLanguageCoverage:
         import_langs = set(_IMPORT_PATTERNS.keys())
 
         # Data formats are exempt — they have no import syntax
-        exempt = {"toml", "xml", "json", "yaml", "ansible", "openapi"}
+        exempt = {"toml", "xml", "json", "yaml", "ansible", "openapi", "markdown"}
         expected = registry_langs - exempt
         missing = expected - import_langs
 
@@ -1735,7 +1735,7 @@ class TestLanguageCoverage:
         def_langs = set(_DEF_PATTERNS.keys())
 
         # Data formats are exempt — they have no symbol definitions
-        exempt = {"toml", "xml", "json", "yaml", "ansible", "openapi"}
+        exempt = {"toml", "xml", "json", "yaml", "ansible", "openapi", "markdown"}
         expected = registry_langs - exempt
         missing = expected - def_langs
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -75,7 +75,7 @@ def test_discover_source_files():
     assert "src/engine.cpp" in files
     assert "include/engine.hpp" in files
     assert "node_modules/foo.js" not in files
-    assert "README.md" not in files  # Not a source file
+    assert "README.md" in files  # Markdown docs are indexed for text search
     assert truncated is False
 
 


### PR DESCRIPTION
Fixes #265.

## Concept

This PR treats Markdown documentation as repository context that should be indexed and retrievable, but not as code.

Currently `.md`/`.markdown`/`.mdx` files are filtered out during discovery because they are not registered as supported language extensions. That means docs such as `README.md`, `AGENTS.md`, `CHANGELOG.md`, and project guides are unavailable to existing indexed-file tools, even though jCodeMunch already stores raw file contents and already has `search_text` for non-symbol lookups.

The implementation adds Markdown as a text-only language:

- local and GitHub discovery now accept `.md`, `.markdown`, and `.mdx`;
- Markdown files are stored in the raw file cache with `language = markdown`;
- `search_text`, `get_file_content`, `get_file_tree`, repo outlines, and file summaries can now see documentation;
- `parse_file(..., "markdown")` intentionally returns no symbols;
- Markdown is exempt from refactoring import/definition pattern coverage because it has no code imports or symbol definitions.

This keeps the code graph clean: Markdown docs do not affect call graph, import graph, dead-code detection, impact analysis, or AST search. They simply become searchable indexed text.

## Why text-only first

A heading-as-symbol parser would be a larger behavior change: it would require deciding symbol kinds for sections, section offsets, search ranking implications, and how those pseudo-symbols should interact with code-focused tools. Text-only indexing is the smallest useful change and matches existing text-only behavior for formats that are useful to index but not useful to parse into code symbols.

## Tests

- `PYTHONPATH=src uv run --group dev python -m pytest tests/test_markdown_language.py -q`
- `PYTHONPATH=src uv run --group dev python -m pytest tests/test_markdown_language.py tests/test_tools.py::test_discover_source_files tests/test_plan_refactoring.py::TestLanguageCoverage tests/test_get_file_tree.py::test_get_file_tree_falls_back_to_extension_without_symbol_language tests/test_server.py::test_language_enum_all_languages_when_config_none -q`
- `PYTHONPATH=src uv run --group dev python -m pytest tests/test_languages.py tests/test_json.py tests/test_get_file_tree.py tests/test_tools.py tests/test_plan_refactoring.py::TestLanguageCoverage tests/test_markdown_language.py -q`
- `uv run python -m compileall -q src tests/test_markdown_language.py`
- `PYTHONPATH=src uv run --group dev python -m pytest tests -q` (`3607 passed, 14 skipped`)
- `git diff --check`
- `uvx ruff check tests/test_markdown_language.py`

Note: running ruff against broader pre-existing files still reports unrelated existing lint issues in `extractor.py`, `sqlite_store.py`, `test_plan_refactoring.py`, and `test_tools.py`; this PR does not address those existing lint findings.