### PR TITLE
fix(hooks): WorktreeRemove with worktree_path now actually removes the worktree

### DIFF
--- a/src/jcodemunch_mcp/hook_event.py
+++ b/src/jcodemunch_mcp/hook_event.py
@@ -45,6 +45,26 @@ def _resolve_worktree_path(cwd: str, name: str) -> str:
     return str(Path(cwd) / ".claude" / "worktrees" / name)
 
 
+def _resolve_main_repo(cwd: str) -> str:
+    """Return the main repo root, even when *cwd* is inside a worktree.
+
+    Uses ``git rev-parse --git-common-dir`` to find the shared ``.git``
+    directory, then takes its parent.  Falls back to *cwd* on any error.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "rev-parse", "--path-format=absolute",
+             "--git-common-dir"],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0:
+            git_common = result.stdout.strip()
+            return str(Path(git_common).parent)
+    except Exception:
+        pass
+    return cwd
+
+
 def _append_manifest(event_type: str, resolved: str, manifest_path: Path) -> None:
     """Append a single event line to the JSONL manifest."""
     entry = {
@@ -130,8 +150,11 @@ def handle_hook_event(event_type: str, manifest_path: Path | None = None) -> Non
             sys.exit(1)
 
     elif event_type == "remove":
+        # cwd may be the worktree itself — resolve to the main repo so
+        # git worktree remove doesn't run from inside the tree it's deleting.
+        repo_root = _resolve_main_repo(cwd) if cwd else _resolve_main_repo(resolved)
         result = subprocess.run(
-            ["git", "-C", cwd, "worktree", "remove", resolved, "--force"],
+            ["git", "-C", repo_root, "worktree", "remove", resolved, "--force"],
             capture_output=True,
             text=True,
         )
@@ -142,7 +165,7 @@ def handle_hook_event(event_type: str, manifest_path: Path | None = None) -> Non
         # Clean up the branch created during worktree add.
         branch_name = f"worktree-{name}"
         subprocess.run(
-            ["git", "-C", cwd, "branch", "-D", branch_name],
+            ["git", "-C", repo_root, "branch", "-D", branch_name],
             capture_output=True,
             text=True,
         )

--- a/src/jcodemunch_mcp/hook_event.py
+++ b/src/jcodemunch_mcp/hook_event.py
@@ -67,8 +67,10 @@ def handle_hook_event(event_type: str, manifest_path: Path | None = None) -> Non
     For 'remove': determines path, runs ``git worktree remove``, records
     to manifest.
 
-    When ``worktreePath`` is provided directly (legacy), the caller already
-    owns the worktree — only manifest recording is performed, no git commands.
+    When ``worktreePath`` is provided directly for a 'create' event, the
+    caller already owns the worktree — only manifest recording is performed.
+    For 'remove', the worktree is still torn down even when the path is
+    provided directly.
 
     Called by Claude Code hooks via:
         jcodemunch-mcp hook-event create
@@ -90,23 +92,30 @@ def handle_hook_event(event_type: str, manifest_path: Path | None = None) -> Non
     cwd = payload.get("cwd", "")
     name = payload.get("name", "")
 
-    # Legacy support: accept worktreePath / worktree_path directly.
-    # When provided, the caller already owns the worktree — skip git commands.
+    # Accept worktreePath / worktree_path directly (Claude Code sends this
+    # for WorktreeRemove).  For 'create' the caller already owns the
+    # worktree — just record the manifest.  For 'remove' we still need to
+    # tear down the worktree and branch.
     legacy_path = payload.get("worktreePath") or payload.get("worktree_path")
 
-    if legacy_path:
+    if legacy_path and event_type == "create":
         resolved = str(Path(legacy_path).resolve())
         _append_manifest(event_type, resolved, manifest_path)
         print(resolved, flush=True)
         return
 
-    # Modern path: Claude Code sends {cwd, name}.
-    if not cwd or not name:
+    if legacy_path:
+        # 'remove' with an explicit path — use it directly.
+        resolved = str(Path(legacy_path).resolve())
+        # Derive name from the last path component for branch cleanup.
+        if not name:
+            name = Path(resolved).name
+    elif cwd and name:
+        worktree_path = _resolve_worktree_path(cwd, name)
+        resolved = str(Path(worktree_path).resolve())
+    else:
         print("ERROR: need cwd+name or worktreePath in stdin payload", file=sys.stderr)
         sys.exit(1)
-
-    worktree_path = _resolve_worktree_path(cwd, name)
-    resolved = str(Path(worktree_path).resolve())
 
     if event_type == "create":
         Path(resolved).parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_watch_claude.py
+++ b/tests/test_watch_claude.py
@@ -226,6 +226,36 @@ class TestHookEvent:
         entry = json.loads(manifest.read_text().strip())
         assert entry["path"] == str(Path("/tmp/legacy-wt").resolve())
 
+    def test_remove_with_worktree_path_runs_git(self, tmp_path):
+        """Remove with worktree_path must still run git worktree remove."""
+        manifest = tmp_path / "manifest.jsonl"
+        payload = json.dumps({
+            "cwd": str(tmp_path),
+            "worktree_path": "/tmp/my-worktree",
+        })
+        mock_run = MagicMock(return_value=subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr="",
+        ))
+        with (
+            patch("sys.stdin", StringIO(payload)),
+            patch("jcodemunch_mcp.hook_event.subprocess.run", mock_run),
+        ):
+            handle_hook_event("remove", manifest_path=manifest)
+
+        assert mock_run.call_count == 2
+        # First call: git worktree remove
+        wt_args = mock_run.call_args_list[0][0][0]
+        assert "worktree" in wt_args
+        assert "remove" in wt_args
+        # Second call: git branch -D (name derived from path)
+        br_args = mock_run.call_args_list[1][0][0]
+        assert "branch" in br_args
+        assert "-D" in br_args
+        assert "worktree-my-worktree" in br_args
+        # Manifest records the remove
+        entry = json.loads(manifest.read_text().strip())
+        assert entry["event"] == "remove"
+
     def test_creates_manifest_if_missing(self, tmp_path):
         manifest = tmp_path / "subdir" / "manifest.jsonl"
         payload = json.dumps({

--- a/tests/test_watch_claude.py
+++ b/tests/test_watch_claude.py
@@ -154,6 +154,7 @@ class TestHookEvent:
             patch("sys.stdin", StringIO(payload)),
             patch("jcodemunch_mcp.hook_event.subprocess.run", mock_run),
             patch("jcodemunch_mcp.hook_event._get_worktree_base", return_value=""),
+            patch("jcodemunch_mcp.hook_event._resolve_main_repo", return_value=str(tmp_path)),
         ):
             handle_hook_event("remove", manifest_path=manifest)
 
@@ -183,6 +184,7 @@ class TestHookEvent:
             patch("sys.stdin", StringIO(payload)),
             patch("jcodemunch_mcp.hook_event.subprocess.run", return_value=fail_result),
             patch("jcodemunch_mcp.hook_event._get_worktree_base", return_value=""),
+            patch("jcodemunch_mcp.hook_event._resolve_main_repo", return_value=str(tmp_path)),
         ):
             # Should not raise
             handle_hook_event("remove", manifest_path=manifest)
@@ -226,6 +228,31 @@ class TestHookEvent:
         entry = json.loads(manifest.read_text().strip())
         assert entry["path"] == str(Path("/tmp/legacy-wt").resolve())
 
+    def test_remove_resolves_main_repo(self, tmp_path):
+        """Remove should run git commands from the main repo, not the worktree."""
+        manifest = tmp_path / "manifest.jsonl"
+        wt_path = tmp_path / ".claude" / "worktrees" / "my-wt"
+        main_repo = tmp_path / "main-repo"
+        payload = json.dumps({
+            "cwd": str(wt_path),  # cwd is the worktree itself
+            "name": "my-wt",
+            "hook_event_name": "WorktreeRemove",
+        })
+        mock_run = MagicMock(return_value=subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr="",
+        ))
+        with (
+            patch("sys.stdin", StringIO(payload)),
+            patch("jcodemunch_mcp.hook_event.subprocess.run", mock_run),
+            patch("jcodemunch_mcp.hook_event._get_worktree_base", return_value=""),
+            patch("jcodemunch_mcp.hook_event._resolve_main_repo", return_value=str(main_repo)),
+        ):
+            handle_hook_event("remove", manifest_path=manifest)
+
+        # git -C should use main_repo, not the worktree path
+        wt_args = mock_run.call_args_list[0][0][0]
+        assert wt_args[2] == str(main_repo)
+
     def test_remove_with_worktree_path_runs_git(self, tmp_path):
         """Remove with worktree_path must still run git worktree remove."""
         manifest = tmp_path / "manifest.jsonl"
@@ -239,6 +266,7 @@ class TestHookEvent:
         with (
             patch("sys.stdin", StringIO(payload)),
             patch("jcodemunch_mcp.hook_event.subprocess.run", mock_run),
+            patch("jcodemunch_mcp.hook_event._resolve_main_repo", return_value=str(tmp_path)),
         ):
             handle_hook_event("remove", manifest_path=manifest)
 


### PR DESCRIPTION
Fixes #269

## Summary

Two bugs prevented `WorktreeRemove` from actually removing worktrees:

- **Legacy early-return skipped git commands:** The `worktree_path` field in the payload triggered a code path that only wrote the manifest entry and returned — never running `git worktree remove`. Fixed by limiting the early-return to `create` events only.
- **git commands ran from inside the worktree being removed:** `cwd` from the payload is the worktree itself (where Claude Code's session ran). `git worktree remove` cannot remove a worktree from inside itself. Fixed by resolving the main repo root via `git rev-parse --git-common-dir` and running removal from there.

## Test plan

- [x] All 15 `TestHookEvent` tests pass (2 new tests added)
- [x] Manual: confirmed orphaned worktrees are cleaned up on session exit