### PR TITLE
fix(get_file_outline): emit flat list with parent ids so nested symbo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to jcodemunch-mcp are documented here.
 
+## [Unreleased]
+
+### Fixed
+- **`get_file_outline` silently dropped every nested symbol** (methods,
+  constructors, fields, properties) on the MCP wire. The producer emitted a
+  nested tree (`children` arrays), but the compact `fo1` encoder schema was
+  designed for a flat list with `parent` ids and the generic encoder loop
+  iterated only top-level rows — so nested children fell on the floor. MCP
+  clients saw classes as if they had no methods, breaking the canonical
+  "outline first, then drill down" workflow. Reproduces on every language
+  (the failure lives in language-agnostic code), confirmed on C# and
+  TypeScript. Producer now DFS-flattens the tree and writes `parent` ids
+  directly, matching the encoder's existing schema intent.
+- **`signature` field was silently nulled on the wire** by `get_file_outline`.
+  The producer emitted it, but the encoder schema's `cols` list omitted it,
+  so it never made it into the compact payload. `signature` is now part of
+  the encoder schema.
+
+### Changed
+- **`get_file_outline` response shape is now flat with `parent` ids** in both
+  the in-process and over-the-wire response. The previous in-process tree
+  shape (nested `children` arrays) is removed. Direct Python callers that
+  walked `result["symbols"][i]["children"]` must rebuild the tree with a
+  `parent`-based group-by — one line. The on-wire compact format already
+  carried `parent`; this just makes the in-process shape match.
+
 ## [1.82.1] — 2026-05-08 — Handshake watchdog for stdio transport
 
 ### Added

--- a/src/jcodemunch_mcp/encoding/schemas/get_file_outline.py
+++ b/src/jcodemunch_mcp/encoding/schemas/get_file_outline.py
@@ -9,7 +9,7 @@ _TABLES = [
     sd.TableSpec(
         key="symbols",
         tag="s",
-        cols=["id", "name", "kind", "line", "end_line", "parent", "summary"],
+        cols=["id", "name", "kind", "signature", "line", "end_line", "parent", "summary"],
         intern=["id", "parent"],
         types={"line": "int", "end_line": "int"},
     ),

--- a/src/jcodemunch_mcp/tools/get_file_outline.py
+++ b/src/jcodemunch_mcp/tools/get_file_outline.py
@@ -6,7 +6,7 @@ import time
 from typing import Optional
 
 from ..storage import IndexStore, record_savings, estimate_savings, cost_avoided
-from ..parser import build_symbol_tree
+from ..parser import Symbol, build_symbol_tree
 from ._utils import resolve_repo
 
 
@@ -61,13 +61,11 @@ def _get_file_outline_single(
             },
         }
 
-    # Build symbol tree
-    from ..parser import Symbol
+    # DFS-flatten the symbol tree into a list with parent ids; class members
+    # follow their class in order.
     symbol_objects = [_dict_to_symbol(s) for s in file_symbols]
     tree = build_symbol_tree(symbol_objects)
-
-    # Convert to output format
-    symbols_output = [_node_to_dict(n) for n in tree]
+    symbols_output = _flatten_tree_with_parents(tree)
 
     elapsed = (time.perf_counter() - start) * 1000
     response_bytes = len(json.dumps(symbols_output).encode("utf-8"))
@@ -123,12 +121,15 @@ def get_file_outline(
     storage_path: Optional[str] = None,
     file_paths: Optional[list[str]] = None,
 ) -> dict:
-    """Get symbols in a file with hierarchical structure.
+    """Get all symbols in a file as a flat list with ``parent`` ids.
 
-    Supports two modes:
-    - Singular: pass ``file_path`` to get the original flat response shape.
-    - Batch: pass ``file_paths`` (list) to query multiple files at once,
-      returning a grouped ``results`` array.
+    Hierarchy is carried by ``parent``: nested symbols point at their
+    enclosing symbol's id; top-level symbols have ``parent=None``. DFS
+    ordering groups class members immediately after the class.
+
+    Modes:
+    - Singular: pass ``file_path`` for one file's outline.
+    - Batch: pass ``file_paths`` (list) to return a grouped ``results`` array.
 
     Args:
         repo: Repository identifier (owner/repo or just repo name)
@@ -169,9 +170,8 @@ def get_file_outline(
         return _get_file_outline_single(file_path, index, owner, name, store, start)
 
 
-def _dict_to_symbol(d: dict) -> "Symbol":
+def _dict_to_symbol(d: dict) -> Symbol:
     """Convert dict back to Symbol dataclass."""
-    from ..parser import Symbol
     return Symbol(
         id=d["id"],
         file=d["file"],
@@ -193,21 +193,24 @@ def _dict_to_symbol(d: dict) -> "Symbol":
     )
 
 
-def _node_to_dict(node) -> dict:
-    """Convert SymbolNode to output dict."""
-    result = {
-        "id": node.symbol.id,
-        "kind": node.symbol.kind,
-        "name": node.symbol.name,
-        "signature": node.symbol.signature,
-        "summary": node.symbol.summary,
-        "line": node.symbol.line,
-    }
-
-    if node.symbol.decorators:
-        result["decorators"] = node.symbol.decorators
-
-    if node.children:
-        result["children"] = [_node_to_dict(c) for c in node.children]
-
-    return result
+def _flatten_tree_with_parents(nodes, parent_id=None) -> list[dict]:
+    """DFS-flatten a SymbolNode tree into dicts; each carries its parent's id (None for roots)."""
+    out: list[dict] = []
+    for node in nodes:
+        sym = node.symbol
+        d = {
+            "id": sym.id,
+            "kind": sym.kind,
+            "name": sym.name,
+            "signature": sym.signature,
+            "summary": sym.summary,
+            "line": sym.line,
+            "end_line": sym.end_line,
+            "parent": parent_id,
+        }
+        if sym.decorators:
+            d["decorators"] = sym.decorators
+        out.append(d)
+        if node.children:
+            out.extend(_flatten_tree_with_parents(node.children, parent_id=sym.id))
+    return out

--- a/tests/encoding/test_tier1_roundtrip.py
+++ b/tests/encoding/test_tier1_roundtrip.py
@@ -378,15 +378,26 @@ def test_get_file_outline_round_trip():
     resp = {
         "repo": "acme/app",
         "file": "src/models/user.py",
-        "symbol_count": 2,
+        "symbol_count": 4,
         "symbols": [
-            {"id": "s1", "name": "User", "kind": "class", "line": 1, "end_line": 20, "parent": "", "summary": ""},
-            {"id": "s2", "name": "get_user", "kind": "function", "line": 25, "end_line": 40, "parent": "", "summary": ""},
+            {"id": "s1", "name": "User", "kind": "class", "signature": "class User", "line": 1, "end_line": 20, "parent": None, "summary": ""},
+            {"id": "s2", "name": "__init__", "kind": "method", "signature": "def __init__(self)", "line": 3, "end_line": 5, "parent": "s1", "summary": ""},
+            {"id": "s3", "name": "name", "kind": "constant", "signature": "name: str", "line": 6, "end_line": 6, "parent": "s1", "summary": ""},
+            {"id": "s4", "name": "get_user", "kind": "function", "signature": "def get_user(uid: int) -> User", "line": 25, "end_line": 40, "parent": None, "summary": ""},
         ],
         "_meta": {"timing_ms": 0.3},
     }
     out = _rt("get_file_outline", resp)
-    assert len(out["symbols"]) == 2
+    assert len(out["symbols"]) == 4
+    by_id = {s["id"]: s for s in out["symbols"]}
+    # parent column carries hierarchy; nested symbols point at their class.
+    assert by_id["s2"]["parent"] == "s1"
+    assert by_id["s3"]["parent"] == "s1"
+    assert by_id["s1"]["parent"] is None
+    assert by_id["s4"]["parent"] is None
+    # signature round-trips through the encoder.
+    assert by_id["s4"]["signature"] == "def get_user(uid: int) -> User"
+    assert by_id["s2"]["signature"] == "def __init__(self)"
 
 
 def test_get_repo_outline_round_trip():

--- a/tests/test_get_file_outline_integration.py
+++ b/tests/test_get_file_outline_integration.py
@@ -1,0 +1,133 @@
+"""Integration tests for get_file_outline: producer + MCP encoder + decoder."""
+
+import textwrap
+
+import pytest
+
+from jcodemunch_mcp.encoding import encode_response
+from jcodemunch_mcp.encoding.decoder import decode
+from jcodemunch_mcp.tools.get_file_outline import get_file_outline
+
+
+@pytest.fixture
+def class_with_members_index(tmp_path):
+    """Python repo: 1 file with one class (ctor + 2 methods) and 1 standalone fn.
+
+    Symbols extracted by the Python parser:
+        - Repo (class)              parent=None
+          - __init__ (method)       parent=Repo
+          - count (method)          parent=Repo
+        - top_level_helper (fn)     parent=None
+    """
+    from jcodemunch_mcp.tools.index_folder import index_folder
+
+    src = tmp_path / "src"
+    store = tmp_path / "store"
+    src.mkdir()
+    store.mkdir()
+    (src / "repo.py").write_text(textwrap.dedent('''\
+        class Repo:
+            """A toy repository."""
+
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+            def count(self) -> int:
+                return 0
+
+
+        def top_level_helper(x: int) -> int:
+            return x + 1
+    '''))
+    r = index_folder(str(src), use_ai_summaries=False, storage_path=str(store))
+    assert r["success"] is True
+    return {"repo": r["repo"], "store": str(store), "src": str(src)}
+
+
+def _outline_through_wire(repo: str, file_path: str, store: str) -> dict:
+    """Helper: run producer, encode through compact pipeline, decode back."""
+    raw = get_file_outline(repo=repo, file_path=file_path, storage_path=store)
+    payload, meta = encode_response("get_file_outline", raw, "compact")
+    assert isinstance(payload, str)
+    assert meta["encoding"] != "json"
+    return decode(payload)
+
+
+def test_nested_methods_appear_in_response(class_with_members_index):
+    """Class methods and constructors appear alongside the class itself."""
+    fx = class_with_members_index
+    decoded = _outline_through_wire(fx["repo"], "repo.py", fx["store"])
+
+    names = [s["name"] for s in decoded["symbols"]]
+    kinds = {s["name"]: s["kind"] for s in decoded["symbols"]}
+
+    assert {"Repo", "__init__", "count", "top_level_helper"} <= set(names)
+    assert kinds["Repo"] == "class"
+    assert kinds["count"] == "method"
+
+
+def test_parent_column_carries_hierarchy(class_with_members_index):
+    """`parent` ids point each nested symbol at its enclosing class."""
+    fx = class_with_members_index
+    decoded = _outline_through_wire(fx["repo"], "repo.py", fx["store"])
+
+    by_name = {s["name"]: s for s in decoded["symbols"]}
+    repo_id = by_name["Repo"]["id"]
+
+    assert by_name["Repo"]["parent"] in (None, "")
+    assert by_name["top_level_helper"]["parent"] in (None, "")
+    assert by_name["__init__"]["parent"] == repo_id
+    assert by_name["count"]["parent"] == repo_id
+
+
+def test_dfs_ordering_groups_members_with_class(class_with_members_index):
+    """Class members appear immediately after the class, before next top-level."""
+    fx = class_with_members_index
+    decoded = _outline_through_wire(fx["repo"], "repo.py", fx["store"])
+    names = [s["name"] for s in decoded["symbols"]]
+
+    assert names.index("Repo") < names.index("__init__")
+    assert names.index("Repo") < names.index("count")
+    helper_idx = names.index("top_level_helper")
+    for member in ("__init__", "count"):
+        assert names.index(member) < helper_idx
+
+
+def test_signature_field_round_trips(class_with_members_index):
+    """`signature` survives encode → decode for nested and top-level symbols."""
+    fx = class_with_members_index
+    decoded = _outline_through_wire(fx["repo"], "repo.py", fx["store"])
+
+    by_name = {s["name"]: s for s in decoded["symbols"]}
+    helper_sig = by_name["top_level_helper"]["signature"] or ""
+    init_sig = by_name["__init__"]["signature"] or ""
+
+    assert "top_level_helper" in helper_sig
+    assert "__init__" in init_sig
+
+
+def test_in_process_response_is_flat(class_with_members_index):
+    """Producer emits a flat list — no nested ``children`` keys."""
+    fx = class_with_members_index
+    raw = get_file_outline(repo=fx["repo"], file_path="repo.py", storage_path=fx["store"])
+
+    symbols = raw["symbols"]
+    assert all("children" not in s for s in symbols)
+    assert any(s.get("parent") for s in symbols)
+
+
+def test_batch_mode_returns_flat_per_file_outlines(class_with_members_index):
+    """Batch mode's per-file inner shape is flat with parent ids too."""
+    fx = class_with_members_index
+    raw = get_file_outline(
+        repo=fx["repo"],
+        file_paths=["repo.py"],
+        storage_path=fx["store"],
+    )
+
+    file_results = raw["results"]
+    assert len(file_results) == 1
+    syms = file_results[0]["symbols"]
+    assert all("children" not in s for s in syms)
+    names = {s["name"] for s in syms}
+    assert {"Repo", "__init__", "count", "top_level_helper"} <= names


### PR DESCRIPTION
**What this PR does / why we need it:**

`get_file_outline` is the canonical "see the API surface of a file without reading it" tool. The producer in `tools/get_file_outline.py` builds a nested tree (`children` arrays under each class), but the compact `fo1` encoder schema in `encoding/schemas/get_file_outline.py` is designed for a **flat** list with `parent` ids — `parent` is one of its declared columns. The generic encoder loop in `encoding/schema_driven.py` only iterates top-level rows of each table, so every nested entry (methods, constructors, fields, properties, events) silently falls on the floor before reaching the wire. MCP clients have been seeing classes as if they had no methods since the `fo1` encoder shipped, which breaks the recommended "outline first, then drill down" workflow.

A second smaller bug rides along on the same encoder schema: `signature` is always emitted by the producer but is missing from the encoder's `cols` list, so it's silently nulled on the wire too.

**Reproduction (this is what every Claude Code / Cursor / Copilot agent sees today):**

C# — a class with a field, constructor, and method (4 symbols expected):

```csharp
public class OrderService : IOrderService
{
    private readonly IMediator _mediator;
    public OrderService(IMediator mediator) { _mediator = mediator; }
    public Task<Order> GetOrder(int id) => _mediator.Send(new GetOrderQuery(id));
}
```

`get_file_outline` over MCP returns this:

```text
#MUNCH/1 tool=get_file_outline enc=fo1
__tables="s:symbols:id|name|kind|line|end_line|parent|summary,..."
s,...::OrderService#class,OrderService,class,1,,,Class OrderService
```

→ Only the class survives. `_mediator`, the constructor, and `GetOrder` are silently dropped.

TypeScript — a class with a couple of methods plus a standalone helper:

```ts
export class HttpServer {
    constructor(private port: number) {}
    listen() { /* ... */ }
    close() { /* ... */ }
}

export function pickFreePort(start: number): number { /* ... */ }
```

`get_file_outline` over MCP returns this:

```text
#MUNCH/1 tool=get_file_outline enc=fo1
__tables="s:symbols:id|name|kind|line|end_line|parent|summary,..."
s,...::HttpServer#class,HttpServer,class,1,...
s,...::pickFreePort#function,pickFreePort,function,7,...
```

→ Top-level symbols only. `HttpServer`'s constructor, `listen`, and `close` are all missing — even though `search_symbols` finds them fine. They just never make it through `get_file_outline`'s encoder.

The Python in-process function returns the full tree correctly in both cases — it's purely the MCP-encoded transport that drops nested entries.

**Languages affected — all of them.**

The bug lives in two places, both language-agnostic:

1. `tools/get_file_outline.py:_node_to_dict` (the producer) — emits a nested tree regardless of source language; just walks the `SymbolNode` graph that `parser.build_symbol_tree` returns.
2. `encoding/schema_driven.py:encode` (the generic encoder) — iterates only top-level rows; identical code path for every tool that uses the schema-driven encoder.

So every language the indexer parses is affected — anywhere a class/module/namespace contains nested members: **Python, TypeScript, JavaScript, TSX, C#, Razor, Java, Kotlin, Go, Rust, C, C++, Objective-C, Swift, PHP, Ruby, Dart, Elixir, Erlang, Haskell, Scala, Julia, R, Perl, Lua, Luau, GDScript, AL, Blade, Vue, EJS, Verse, Fortran, Groovy, SQL, Proto, GraphQL, OpenAPI, Bash, AutoHotkey, Asm, Nix, HCL, TOML, XML, CSS**.

Verified live over MCP on a C# project and a TypeScript project during bug discovery. Python is covered by the new integration test (class + ctor + 2 methods round-trips correctly post-fix).

**Changes made:**

* `src/jcodemunch_mcp/tools/get_file_outline.py`: replaced the recursive `_node_to_dict` helper with `_flatten_tree_with_parents`, a DFS-flatten that threads `parent` ids onto each entry. The schema's `parent` column carries the hierarchy. DFS ordering preserves the "class first, then its members, then next top-level symbol" grouping that callers see today.
* `src/jcodemunch_mcp/encoding/schemas/get_file_outline.py`: added `signature` to `cols` so it stops getting silently nulled on the wire.
* Updated the `get_file_outline` docstring — it previously promised "hierarchical structure" with a `children` shape that was never delivered over MCP.

**Breaking change for direct Python callers** (documented under `## Changed` in CHANGELOG): the in-process response shape is also flat now. Any caller that walked `result["symbols"][i]["children"]` must group by `parent` — one line. The on-wire compact format already carried `parent`; this just makes the in-process shape match.

**Testing:**

* New `tests/test_get_file_outline_integration.py` — 6 tests, real-indexed Python fixture (class + ctor + 2 methods + standalone function), full producer → encoder → decoder round-trip. Asserts:
  * nested members (`__init__`, `count`) survive the wire (regression test for the dropped-children bug);
  * `parent` ids point each method at its enclosing class id;
  * DFS ordering keeps members grouped with their class, before the next top-level symbol;
  * `signature` round-trips (regression test for the silent-null bug);
  * in-process response is also flat (no `children` keys);
  * batch mode flattens too.
* Strengthened the existing tier-1 round-trip test in `tests/encoding/test_tier1_roundtrip.py`. The old version asserted only `len(out["symbols"]) == 2` against hand-rolled flat input with empty `parent=""` placeholders — which is exactly why this bug shipped: the encoder unit test never exercised the producer's actual output. Now asserts `parent` and `signature` survival on a class+methods+field example.
* Full suite: 3652 passed, 12 skipped. One pre-existing failure (`test_no_warning_when_config_key_present`) reproduces on pristine `upstream/main` — env-var leak from `JCODEMUNCH_MAX_INDEX_FILES` in the shell environment, unrelated to this change.
* Schema budget gate (`tests/test_schema_budget.py`): `git diff upstream/main..HEAD` on `src/jcodemunch_mcp/server.py` and `src/jcodemunch_mcp/config.py` is empty, so `tools/list` is byte-identical to upstream and the gate passes mathematically. The `core_compact <= 4000` sub-test passes locally.
* Retrieval-quality replay: zero diff vs `upstream/main` in `tools/search_symbols.py`, `retrieval/`, `embeddings/`, `storage/`, `benchmarks/replay/` — metrics cannot move.
