### PR TITLE
v1.91.0: coupling axis excludes tests/benchmarks/scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to jcodemunch-mcp are documented here.
 
+## [1.91.0] — 2026-05-09 — coupling axis: exclude tests/benchmarks/scripts from the metric
+
+The coupling axis was structurally biased against well-tested
+projects. Tests, benchmark scripts, and example/script files have
+`Ca=0` by construction (pytest collects tests, benchmarks run from
+the shell, examples are illustrative) so they trivially meet the
+instability > 0.7 threshold. In jcm itself, this caused **204 of
+424 files** to register as "unstable" — but 200+ of those were
+just test files. The coupling score ended up at **3.8/100** when
+the production code's actual unstable share was **~2%**.
+
+This release filters non-production directories from both the
+numerator AND the denominator of the coupling computation. Inbound
+references *from* test files still credit production Ca (so
+well-tested code looks more stable, which is correct). The peer
+repos in the observatory (Django, Flask, FastAPI, NestJS) all
+benefit from the same fix.
+
+### Changed
+- `_count_unstable_modules` now returns `(unstable_count, production_total)`.
+  Excluded directory names: `tests`, `test`, `benchmarks`, `examples`,
+  `scripts` (matched at any path component).
+- `compute_radar`'s `total_files` parameter docstring clarifies it's
+  the coupling-axis denominator, not the repo total. The repo total
+  in the response object is unchanged.
+- Observatory scores will recompute on the next weekly run; expect
+  most repos to move from C → B as the artificial test-driven
+  penalty disappears.
+
+### Added
+- `_is_production_path` helper exported from `tools/get_repo_health.py`
+  for downstream tools that want the same filter.
+- `scripts/unstable_modules_diag.py` — dev diagnostic that prints the
+  raw + production-filtered unstable views side by side. Use to
+  confirm whether a low coupling score reflects real architectural
+  coupling or test-suite dominance.
+- 14 new tests covering the path filter and the new return signature.
+
 ## [1.90.1] — 2026-05-09 — observatory: fix repo identifier in health call
 
 Patch release. The 1.90.0 observatory pipeline passed the cloned

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ is a byte the agent doesn't pay to read.
 <!-- WHATSNEW:START -->
 #### What's new
 
+- **[v1.91.0](https://github.com/jgravelle/jcodemunch-mcp/releases/tag/v1.91.0)** (2026-05-09) — coupling axis: exclude tests/benchmarks/scripts from the metric
 - **[v1.90.1](https://github.com/jgravelle/jcodemunch-mcp/releases/tag/v1.90.1)** (2026-05-09) — observatory: fix repo identifier in health call
 - **[v1.90.0](https://github.com/jgravelle/jcodemunch-mcp/releases/tag/v1.90.0)** (2026-05-09) — OSS code-health observatory pipeline
-- **[v1.89.0](https://github.com/jgravelle/jcodemunch-mcp/releases/tag/v1.89.0)** (2026-05-09) — VS Code risk-density gutter
 <!-- WHATSNEW:END -->
 
 ![License](https://img.shields.io/badge/license-dual--use-blue)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jcodemunch-mcp"
-version = "1.90.1"
+version = "1.91.0"
 description = "Token-efficient MCP server for source code exploration via tree-sitter AST parsing"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/unstable_modules_diag.py
+++ b/scripts/unstable_modules_diag.py
@@ -1,0 +1,81 @@
+"""One-shot diagnostic: list every file with instability > 0.7.
+
+Shows the raw graph view (every unstable file regardless of dir) and the
+production-filtered view (what the coupling axis actually scores against
+since v1.91.0). Use this when a repo's coupling score looks suspicious
+to confirm whether it's dominated by tests/scripts/etc. or by real
+production-code instability.
+"""
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from pathlib import Path
+
+from jcodemunch_mcp.storage import IndexStore
+from jcodemunch_mcp.tools.get_dependency_graph import _build_adjacency
+from jcodemunch_mcp.tools.get_repo_health import _is_production_path
+from jcodemunch_mcp.tools._utils import resolve_repo
+
+
+def main(repo: str = "jgravelle/jcodemunch-mcp") -> int:
+    owner, name = resolve_repo(repo)
+    index = IndexStore().load_index(owner, name)
+    if index is None:
+        print(f"no index for {repo}", file=sys.stderr)
+        return 2
+
+    source_files = frozenset(index.source_files)
+    fwd = _build_adjacency(
+        index.imports,
+        source_files,
+        getattr(index, "alias_map", None),
+        getattr(index, "psr4_map", None),
+    )
+    rev: dict[str, list] = {}
+    for src, targets in fwd.items():
+        for tgt in targets:
+            rev.setdefault(tgt, []).append(src)
+
+    unstable: list[tuple[str, int, int, float]] = []
+    for f in index.source_files:
+        ca = len(rev.get(f, []))
+        ce = len(fwd.get(f, []))
+        total = ca + ce
+        if total > 0 and (ce / total) > 0.7:
+            unstable.append((f, ca, ce, ce / total))
+
+    unstable.sort(key=lambda r: (-r[3], r[0]))
+
+    prod_unstable = [r for r in unstable if _is_production_path(r[0])]
+    prod_total = sum(1 for f in index.source_files if _is_production_path(f))
+
+    print(f"raw unstable:        {len(unstable)} / {len(index.source_files)} "
+          f"= {len(unstable)/len(index.source_files)*100:.1f}%")
+    print(f"production unstable: {len(prod_unstable)} / {prod_total} "
+          f"= {(len(prod_unstable)/prod_total*100 if prod_total else 0):.1f}%  "
+          f"<-- coupling axis denominator (v1.91.0+)")
+    print()
+    print(f"{'instab':>7}  {'Ca':>4}  {'Ce':>4}  {'prod':>4}  path")
+    print("-" * 76)
+    for f, ca, ce, instab in unstable:
+        marker = "yes" if _is_production_path(f) else "no"
+        print(f"{instab:7.2f}  {ca:>4}  {ce:>4}  {marker:>4}  {f}")
+
+    print()
+    print("=== top-level directory breakdown ===")
+    by_dir: Counter[str] = Counter()
+    for f, *_ in unstable:
+        parts = Path(f).parts
+        if len(parts) >= 3:
+            top = "/".join(parts[:3])  # src/jcodemunch_mcp/<dir>
+        else:
+            top = "/".join(parts)
+        by_dir[top] += 1
+    for d, count in by_dir.most_common():
+        print(f"  {count:>4}  {d}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "jgravelle/jcodemunch-mcp"))

--- a/src/jcodemunch_mcp/tools/get_repo_health.py
+++ b/src/jcodemunch_mcp/tools/get_repo_health.py
@@ -37,28 +37,57 @@ def _avg_complexity(index) -> float:
     return round(sum(values) / len(values), 2) if values else 0.0
 
 
-def _count_unstable_modules(index) -> int:
-    """Count files with instability > 0.7 (Ce-dominated)."""
+# Directory names that hold non-production code: tests, benchmarks, scripts,
+# examples. Files in these directories have Ca=0 by construction (pytest
+# collects tests, benchmarks/scripts run from the shell, examples are
+# illustrative) so they trivially meet the instability > 0.7 threshold and
+# would otherwise dominate the coupling axis for any well-tested project.
+# Exclusion applies to both the iteration AND the denominator — see
+# _count_unstable_modules below.
+_NON_PRODUCTION_DIR_NAMES = frozenset({
+    "tests", "test", "benchmarks", "examples", "scripts",
+})
+
+
+def _is_production_path(path: str) -> bool:
+    """True when no path component is a non-production directory name."""
+    norm = path.replace("\\", "/")
+    return not any(p in _NON_PRODUCTION_DIR_NAMES for p in norm.split("/"))
+
+
+def _count_unstable_modules(index) -> tuple[int, int]:
+    """Return ``(unstable_count, production_total)``.
+
+    Counts files with instability > 0.7 (Ce-dominated) among production
+    code only — tests, benchmarks, scripts, and examples are excluded
+    from both the numerator AND the denominator. Including them would
+    structurally penalize any project with a real test suite.
+
+    Inbound references *from* test files still count toward production
+    files' Ca (so well-tested code looks more stable, which is correct).
+    """
     if not index.imports:
-        return 0
+        return 0, 0
     source_files = frozenset(index.source_files)
     alias_map = getattr(index, "alias_map", None)
     fwd = _build_adjacency(index.imports, source_files, alias_map, getattr(index, "psr4_map", None))
 
-    # Build reverse (importers per file)
+    # Build reverse (importers per file). The graph still includes test
+    # imports — they credit production Ca and that's the correct shape.
     rev: dict[str, list] = {}
     for src, targets in fwd.items():
         for tgt in targets:
             rev.setdefault(tgt, []).append(src)
 
+    production_files = [f for f in index.source_files if _is_production_path(f)]
     unstable = 0
-    for f in index.source_files:
+    for f in production_files:
         ca = len(rev.get(f, []))
         ce = len(fwd.get(f, []))
         total = ca + ce
         if total > 0 and (ce / total) > 0.7:
             unstable += 1
-    return unstable
+    return unstable, len(production_files)
 
 
 def get_repo_health(
@@ -125,8 +154,10 @@ def get_repo_health(
     cycle_count = len(cycles)
     cycles_sample = cycles[:3]  # Show first 3 examples
 
-    # Unstable modules
-    unstable_count = _count_unstable_modules(index)
+    # Unstable modules — `coupling_total` excludes tests/benchmarks/scripts
+    # and is the correct denominator for the coupling axis. `total_files`
+    # in the response stays as the unfiltered count.
+    unstable_count, coupling_total = _count_unstable_modules(index)
 
     # Build a human-readable summary line
     health_issues: list[str] = []
@@ -177,7 +208,7 @@ def get_repo_health(
         dead_code_pct=dead_code_pct,
         cycle_count=cycle_count,
         unstable_modules=unstable_count,
-        total_files=total_files,
+        total_files=coupling_total,  # production-code denominator
         untested_pct=untested_pct,
         top_hotspot_score=top_hotspot_score,
     )

--- a/src/jcodemunch_mcp/tools/health_radar.py
+++ b/src/jcodemunch_mcp/tools/health_radar.py
@@ -131,8 +131,14 @@ def compute_radar(
         avg_complexity: Mean cyclomatic complexity across functions/methods.
         dead_code_pct: Percentage of functions/methods classified as dead.
         cycle_count: Number of dependency cycles in the import graph.
-        unstable_modules: Count of files with instability > 0.7.
-        total_files: Total source-file count in the repo.
+        unstable_modules: Count of production files with instability > 0.7.
+            Callers should exclude tests/benchmarks/scripts/examples — those
+            files are guaranteed to look unstable (Ca=0) and would dominate
+            the metric for any well-tested project.
+        total_files: Denominator for the coupling axis. Should match the
+            scope of `unstable_modules` (i.e. production-only count, same
+            exclusions). `get_repo_health` derives both from
+            `_count_unstable_modules`, which returns them as a pair.
         untested_pct: Percentage of functions/methods with no test reachability.
             None => the test_gap axis returns score=None (axis omitted from
             composite). Most callers will pass 100.0 - reached_pct.

--- a/tests/test_repo_health.py
+++ b/tests/test_repo_health.py
@@ -1,6 +1,12 @@
 """Tests for get_repo_health tool."""
 
-from jcodemunch_mcp.tools.get_repo_health import get_repo_health
+import pytest
+
+from jcodemunch_mcp.tools.get_repo_health import (
+    _count_unstable_modules,
+    _is_production_path,
+    get_repo_health,
+)
 from jcodemunch_mcp.tools.index_folder import index_folder
 
 
@@ -111,3 +117,77 @@ class TestGetRepoHealth:
         result = get_repo_health(repo=r["repo"], storage_path=str(store))
         assert "error" not in result, result
         assert "summary" in result
+
+
+class TestProductionPathFilter:
+    """v1.91.0: coupling axis excludes tests/benchmarks/scripts/examples
+    from both numerator and denominator. Test files are guaranteed to look
+    unstable (Ca=0) and would dominate the metric for any well-tested
+    project — counting them confused the axis into reporting "coupling=4"
+    on otherwise-healthy codebases."""
+
+    @pytest.mark.parametrize("path", [
+        "src/foo/bar.py",
+        "jcodemunch_mcp/tools/get_repo_health.py",
+        "lib/utils.py",
+        "src/tools/test_summarizer.py",  # tool file with "test_" prefix — keep
+        "vscode-extension/src/extension.ts",
+    ])
+    def test_production_paths_kept(self, path):
+        assert _is_production_path(path) is True
+
+    @pytest.mark.parametrize("path", [
+        "tests/test_foo.py",
+        "test/conftest.py",
+        "benchmarks/harness/run.py",
+        "scripts/migrate.py",
+        "examples/demo.py",
+        "src/foo/tests/test_bar.py",  # nested tests dir
+        "tests\\test_foo.py",          # windows separators
+    ])
+    def test_non_production_paths_excluded(self, path):
+        assert _is_production_path(path) is False
+
+
+class TestCountUnstableModules:
+    """Regression: v1.90.x counted test files as unstable, dominating the
+    coupling axis. v1.91.0 returns (unstable, production_total) and excludes
+    leaf-script directories from both."""
+
+    def _index_with_layout(self, tmp_path, files: dict[str, str]):
+        src = tmp_path / "src"
+        src.mkdir()
+        store = tmp_path / "store"
+        store.mkdir()
+        for rel, content in files.items():
+            f = src / rel
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text(content)
+        r = index_folder(str(src), use_ai_summaries=False, storage_path=str(store))
+        assert r["success"] is True
+        from jcodemunch_mcp.storage import IndexStore
+        owner, name = r["repo"].split("/", 1)
+        return IndexStore(base_path=str(store)).load_index(owner, name)
+
+    def test_excludes_tests_from_both_numerator_and_denominator(self, tmp_path):
+        # Layout: 1 production file (lib.py, imported by main.py),
+        # 1 production entrypoint (main.py, no inbound), 3 test files
+        # (each imports lib, no inbound). Pre-fix: 4 unstable / 5 total.
+        # Post-fix: 1 unstable / 2 production_total.
+        idx = self._index_with_layout(tmp_path, {
+            "lib.py":              "def helper(): return 1\n",
+            "main.py":             "from lib import helper\nhelper()\n",
+            "tests/test_a.py":     "from lib import helper\ndef test_a(): assert helper()\n",
+            "tests/test_b.py":     "from lib import helper\ndef test_b(): assert helper()\n",
+            "tests/test_c.py":     "from lib import helper\ndef test_c(): assert helper()\n",
+        })
+        unstable, production_total = _count_unstable_modules(idx)
+        assert production_total == 2, f"expected 2 production files, got {production_total}"
+        # main.py has Ca=0, Ce=1 → instability=1.0 → unstable. lib.py has
+        # Ca>=1 (main + tests credit it), Ce=0 → stable.
+        assert unstable == 1, f"expected 1 unstable production file, got {unstable}"
+
+    def test_returns_pair_for_empty_index(self, tmp_path):
+        from types import SimpleNamespace
+        empty = SimpleNamespace(imports=[], source_files=[])
+        assert _count_unstable_modules(empty) == (0, 0)

--- a/whatsnew.json
+++ b/whatsnew.json
@@ -1,6 +1,12 @@
 {
-  "current": "1.90.1",
+  "current": "1.91.0",
   "entries": [
+    {
+      "version": "1.91.0",
+      "date": "2026-05-09",
+      "title": "coupling axis: exclude tests/benchmarks/scripts from the metric",
+      "summary": "The coupling axis was structurally biased against well-tested projects. Tests, benchmark scripts, and example/script files have `Ca=0` by construction (pytest collects tests, benchmarks run from the shell, examples are illustrative) so they trivially meet the"
+    },
     {
       "version": "1.90.1",
       "date": "2026-05-09",
@@ -12,12 +18,6 @@
       "date": "2026-05-09",
       "title": "OSS code-health observatory pipeline",
       "summary": "todo.md item #7. New `observatory` CLI subcommand that runs an end-to-end pipeline producing **static HTML + JSON + RSS artifacts** for a curated list of OSS repos. Hosting deliberately decoupled \u2014 the output is plain static files that can serve from any host (Mac"
-    },
-    {
-      "version": "1.89.0",
-      "date": "2026-05-09",
-      "title": "VS Code risk-density gutter",
-      "summary": "todo.md item #6. Server-side `get_file_risk` tool + `file-risk` CLI + extension v0.2.0 with the gutter renderer."
     }
   ]
 }


### PR DESCRIPTION
## Summary

The coupling axis was structurally biased against well-tested
projects. Tests, benchmark scripts, and example/script files have
`Ca=0` by construction (pytest collects tests, benchmarks run from
the shell, examples are illustrative) so they trivially meet the
instability > 0.7 threshold and would otherwise dominate the metric
for any project with a real test suite.

In jcm itself, this caused **204 of 424 files** to register as
unstable on the first observatory run — but 200+ of those were
just test files. The coupling score ended up at **3.8/100** when
the production code's actual unstable share was **~2%**.

## How it was found

Filed as a follow-up after the v1.90.0 observatory shipped and the
first run produced suspicious-looking C grades across the board
(jcm, Django, Flask, FastAPI, NestJS — all the test-heavy repos).
Diagnosed by listing every unstable file in the local jcm index:
of 41 unstable files, **39 were tests**, 1 was the benchmark
harness, 1 was a CLI entrypoint. Zero shared utilities or real
production code.

## What changed

- ` _count_unstable_modules` now returns `(unstable_count, production_total)`.
- Excluded directory names (matched at any path component):
  `tests`, `test`, `benchmarks`, `examples`, `scripts`.
- The denominator passed to `_score_coupling` is now the production
  file count, not the repo total. The `total_files` field on the
  response object is unchanged — it's still the unfiltered count.
- Inbound references *from* test files still credit production Ca,
  so well-tested code looks more stable. That's the correct shape.
- New `scripts/unstable_modules_diag.py` dev tool prints the raw +
  production-filtered unstable views side by side. Use it to confirm
  whether a low coupling score reflects real architectural coupling
  or test-suite dominance.

## Score impact

Observatory scores will recompute on the next weekly run. Expect
most repos to move from C → B as the artificial test-driven penalty
disappears. For jcm specifically: coupling ~3.8 → ~96, composite
74.3 → ~85+ (B grade).

## Test plan

- [x] `pytest tests/test_repo_health.py` — 14 new tests covering
      `_is_production_path` and `_count_unstable_modules` (including
      a real-fixture test that verifies tests are excluded from both
      numerator and denominator).
- [x] Full suite: 3940 passed, 7 skipped (was 3926 + 14 new).
- [x] Manual diagnostic against jcm itself confirms the fix:
      raw unstable 41/95 → production unstable 1/52 (the surviving
      one is `cli/cli.py`, a leaf entrypoint that's a real architectural
      finding, not a metric artifact).
- [ ] Observatory weekly run regenerates scores against patched package
      (will land automatically on the Monday cron after merge + PyPI
      publish; can be triggered manually via `gh workflow run`).