### PR TITLE
v1.92.0: coupling axis filename filter (closes #280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to jcodemunch-mcp are documented here.
 
+## [1.92.0] — 2026-05-09 — coupling axis: filename-pattern filter for inline test conventions
+
+Closes [#280](https://github.com/jgravelle/jcodemunch-mcp/issues/280).
+v1.91.0 fixed the coupling axis for projects that use a `tests/`
+directory, but left untouched ecosystems that co-locate tests with
+source: Go (`*_test.go`), TypeScript (`*.spec.ts`, `*.test.ts`),
+JavaScript (Jest/Jasmine/Karma), Ruby (RSpec), and Java (JUnit).
+The first observatory rebuild after v1.91.0 confirmed the gap:
+test-heavy Python repos moved C → B/A, but Gin, Cobra, and NestJS
+showed Δ = 0.
+
+This release adds a regex-based filename filter alongside the
+existing directory filter. `_is_production_path` now returns
+`False` for any of:
+
+- `*_test.go` — Go's standard testing convention
+- `*.test.{js,jsx,ts,tsx}` — Jest
+- `*.spec.{js,jsx,ts,tsx}` — Jasmine, Karma, Angular, NestJS
+- `*_spec.rb` — RSpec
+- `*Test.java` — JUnit (case-insensitive)
+
+### Changed
+- `tools/get_repo_health.py` introduces `_NON_PRODUCTION_FILENAME_RE`
+  alongside `_NON_PRODUCTION_DIR_NAMES`. Both filters are applied;
+  failing either drops the path from the production set.
+
+### Added
+- 16 new parametrized test cases in `TestProductionPathFilter`
+  covering each filename convention plus near-miss cases that
+  should *not* be filtered (`protest.go`, `manifest.ts`, etc.).
+
+### Out of scope
+- Inline test conventions like Rust's `#[cfg(test)] mod tests`
+  cannot be detected by path alone. Would need an AST-aware
+  approach. Open follow-up; not blocking.
+
 ## [1.91.0] — 2026-05-09 — coupling axis: exclude tests/benchmarks/scripts from the metric
 
 The coupling axis was structurally biased against well-tested

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ is a byte the agent doesn't pay to read.
 <!-- WHATSNEW:START -->
 #### What's new
 
+- **[v1.92.0](https://github.com/jgravelle/jcodemunch-mcp/releases/tag/v1.92.0)** (2026-05-09) — coupling axis: filename-pattern filter for inline test conventions
 - **[v1.91.0](https://github.com/jgravelle/jcodemunch-mcp/releases/tag/v1.91.0)** (2026-05-09) — coupling axis: exclude tests/benchmarks/scripts from the metric
 - **[v1.90.1](https://github.com/jgravelle/jcodemunch-mcp/releases/tag/v1.90.1)** (2026-05-09) — observatory: fix repo identifier in health call
-- **[v1.90.0](https://github.com/jgravelle/jcodemunch-mcp/releases/tag/v1.90.0)** (2026-05-09) — OSS code-health observatory pipeline
 <!-- WHATSNEW:END -->
 
 ![License](https://img.shields.io/badge/license-dual--use-blue)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jcodemunch-mcp"
-version = "1.91.0"
+version = "1.92.0"
 description = "Token-efficient MCP server for source code exploration via tree-sitter AST parsing"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/jcodemunch_mcp/tools/get_repo_health.py
+++ b/src/jcodemunch_mcp/tools/get_repo_health.py
@@ -15,6 +15,7 @@ tools — no logic is duplicated here.
 
 from __future__ import annotations
 
+import re
 import time
 from typing import Optional
 
@@ -48,11 +49,30 @@ _NON_PRODUCTION_DIR_NAMES = frozenset({
     "tests", "test", "benchmarks", "examples", "scripts",
 })
 
+# Filename suffixes for ecosystems that co-locate tests with source rather
+# than placing them under a tests/ directory:
+#   Go:        foo_test.go
+#   Jest:      foo.test.{js,jsx,ts,tsx}
+#   Jasmine/Karma/Angular/NestJS:  foo.spec.{js,jsx,ts,tsx}
+#   RSpec:     foo_spec.rb
+#   JUnit:     FooTest.java
+# Inline conventions like Rust's #[cfg(test)] mod tests cannot be detected
+# by path alone and are out of scope — would need an AST-aware approach.
+_NON_PRODUCTION_FILENAME_RE = re.compile(
+    r"(?:_test\.go|\.(?:test|spec)\.[jt]sx?|_spec\.rb|Test\.java)$",
+    re.IGNORECASE,
+)
+
 
 def _is_production_path(path: str) -> bool:
-    """True when no path component is a non-production directory name."""
+    """True when the path is neither under a non-production directory nor
+    a test-suffix file. See module-level constants for the exact rules."""
     norm = path.replace("\\", "/")
-    return not any(p in _NON_PRODUCTION_DIR_NAMES for p in norm.split("/"))
+    if any(p in _NON_PRODUCTION_DIR_NAMES for p in norm.split("/")):
+        return False
+    if _NON_PRODUCTION_FILENAME_RE.search(norm):
+        return False
+    return True
 
 
 def _count_unstable_modules(index) -> tuple[int, int]:

--- a/tests/test_repo_health.py
+++ b/tests/test_repo_health.py
@@ -132,6 +132,11 @@ class TestProductionPathFilter:
         "lib/utils.py",
         "src/tools/test_summarizer.py",  # tool file with "test_" prefix — keep
         "vscode-extension/src/extension.ts",
+        # Filename-suffix near-misses that should NOT be filtered:
+        "pkg/foo/protest.go",            # contains "test" but no _test.go suffix
+        "src/manifest.ts",               # no .spec/.test infix
+        "src/Foo.java",                  # no Test suffix
+        "src/foo_specifications.rb",     # _spec is part of word, not the suffix
     ])
     def test_production_paths_kept(self, path):
         assert _is_production_path(path) is True
@@ -144,6 +149,19 @@ class TestProductionPathFilter:
         "examples/demo.py",
         "src/foo/tests/test_bar.py",  # nested tests dir
         "tests\\test_foo.py",          # windows separators
+        # v1.92.0: filename-suffix conventions across ecosystems.
+        "pkg/foo/foo_test.go",                 # Go
+        "src/app/foo.service.spec.ts",         # Angular/NestJS
+        "src/app/foo.service.spec.tsx",        # TSX spec
+        "src/app/foo.test.ts",                 # Jest TS
+        "src/app/foo.test.tsx",                # Jest TSX
+        "src/app/foo.test.js",                 # Jest JS
+        "src/app/foo.test.jsx",                # Jest JSX
+        "src/app/foo.spec.js",                 # Jasmine/Karma JS
+        "src/app/foo.spec.jsx",                # Jasmine/Karma JSX
+        "spec/models/user_spec.rb",            # RSpec
+        "src/com/example/FooTest.java",        # JUnit
+        "src/app/Foo.SPEC.TS",                 # case-insensitive
     ])
     def test_non_production_paths_excluded(self, path):
         assert _is_production_path(path) is False

--- a/whatsnew.json
+++ b/whatsnew.json
@@ -1,6 +1,12 @@
 {
-  "current": "1.91.0",
+  "current": "1.92.0",
   "entries": [
+    {
+      "version": "1.92.0",
+      "date": "2026-05-09",
+      "title": "coupling axis: filename-pattern filter for inline test conventions",
+      "summary": "Closes [#280](https://github.com/jgravelle/jcodemunch-mcp/issues/280). v1.91.0 fixed the coupling axis for projects that use a `tests/` directory, but left untouched ecosystems that co-locate tests with source: Go (`*_test.go`), TypeScript (`*.spec.ts`, `*.test.ts`),"
+    },
     {
       "version": "1.91.0",
       "date": "2026-05-09",
@@ -12,12 +18,6 @@
       "date": "2026-05-09",
       "title": "observatory: fix repo identifier in health call",
       "summary": "Patch release. The 1.90.0 observatory pipeline passed the cloned repo's absolute filesystem path to `get_repo_health(repo=...)`, which then tried to parse it as `owner/name` and tripped the path- separator guard in `sqlite_store._safe_repo_component`. Every repo"
-    },
-    {
-      "version": "1.90.0",
-      "date": "2026-05-09",
-      "title": "OSS code-health observatory pipeline",
-      "summary": "todo.md item #7. New `observatory` CLI subcommand that runs an end-to-end pipeline producing **static HTML + JSON + RSS artifacts** for a curated list of OSS repos. Hosting deliberately decoupled \u2014 the output is plain static files that can serve from any host (Mac"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #280. v1.91.0 fixed the coupling axis for projects that
keep tests under a `tests/` directory, but ecosystems that
co-locate tests with source were untouched. The first observatory
rebuild after v1.91.0 confirmed the gap empirically: test-heavy
Python repos moved C → B/A, but Gin, Cobra, and NestJS showed
**Δ = 0**.

## What changed

`tools/get_repo_health.py` adds a regex-based filename filter
alongside the existing directory filter:

| Pattern | Convention |
|---|---|
| `*_test.go` | Go (standard library testing) |
| `*.test.{js,jsx,ts,tsx}` | Jest |
| `*.spec.{js,jsx,ts,tsx}` | Jasmine, Karma, Angular, NestJS |
| `*_spec.rb` | RSpec |
| `*Test.java` | JUnit (case-insensitive) |

`_is_production_path` applies both filters; failing either drops
the path from the production set. Behavior is unchanged for paths
that don't match the new patterns (e.g. existing Python codebases).

## Out of scope

- **Rust's `#[cfg(test)] mod tests`** — inline annotations can't
  be detected by path alone. Would need AST-aware analysis. Open
  follow-up; not blocking.
- **Less-universal conventions** like `*Tests.kt` (Kotlin) and
  `*Tests.cs` (.NET) — left out for now since their false-positive
  risk is higher than the patterns above. Worth a separate issue
  if a real codebase needs them.

## Score impact

Observatory scores will recompute on the next weekly run. Expected
movements based on per-repo test conventions:

| Repo | v1.91.0 | Expected |
|---|---|---|
| Gin | 84.4 (B) | likely +5 to +10 |
| Cobra | 83.4 (B) | likely +5 to +10 |
| NestJS | 76.5 (C) | likely +10 to +15 |

(Other repos may shift slightly; will know exact numbers post-merge
when the workflow rebuilds.)

## Test plan

- [x] 16 new parametrized cases in `TestProductionPathFilter`
      covering every filename convention plus near-miss cases that
      should *not* be filtered (`protest.go`, `manifest.ts`,
      `foo_specifications.rb`, `Foo.java`).
- [x] Full suite: 3956 passed, 7 skipped (was 3940 + 16 new).
- [ ] Observatory rebuild against patched package (will run on the
      Monday cron after merge + PyPI publish; can be triggered
      manually via `gh workflow run`).