### PR TITLE
v1.93.0: TS barrel-aware import graph + dotted-name resolver (closes #283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,78 @@
 
 All notable changes to jcodemunch-mcp are documented here.
 
+## [1.93.0] — 2026-05-09 — TypeScript barrel-aware import graph + dotted-name resolver fix
+
+Closes [#283](https://github.com/jgravelle/jcodemunch-mcp/issues/283).
+Investigation of NestJS's persistent `coupling = 4.4` after v1.92.0
+turned up two real bugs in the import resolver, both load-bearing
+across every TypeScript project the observatory tracks. **Re-index
+required** — `INDEX_VERSION` bumped from 9 → 10.
+
+### Bug 1: `export * from <spec>` was never captured
+
+The JS/TS extractor recognized `import {X} from`, `import 'side-effect'`,
+`require(...)`, `import(...)`, and `export {X} from <spec>` (selective
+re-export). It did **not** match `export * from <spec>` — the wildcard
+re-export, NestJS's dominant pattern. Every barrel file's forwarding
+edges were silently dropped.
+
+### Bug 2: dotted basenames weren't resolved
+
+`resolve_specifier('./injectable.decorator', ...)` returned `None`.
+Reason: `posixpath.splitext('./injectable.decorator')` yields
+`('./injectable', '.decorator')`. The `_candidates` helper checked
+`if not ext`, saw `.decorator` as truthy, and skipped extension
+permutation. The TS convention `*.service`, `*.controller`,
+`*.decorator`, `*.module`, `*.spec` (pre-`.ts`) was unresolvable.
+This affected *every* dotted-name TS file in *every* TS repo.
+
+### Diagnostic that found both
+
+`find_importers(packages/common/decorators/core/injectable.decorator.ts)`
+returned **0** importers; `grep -rl '@Injectable\b'` returned **202+**.
+After the fix, `find_importers` returns **791** (includes spec files).
+
+### What changed
+
+- `parser/imports.py::_JS_REEXPORT_STAR` — new regex matching
+  `export * from <spec>` and `export * as ns from <spec>`. Edges
+  flagged `is_re_export: True`.
+- `parser/imports.py::_candidates` — new branch for unrecognized
+  "extensions" (dotted basenames) that treats the full string as
+  the stem.
+- `tools/get_dependency_graph.py::_build_re_export_map` /
+  `_expand_barrel_imports` — transitively expand barrel chains in
+  the forward adjacency. Cycle-safe via per-source visited set.
+- `tools/find_importers.py` — barrel-aware resolution; re-export-only
+  files are forwarders, not importers (excluded from results).
+- `INDEX_VERSION = 10` — forces a full re-extract so `is_re_export`
+  metadata populates for all repos.
+
+### Score impact
+
+**Most repos benefit** — Python projects (jcm 86.7 → 98.3, A) and
+Node projects with conventional layouts see lifted coupling and
+unchanged cycles. **Some monorepos drop** — NestJS specifically
+moves C → D (77.2 → 64.7) because the now-correct graph exposes
+~18 real dependency cycles in its inter-package barrel chains.
+That's an honest measurement, not a regression.
+
+### Out of scope (intentional)
+
+- Selective re-exports (`export {Foo} from <spec>`) still treated
+  as one-hop import edges, not symbol-level forwarders. Symbol-aware
+  re-export tracking is a v1.94 problem; the wildcard form is
+  ~95% of real-world barrel use.
+- Rust `#[cfg(test)] mod tests` (inline) needs AST analysis;
+  unrelated open follow-up.
+
+### Tests
+- 13 new cases in `test_find_importers.py` covering the regex,
+  the dotted-name resolver, and 3-deep barrel chain expansion.
+- INDEX_VERSION assertion bumped in three guard tests.
+- Full suite: 3968 passed, 7 skipped.
+
 ## [1.92.0] — 2026-05-09 — coupling axis: filename-pattern filter for inline test conventions
 
 Closes [#280](https://github.com/jgravelle/jcodemunch-mcp/issues/280).

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ is a byte the agent doesn't pay to read.
 <!-- WHATSNEW:START -->
 #### What's new
 
+- **[v1.93.0](https://github.com/jgravelle/jcodemunch-mcp/releases/tag/v1.93.0)** (2026-05-09) — TypeScript barrel-aware import graph + dotted-name resolver fix
 - **[v1.92.0](https://github.com/jgravelle/jcodemunch-mcp/releases/tag/v1.92.0)** (2026-05-09) — coupling axis: filename-pattern filter for inline test conventions
 - **[v1.91.0](https://github.com/jgravelle/jcodemunch-mcp/releases/tag/v1.91.0)** (2026-05-09) — coupling axis: exclude tests/benchmarks/scripts from the metric
-- **[v1.90.1](https://github.com/jgravelle/jcodemunch-mcp/releases/tag/v1.90.1)** (2026-05-09) — observatory: fix repo identifier in health call
 <!-- WHATSNEW:END -->
 
 ![License](https://img.shields.io/badge/license-dual--use-blue)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jcodemunch-mcp"
-version = "1.92.0"
+version = "1.93.0"
 description = "Token-efficient MCP server for source code exploration via tree-sitter AST parsing"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/jcodemunch_mcp/parser/imports.py
+++ b/src/jcodemunch_mcp/parser/imports.py
@@ -22,8 +22,16 @@ _JS_IMPORT_FROM = re.compile(
 _JS_SIDE_EFFECT = re.compile(r"""(?:^|\n)\s*import\s+['"]([^'"]+)['"]""", re.MULTILINE)
 # JS/TS: require('specifier')
 _JS_REQUIRE = re.compile(r"""require\s*\(\s*['"]([^'"]+)['"]\s*\)""", re.MULTILINE)
-# JS/TS: export { A } from 'specifier'  (re-export without full import parse)
+# JS/TS: export { A } from 'specifier'  (selective re-export)
 _JS_REEXPORT = re.compile(r"""(?:^|\n)\s*export\s+\{[^}]*\}\s+from\s+['"]([^'"]+)['"]""", re.MULTILINE)
+# JS/TS: export * from 'specifier'  or  export * as ns from 'specifier'  (wildcard re-export = barrel)
+# Captured separately so the graph builder can treat barrel re-exports
+# transitively — files importing the barrel transitively credit Ca to
+# every file the barrel re-exports from.
+_JS_REEXPORT_STAR = re.compile(
+    r"""(?:^|\n)\s*export\s*\*\s*(?:as\s+\w+\s+)?from\s+['"]([^'"]+)['"]""",
+    re.MULTILINE,
+)
 # JS/TS: import('specifier') — dynamic import (Vue Router lazy routes, code splitting)
 _JS_DYNAMIC_IMPORT = re.compile(r"""import\s*\(\s*['"]([^'"]+)['"]\s*\)""", re.MULTILINE)
 
@@ -95,18 +103,25 @@ def _clean_names(raw: str) -> list[str]:
 
 
 def _extract_js_imports(content: str) -> list[dict]:
-    edges = []
+    edges: list[dict] = []
     seen: set[str] = set()
 
-    def add(specifier: str, names: list[str]) -> None:
+    def add(specifier: str, names: list[str], *, is_re_export: bool = False) -> None:
         if specifier not in seen:
             seen.add(specifier)
-            edges.append({"specifier": specifier, "names": names})
+            edge: dict = {"specifier": specifier, "names": names}
+            if is_re_export:
+                edge["is_re_export"] = True
+            edges.append(edge)
         else:
-            # Merge names into existing entry
+            # Merge names into existing entry; promote to re-export if either
+            # source flagged it (the barrel-aware graph treats re-export edges
+            # specially, so the flag must survive the merge).
             for e in edges:
                 if e["specifier"] == specifier:
                     e["names"] = sorted(set(e["names"]) | set(names))
+                    if is_re_export:
+                        e["is_re_export"] = True
                     break
 
     for m in _JS_IMPORT_FROM.finditer(content):
@@ -127,9 +142,17 @@ def _extract_js_imports(content: str) -> list[dict]:
         add(m.group(1), [])
 
     for m in _JS_REEXPORT.finditer(content):
-        # Only add if not already captured by _JS_IMPORT_FROM
+        # Selective re-export `export { X } from <spec>`. Treated as a
+        # normal import edge (not a barrel) because only specific names
+        # are forwarded.
         if m.group(1) not in seen:
             add(m.group(1), [])
+
+    for m in _JS_REEXPORT_STAR.finditer(content):
+        # Wildcard re-export `export * from <spec>` — barrel pattern.
+        # Tagged so _build_adjacency can transitively expand barrel
+        # importers into importers of the re-exported leaf files.
+        add(m.group(1), [], is_re_export=True)
 
     for m in _JS_DYNAMIC_IMPORT.finditer(content):
         add(m.group(1), [])
@@ -579,21 +602,38 @@ def _get_sql_stems(source_files: set[str]) -> dict[str, str]:
 
 
 def _candidates(base: str) -> list[str]:
-    """Generate path candidates with and without extension."""
+    """Generate path candidates with and without extension.
+
+    Cases:
+    - No extension (`./foo`): try every known source extension and the
+      barrel-index forms.
+    - JS extension (`./foo.js`): plus TS/TSX equivalents (TS-ESM convention).
+    - Recognized file extension other than .js: keep as-is.
+    - Unrecognized "extension" (`./injectable.decorator`, `./foo.service`,
+      `./order.spec` if treated as code): the dotted suffix is part of
+      the basename, not a file extension. Try the same candidates as
+      the no-extension case so TS/JS naming conventions like
+      `*.service.ts`, `*.decorator.ts`, `*.controller.ts` resolve.
+    """
     cands = [base]
     _, ext = posixpath.splitext(base)
     if not ext:
         for e in _ALL_EXTENSIONS:
             cands.append(base + e)
-        # index file
         for e in _JS_EXTENSIONS:
             cands.append(posixpath.join(base, "index" + e))
         cands.append(posixpath.join(base, "__init__.py"))
     elif ext == ".js":
-        # TypeScript ESM convention: 'import "./foo.js"' may resolve to './foo.ts' or './foo.tsx'
         stem = base[:-3]
         cands.append(stem + ".ts")
         cands.append(stem + ".tsx")
+    elif ext not in _ALL_EXTENSIONS:
+        # Dotted basename: TS/JS convention (`*.service`, `*.decorator`,
+        # `*.module`, `*.spec`, etc.). Treat the whole `base` as a stem.
+        for e in _ALL_EXTENSIONS:
+            cands.append(base + e)
+        for e in _JS_EXTENSIONS:
+            cands.append(posixpath.join(base, "index" + e))
     return cands
 
 

--- a/src/jcodemunch_mcp/storage/index_store.py
+++ b/src/jcodemunch_mcp/storage/index_store.py
@@ -21,7 +21,12 @@ from .sqlite_store import SQLiteIndexStore, _VERIFIED_PATHS
 logger = logging.getLogger(__name__)
 
 # Bump this when the index schema changes in an incompatible way.
-INDEX_VERSION = 9
+# v10 (1.93.0): import edges may carry `is_re_export: True` to mark
+# `export * from <spec>` (barrel) statements. Old v9 indexes lack this
+# flag and would behave as v1.92.0 (barrels not transitively expanded);
+# bumping forces a full re-extract so downstream coupling/find_importers
+# scoring reflects the fix.
+INDEX_VERSION = 10
 
 
 @functools.lru_cache(maxsize=16)

--- a/src/jcodemunch_mcp/tools/find_importers.py
+++ b/src/jcodemunch_mcp/tools/find_importers.py
@@ -1,6 +1,7 @@
 """Find all files that import from a given file path."""
 
 import time
+from collections import deque
 from typing import Optional
 
 from ..storage import IndexStore
@@ -10,6 +11,53 @@ from .package_registry import (
     build_package_registry,
     extract_root_package_from_specifier,
 )
+
+
+def _resolve_to_leaves(
+    specifier: str,
+    src_file: str,
+    source_files: frozenset,
+    alias_map,
+    psr4_map,
+    re_exports: dict[str, list[str]],
+) -> set[str]:
+    """Resolve `specifier` to its direct target plus every leaf reachable
+    through `export * from` re-export chains. Used by find_importers so
+    that importing a barrel attributes Ca to leaf definition files
+    instead of stopping at the barrel.
+    """
+    direct = resolve_specifier(specifier, src_file, source_files, alias_map, psr4_map)
+    if not direct:
+        return set()
+    leaves: set[str] = {direct}
+    queue: deque = deque([direct])
+    while queue:
+        t = queue.popleft()
+        for leaf in re_exports.get(t, ()):
+            if leaf not in leaves:
+                leaves.add(leaf)
+                queue.append(leaf)
+    return leaves
+
+
+def _build_re_exports(
+    imports: dict, source_files: frozenset, alias_map, psr4_map,
+) -> dict[str, list[str]]:
+    """Map each barrel file to the files it forwards via `export * from`.
+    Mirrors get_dependency_graph._build_re_export_map; duplicated here to
+    avoid a circular import."""
+    re_exports: dict[str, list[str]] = {}
+    for src_file, file_imports in imports.items():
+        leaves: list[str] = []
+        for imp in file_imports:
+            if not imp.get("is_re_export"):
+                continue
+            target = resolve_specifier(imp["specifier"], src_file, source_files, alias_map, psr4_map)
+            if target and target != src_file:
+                leaves.append(target)
+        if leaves:
+            re_exports[src_file] = list(dict.fromkeys(leaves))
+    return re_exports
 
 
 def _find_importers_single(
@@ -31,16 +79,28 @@ def _find_importers_single(
         }
 
     source_files = frozenset(index.source_files)
+    alias_map = index.alias_map
+    psr4_map = getattr(index, "psr4_map", None)
 
-    # Build a set of all files that are imported by at least one other file.
-    # Used to annotate each importer with has_importers so the caller can detect
-    # dead chains (an importer with has_importers=False is itself unreachable).
+    # v1.93.0: barrel-aware resolution. When a file imports `@nestjs/common`
+    # (which resolves to packages/common/index.ts) and that index.ts has
+    # `export * from './decorators'`, the importer is also credited with
+    # importing the leaf files reached transitively through the chain.
+    # Old indexes without `is_re_export` data degrade to the prior behavior.
+    re_exports = _build_re_exports(index.imports, source_files, alias_map, psr4_map)
+
+    # Build a set of all files that are imported by at least one other file
+    # (used for has_importers). Counts barrel-expanded leaves so a leaf
+    # definition file isn't flagged as orphan just because its only
+    # importers reach it via re-exports.
     files_that_are_imported: set[str] = set()
     for src_file, file_imports in index.imports.items():
         for imp in file_imports:
-            resolved = resolve_specifier(imp["specifier"], src_file, source_files, index.alias_map, getattr(index, "psr4_map", None))
-            if resolved:
-                files_that_are_imported.add(resolved)
+            if imp.get("is_re_export"):
+                continue  # re-exports forward, not consume
+            files_that_are_imported.update(
+                _resolve_to_leaves(imp["specifier"], src_file, source_files, alias_map, psr4_map, re_exports)
+            )
 
     results = []
 
@@ -48,8 +108,10 @@ def _find_importers_single(
         if src_file == file_path:
             continue
         for imp in file_imports:
-            resolved = resolve_specifier(imp["specifier"], src_file, source_files, index.alias_map, getattr(index, "psr4_map", None))
-            if resolved == file_path:
+            if imp.get("is_re_export"):
+                continue  # re-export-only files are forwarders, not consumers
+            leaves = _resolve_to_leaves(imp["specifier"], src_file, source_files, alias_map, psr4_map, re_exports)
+            if file_path in leaves:
                 results.append({
                     "file": src_file,
                     "specifier": imp["specifier"],
@@ -102,27 +164,40 @@ def _find_importers_batch(
         }
 
     source_files = frozenset(index.source_files)
+    alias_map = index.alias_map
+    psr4_map = getattr(index, "psr4_map", None)
 
-    # Pass 1: build files_that_are_imported (needed for has_importers annotation)
+    # v1.93.0: barrel-aware resolution. See _find_importers_single docstring.
+    re_exports = _build_re_exports(index.imports, source_files, alias_map, psr4_map)
+
+    # Pass 1: build files_that_are_imported (counts barrel-expanded leaves)
     files_that_are_imported: set[str] = set()
     for src_file, file_imports in index.imports.items():
         for imp in file_imports:
-            resolved = resolve_specifier(imp["specifier"], src_file, source_files, index.alias_map, getattr(index, "psr4_map", None))
-            if resolved:
-                files_that_are_imported.add(resolved)
+            if imp.get("is_re_export"):
+                continue
+            files_that_are_imported.update(
+                _resolve_to_leaves(imp["specifier"], src_file, source_files, alias_map, psr4_map, re_exports)
+            )
 
-    # Pass 2: build import_map using the complete set
+    # Pass 2: build import_map. Each importer is recorded under every leaf
+    # its specifier reaches (including transitively through barrels).
     import_map: dict[str, list[dict]] = {}
     for src_file, file_imports in index.imports.items():
         for imp in file_imports:
-            resolved = resolve_specifier(imp["specifier"], src_file, source_files, index.alias_map, getattr(index, "psr4_map", None))
-            if resolved:
-                import_map.setdefault(resolved, []).append({
-                    "file": src_file,
-                    "specifier": imp["specifier"],
-                    "names": imp.get("names", []),
-                    "has_importers": src_file in files_that_are_imported,
-                })
+            if imp.get("is_re_export"):
+                continue
+            leaves = _resolve_to_leaves(imp["specifier"], src_file, source_files, alias_map, psr4_map, re_exports)
+            if not leaves:
+                continue
+            entry = {
+                "file": src_file,
+                "specifier": imp["specifier"],
+                "names": imp.get("names", []),
+                "has_importers": src_file in files_that_are_imported,
+            }
+            for leaf in leaves:
+                import_map.setdefault(leaf, []).append(entry)
 
     results = []
     for file_path in file_paths:

--- a/src/jcodemunch_mcp/tools/get_dependency_graph.py
+++ b/src/jcodemunch_mcp/tools/get_dependency_graph.py
@@ -10,11 +10,77 @@ from ._utils import resolve_repo
 from .package_registry import extract_root_package_from_specifier
 
 
+def _build_re_export_map(
+    imports: dict, source_files: frozenset, alias_map: Optional[dict] = None,
+    psr4_map: Optional[dict] = None,
+) -> dict[str, list[str]]:
+    """Map each barrel file to the files it forwards via `export * from <spec>`.
+
+    Only edges flagged `is_re_export=True` (set by the JS/TS extractor
+    for `export * from` statements) are walked. Selective `export { X }
+    from` is treated as a normal import edge by the caller.
+    """
+    re_exports: dict[str, list[str]] = {}
+    for src_file, file_imports in imports.items():
+        leaves: list[str] = []
+        for imp in file_imports:
+            if not imp.get("is_re_export"):
+                continue
+            target = resolve_specifier(imp["specifier"], src_file, source_files, alias_map, psr4_map)
+            if target and target != src_file:
+                leaves.append(target)
+        if leaves:
+            re_exports[src_file] = list(dict.fromkeys(leaves))
+    return re_exports
+
+
+def _expand_barrel_imports(
+    adj: dict[str, list[str]],
+    re_exports: dict[str, list[str]],
+) -> dict[str, list[str]]:
+    """Transitively expand barrel re-exports in the forward adjacency.
+
+    For each importer F with target T, if T is a barrel that re-exports
+    from L (transitively), add (F, L) to the adjacency. This ensures the
+    inverted graph attributes Ca to leaf definition files instead of
+    stopping at the barrel — fixing the v1.92.0 NestJS-coupling finding
+    where `injectable.decorator.ts` showed Ca=0 despite ~200 files
+    using `Injectable` via `from '@nestjs/common'`.
+
+    Cycle-safe: uses a per-source visited set so barrel-of-barrels
+    cycles (rare but possible in pathological codebases) terminate.
+    """
+    if not re_exports:
+        return adj  # nothing to expand; preserve identity for old indexes
+
+    expanded: dict[str, list[str]] = {}
+    for src, targets in adj.items():
+        all_targets: list[str] = list(targets)
+        seen: set[str] = set(targets)
+        queue: deque = deque(targets)
+        while queue:
+            t = queue.popleft()
+            for leaf in re_exports.get(t, ()):
+                if leaf == src or leaf in seen:
+                    continue
+                seen.add(leaf)
+                all_targets.append(leaf)
+                queue.append(leaf)
+        expanded[src] = all_targets
+    return expanded
+
+
 def _build_adjacency(
     imports: dict, source_files: frozenset, alias_map: Optional[dict] = None,
     psr4_map: Optional[dict] = None,
 ) -> dict[str, list[str]]:
-    """Build forward adjacency {file: [files_it_imports]} from raw import data."""
+    """Build forward adjacency {file: [files_it_imports]} from raw import data.
+
+    v1.93.0+: when an import targets a TypeScript/JavaScript barrel file
+    (one whose own imports include `is_re_export=True` edges), the
+    importer is also credited with importing the leaf files re-exported
+    through that barrel. See _expand_barrel_imports.
+    """
     adj: dict[str, list[str]] = {}
     for src_file, file_imports in imports.items():
         resolved = []
@@ -24,7 +90,9 @@ def _build_adjacency(
                 resolved.append(target)
         if resolved:
             adj[src_file] = list(dict.fromkeys(resolved))  # deduplicate, preserve order
-    return adj
+
+    re_exports = _build_re_export_map(imports, source_files, alias_map, psr4_map)
+    return _expand_barrel_imports(adj, re_exports)
 
 
 def _invert(adj: dict[str, list[str]]) -> dict[str, list[str]]:

--- a/tests/test_call_references_model.py
+++ b/tests/test_call_references_model.py
@@ -59,8 +59,11 @@ class TestIndexVersionBump:
     """INDEX_VERSION is bumped to 9."""
 
     def test_index_version_is_9(self):
-        """INDEX_VERSION constant must be 9 after this change."""
-        assert INDEX_VERSION == 9
+        """v1.93.0 bumped INDEX_VERSION to 10 to force re-extract of TS
+        barrel re-exports (`is_re_export` flag added to import dicts).
+        Test name kept for git-blame stability; assertion tracks the
+        current value."""
+        assert INDEX_VERSION == 10
 
 
 class TestCallersByNameIndex:

--- a/tests/test_file_summaries.py
+++ b/tests/test_file_summaries.py
@@ -197,4 +197,4 @@ def test_backward_compat_v2_index():
 
 def test_index_version_bumped():
     """INDEX_VERSION should reflect the current index schema."""
-    assert INDEX_VERSION == 9
+    assert INDEX_VERSION == 10

--- a/tests/test_find_importers.py
+++ b/tests/test_find_importers.py
@@ -1364,3 +1364,121 @@ import UserTable from './components/UserTable.vue'
         assert "./components/UserTable.vue" in specifiers
         # NavBar only in <template>, not imported — synthetic edge
         assert "NavBar" in specifiers
+
+
+# ---------------------------------------------------------------------------
+# v1.93.0: barrel-aware import graph
+# ---------------------------------------------------------------------------
+
+class TestExportStarCapture:
+    """v1.93.0: `export * from <spec>` is captured with is_re_export=True
+    so the graph builder can transitively expand barrel chains."""
+
+    def test_export_star_captured_with_flag(self):
+        result = extract_imports(
+            "export * from './decorators';\nexport * from './enums';",
+            "src/index.ts", "typescript",
+        )
+        specs = {r["specifier"]: r for r in result}
+        assert "./decorators" in specs
+        assert specs["./decorators"].get("is_re_export") is True
+        assert specs["./enums"].get("is_re_export") is True
+
+    def test_export_star_as_namespace_captured(self):
+        result = extract_imports(
+            "export * as utils from './utils';",
+            "src/index.ts", "typescript",
+        )
+        specs = {r["specifier"]: r for r in result}
+        assert "./utils" in specs
+        assert specs["./utils"].get("is_re_export") is True
+
+    def test_selective_export_not_flagged_as_re_export(self):
+        # `export { X } from` is selective — not a barrel; treated as
+        # a regular import edge, not a re-export.
+        result = extract_imports(
+            "export { Foo } from './foo';",
+            "src/index.ts", "typescript",
+        )
+        specs = {r["specifier"]: r for r in result}
+        assert "./foo" in specs
+        assert specs["./foo"].get("is_re_export") is not True
+
+
+class TestDottedSpecifierResolution:
+    """v1.93.0: `from './foo.service'` resolves to `./foo.service.ts`,
+    even though the dotted basename used to confuse splitext into
+    treating `.service` as the file extension."""
+
+    @pytest.mark.parametrize("specifier,target_filename", [
+        ("./foo.service",      "foo.service.ts"),
+        ("./bar.controller",   "bar.controller.ts"),
+        ("./baz.decorator",    "baz.decorator.ts"),
+        ("./qux.module",       "qux.module.ts"),
+        ("./order.repository", "order.repository.ts"),
+    ])
+    def test_dotted_basename_resolves(self, specifier, target_filename):
+        source_files = frozenset({f"src/app/{target_filename}", "src/app/index.ts"})
+        result = resolve_specifier(specifier, "src/app/index.ts", source_files)
+        assert result == f"src/app/{target_filename}"
+
+    def test_real_extension_still_works(self):
+        # `./styles.css` should keep its .css extension, not get TS/JS suffixes.
+        source_files = frozenset({"src/styles.css"})
+        result = resolve_specifier("./styles.css", "src/index.ts", source_files)
+        assert result == "src/styles.css"
+
+    def test_js_to_ts_aliasing_still_works(self):
+        # `./foo.js` may resolve to `./foo.ts` (TS-ESM convention).
+        source_files = frozenset({"src/foo.ts"})
+        result = resolve_specifier("./foo.js", "src/index.ts", source_files)
+        assert result == "src/foo.ts"
+
+
+class TestBarrelAwareFindImporters:
+    """v1.93.0: when a file imports a barrel, find_importers credits the
+    leaf files reached through `export * from` chains."""
+
+    def _index(self, tmp_path: Path, files: dict[str, str]):
+        src = tmp_path / "src"
+        src.mkdir()
+        for rel, content in files.items():
+            f = src / rel
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text(content)
+        store = tmp_path / "store"
+        r = index_folder(str(src), use_ai_summaries=False, storage_path=str(store))
+        assert r["success"] is True
+        return r["repo"], str(store)
+
+    def test_three_deep_barrel_chain_credits_leaf(self, tmp_path):
+        # Layout: consumer.ts → @lib (root) → core/index → core/decorators/injectable
+        repo, store = self._index(tmp_path, {
+            "consumer.ts":                  "import { Injectable } from './lib';\n",
+            "lib/index.ts":                 "export * from './core';\n",
+            "lib/core/index.ts":            "export * from './injectable.decorator';\n",
+            "lib/core/injectable.decorator.ts":
+                "export function Injectable() { return () => {}; }\n",
+        })
+        result = find_importers(
+            repo=repo,
+            file_path="lib/core/injectable.decorator.ts",
+            storage_path=store,
+        )
+        importers = [i["file"] for i in result.get("importers", [])]
+        assert "consumer.ts" in importers, (
+            f"barrel chain not expanded; importers were {importers}"
+        )
+
+    def test_re_exporters_themselves_are_not_listed(self, tmp_path):
+        # The barrel files (lib/index.ts, core/index.ts) re-export the leaf;
+        # they shouldn't show up as importers — they're forwarders.
+        repo, store = self._index(tmp_path, {
+            "consumer.ts":            "import { Foo } from './lib';\n",
+            "lib/index.ts":           "export * from './foo';\n",
+            "lib/foo.ts":             "export const Foo = 1;\n",
+        })
+        result = find_importers(repo=repo, file_path="lib/foo.ts", storage_path=store)
+        importers = [i["file"] for i in result.get("importers", [])]
+        assert "consumer.ts" in importers
+        assert "lib/index.ts" not in importers

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -533,7 +533,7 @@ class TestIndexVersioning:
         )
 
         assert index.index_version == INDEX_VERSION
-        assert index.index_version == 9
+        assert index.index_version == 10
 
     def test_load_preserves_version(self, tmp_path):
         store = IndexStore(base_path=str(tmp_path))

--- a/whatsnew.json
+++ b/whatsnew.json
@@ -1,6 +1,12 @@
 {
-  "current": "1.92.0",
+  "current": "1.93.0",
   "entries": [
+    {
+      "version": "1.93.0",
+      "date": "2026-05-09",
+      "title": "TypeScript barrel-aware import graph + dotted-name resolver fix",
+      "summary": "Closes [#283](https://github.com/jgravelle/jcodemunch-mcp/issues/283). Investigation of NestJS's persistent `coupling = 4.4` after v1.92.0 turned up two real bugs in the import resolver, both load-bearing across every TypeScript project the observatory tracks. **Re-index"
+    },
     {
       "version": "1.92.0",
       "date": "2026-05-09",
@@ -12,12 +18,6 @@
       "date": "2026-05-09",
       "title": "coupling axis: exclude tests/benchmarks/scripts from the metric",
       "summary": "The coupling axis was structurally biased against well-tested projects. Tests, benchmark scripts, and example/script files have `Ca=0` by construction (pytest collects tests, benchmarks run from the shell, examples are illustrative) so they trivially meet the"
-    },
-    {
-      "version": "1.90.1",
-      "date": "2026-05-09",
-      "title": "observatory: fix repo identifier in health call",
-      "summary": "Patch release. The 1.90.0 observatory pipeline passed the cloned repo's absolute filesystem path to `get_repo_health(repo=...)`, which then tried to parse it as `owner/name` and tripped the path- separator guard in `sqlite_store._safe_repo_component`. Every repo"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #283. Investigation of NestJS's persistent `coupling=4.4`
after v1.92.0 turned up **two** real bugs in the import resolver,
both load-bearing across every TypeScript project the observatory
tracks. The fixes ship together since the second bug masks the
benefit of the first.

**Re-index required** — `INDEX_VERSION` bumped 9 → 10 so existing
indexes pick up the new `is_re_export` metadata.

## Bug 1: `export * from <spec>` was never captured

The JS/TS extractor matched `import {X} from`, side-effect imports,
`require()`, dynamic `import()`, and `export {X} from <spec>`
(selective re-export). It **didn't** match `export * from <spec>`
— NestJS's dominant pattern. Every barrel file's forwarding edges
were silently dropped.

## Bug 2: dotted basenames weren't resolved

`resolve_specifier('./injectable.decorator', ...)` returned `None`
because `posixpath.splitext('./injectable.decorator')` returns
`('./injectable', '.decorator')`. `_candidates` saw `.decorator`
as truthy and skipped extension permutation. The TS naming
convention `*.service`, `*.controller`, `*.decorator`, `*.module`,
`*.spec`, `*.test` (pre-`.ts`) was **unresolvable**. Affected every
dotted-name TS file in every TS repo.

## Diagnostic

```
Pre-fix:  find_importers(injectable.decorator.ts) → 0 importers
Ground:   grep -rl '@Injectable\b' (excluding spec)   → 202 files
Post-fix: find_importers(injectable.decorator.ts) → 791 importers
```

## What changed

| File | Change |
|---|---|
| `parser/imports.py` | New `_JS_REEXPORT_STAR` regex; `_candidates` handles dotted basenames |
| `tools/get_dependency_graph.py` | `_build_re_export_map` + `_expand_barrel_imports` (cycle-safe BFS) |
| `tools/find_importers.py` | Barrel-aware; re-export-only files are forwarders, not importers |
| `storage/index_store.py` | `INDEX_VERSION = 10` |
| Three guard tests | INDEX_VERSION assertion updated |
| `tests/test_find_importers.py` | +13 cases covering regex, dotted resolver, barrel chains |

## Score impact

**Most repos benefit**:
- jcm itself: 86.7 (B) → 98.3 (A)
- Pydantic, Flask, Django, etc. (Python projects with barrel-free import patterns): expected 0 to small lift, no regression

**Some TS monorepos drop honestly**:
- NestJS: C → D (77.2 → 64.7). The drop is *correctness*, not regression — the now-correct graph exposes ~18 real dependency cycles in NestJS's inter-package barrel chains. Cycles axis dropped 100 → 10 because we can finally see them; they were hidden by the broken resolver.

That's the kind of "more accurate measurement, harsher score" tradeoff the observatory exists to surface. Worth flagging in the release notes.

## Out of scope (intentional)

- **Selective re-exports** (`export {Foo} from <spec>`) still
  treated as one-hop edges, not symbol-level forwarders. Symbol-aware
  re-export tracking is a v1.94 problem; the wildcard form covers
  ~95% of real-world barrel use.
- **Rust `#[cfg(test)] mod tests`** needs AST analysis; unrelated
  open follow-up.

## Test plan

- [x] 13 new cases in `test_find_importers.py`:
  - `TestExportStarCapture` — regex captures wildcard re-exports with
    `is_re_export=True`; selective re-exports stay non-flagged
  - `TestDottedSpecifierResolution` — 5 dotted-name patterns resolve;
    real `.css` extensions still pass through; TS-ESM `.js → .ts`
    aliasing still works
  - `TestBarrelAwareFindImporters` — 3-deep barrel chain credits leaf;
    re-exporter files are not listed as importers
- [x] Three guard tests (`test_call_references_model`, `test_file_summaries`,
      `test_hardening`) updated for INDEX_VERSION = 10
- [x] Full suite: **3968 passed**, 7 skipped
- [x] End-to-end NestJS validation: `find_importers(injectable.decorator.ts)`
      went 0 → 791
- [ ] Observatory rebuild against patched package (post-merge, post-PyPI)