### PR TITLE
fix: allow OpenRouter managed endpoint and update default model

### DIFF
--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -1639,7 +1639,7 @@ def generate_template() -> str:
   // Leave empty ("") to use the provider's default model.
   // Examples: "claude-haiku-4-5-20251001" (anthropic), "gemini-2.5-flash-lite" (gemini),
   //           "gpt-4o-mini" (openai), "minimax-m2.7" (minimax), "glm-5" (glm),
-  //           "meta-llama/llama-3.3-70b-instruct:free" (openrouter)
+  //           "nvidia/nemotron-3-nano-30b-a3b:free" (openrouter)
   // "summarizer_model": "",
   // "embed_model": "",
   //   Sentence-transformers model name for local (free) semantic embeddings.

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -5084,7 +5084,7 @@ def _run_config(check: bool = False, init: bool = False, upgrade: bool = False) 
         suffix = "JCODEMUNCH_SUMMARIZER_PROVIDER=openrouter" if provider == "openrouter" else "OPENROUTER_API_KEY set"
         print(f"  Active provider:  {green('OpenRouter')}  ({suffix})")
         row("  OPENAI_API_BASE", "https://openrouter.ai/api/v1", "default")
-        row("  OPENAI_MODEL", "meta-llama/llama-3.3-70b-instruct:free", "default")
+        row("  OPENAI_MODEL", "nvidia/nemotron-3-nano-30b-a3b:free", "default")
     elif provider == "none":
         print(f"  Active provider:  {yellow('none')} — explicitly disabled, signature fallback active")
     else:

--- a/src/jcodemunch_mcp/summarizer/batch_summarize.py
+++ b/src/jcodemunch_mcp/summarizer/batch_summarize.py
@@ -14,6 +14,12 @@ from ..parser.symbols import Symbol
 logger = logging.getLogger(__name__)
 
 _LOCALHOST_HOSTS = {"127.0.0.1", "localhost", "::1", "[::1]"}
+_MANAGED_OPENAI_COMPAT_BASES = {
+    "https://api.openai.com/v1",
+    "https://api.minimax.io/v1",
+    "https://api.z.ai/api/paas/v4",
+    "https://openrouter.ai/api/v1",
+}
 _AUTO_DETECT_ORDER = [
     ("ANTHROPIC_API_KEY", "anthropic"),
     ("GOOGLE_API_KEY", "gemini"),
@@ -32,6 +38,11 @@ def _is_localhost_url(url: str) -> bool:
         return parsed.hostname in _LOCALHOST_HOSTS
     except Exception:
         return False
+
+
+def _is_managed_openai_compat_url(url: str) -> bool:
+    """Return True for built-in hosted OpenAI-compatible provider endpoints."""
+    return url.rstrip("/").lower() in _MANAGED_OPENAI_COMPAT_BASES
 
 
 def extract_summary_from_docstring(docstring: str) -> str:
@@ -388,9 +399,13 @@ class OpenAIBatchSummarizer(BaseSummarizer):
         self.api_base = api_base.rstrip("/") if api_base else None
         if self.api_base:
             # Strip trailing slash if present
-            # Security: restrict to localhost unless explicitly overridden
+            # Security: restrict custom remote endpoints unless explicitly overridden.
             allow_remote = _config.get("allow_remote_summarizer", False)
-            if not _is_localhost_url(self.api_base) and not allow_remote:
+            if (
+                not _is_localhost_url(self.api_base)
+                and not _is_managed_openai_compat_url(self.api_base)
+                and not allow_remote
+            ):
                 logger.warning(
                     "OPENAI_API_BASE points to non-localhost URL (%s). "
                     "Ignoring for security. Set JCODEMUNCH_ALLOW_REMOTE_SUMMARIZER=1 to allow.",
@@ -647,7 +662,7 @@ def _create_summarizer() -> Optional[BaseSummarizer]:
             s = _make_openai_compat(
                 api_key=os.environ.get("OPENROUTER_API_KEY"),
                 base_url="https://openrouter.ai/api/v1",
-                model=model_override or "meta-llama/llama-3.3-70b-instruct:free",
+                model=model_override or "nvidia/nemotron-3-nano-30b-a3b:free",
             )
         except ValueError:
             return None

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -777,7 +777,7 @@ def test_openai_summarizer_openrouter_provider_defaults():
             _cfg_module._GLOBAL_CONFIG["allow_remote_summarizer"] = True
             with patch.object(OpenAIBatchSummarizer, "_init_client"):
                 summarizer = OpenAIBatchSummarizer(
-                    model="meta-llama/llama-3.3-70b-instruct:free",
+                    model="nvidia/nemotron-3-nano-30b-a3b:free",
                     api_base="https://openrouter.ai/api/v1",
                     api_key="test-key",
                 )
@@ -803,7 +803,7 @@ def test_openai_summarizer_openrouter_provider_defaults():
 
     mock_client.post.assert_called_once()
     assert mock_client.post.call_args[0][0] == "https://openrouter.ai/api/v1/chat/completions"
-    assert mock_client.post.call_args[1]["json"]["model"] == "meta-llama/llama-3.3-70b-instruct:free"
+    assert mock_client.post.call_args[1]["json"]["model"] == "nvidia/nemotron-3-nano-30b-a3b:free"
     assert symbols[0].summary == "Uses the OpenRouter endpoint."
 
 
@@ -983,6 +983,32 @@ def test_create_summarizer_auto_mode_detects_provider(monkeypatch):
     assert s is not None
     assert isinstance(s, OpenAIBatchSummarizer)
     assert s.model == "glm-5"
+
+
+def test_create_summarizer_openrouter_managed_endpoint_allowed_without_override(monkeypatch):
+    """OpenRouter should initialize without the remote override because it uses a managed endpoint."""
+    for key in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "OPENAI_API_BASE", "MINIMAX_API_KEY", "ZHIPUAI_API_KEY", "OPENROUTER_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    def fake_init_client(self):
+        self.client = object()
+
+    with patch.object(OpenAIBatchSummarizer, "_init_client", fake_init_client), patch(
+        "jcodemunch_mcp.summarizer.batch_summarize._config.get",
+        side_effect=lambda k, d=None: (
+            "auto" if k == "use_ai_summaries"
+            else "" if k == "summarizer_model"
+            else False if k == "allow_remote_summarizer"
+            else d
+        ),
+    ):
+        s = _create_summarizer()
+
+    assert s is not None
+    assert isinstance(s, OpenAIBatchSummarizer)
+    assert s.api_base == "https://openrouter.ai/api/v1"
+    assert s.model == "nvidia/nemotron-3-nano-30b-a3b:free"
 
 
 def test_create_summarizer_model_override_applied_to_glm(monkeypatch):


### PR DESCRIPTION
## Summary

- treat the built-in OpenRouter base URL as a managed OpenAI-compatible endpoint instead of blocking it as a generic remote URL
- switch the default OpenRouter summarizer model to `nvidia/nemotron-3-nano-30b-a3b:free`
- align the config output and regression tests with the new default behavior

## Why

OpenRouter provider detection already worked, but summarizer initialization still failed because the built-in OpenRouter endpoint was handled like an arbitrary remote `OPENAI_API_BASE`. That caused `test_summarizer` to report a misconfigured provider even when `OPENROUTER_API_KEY` was present.

Once that path was fixed, the previous default OpenRouter model was also a poor fit for this summary-generation workflow. The new default is faster and produced valid summaries in the local diagnostic path.

## What

- allow the built-in OpenRouter endpoint through the OpenAI-compatible safety gate without requiring `allow_remote_summarizer`
- keep the remote override requirement for custom non-managed endpoints
- change the OpenRouter default summarizer model to `nvidia/nemotron-3-nano-30b-a3b:free`
- update status output, config template text, and OpenRouter regression coverage

## Before and After

| Area | Before | After |
| --- | --- | --- |
| OpenRouter initialization | Built-in OpenRouter endpoint could be rejected as a non-local remote URL | Built-in OpenRouter endpoint is treated as a managed provider endpoint |
| Remote override requirement | OpenRouter could require `allow_remote_summarizer` even for the built-in base URL | Only custom remote endpoints require `allow_remote_summarizer` |
| Default OpenRouter model | `meta-llama/llama-3.3-70b-instruct:free` | `nvidia/nemotron-3-nano-30b-a3b:free` |
| `test_summarizer` outcome | Provider could be detected but still fail to initialize | Provider initializes and can produce a real summary |
| Diagnostics and tests | Reflected the old default model and behavior | Aligned with the managed-endpoint logic and new default model |