### PR TITLE
fix: report unloadable repo indexes truthfully

### DIFF
--- a/src/jcodemunch_mcp/storage/index_store.py
+++ b/src/jcodemunch_mcp/storage/index_store.py
@@ -47,6 +47,43 @@ logger = logging.getLogger(__name__)
 INDEX_VERSION = 16
 
 
+@dataclass(frozen=True)
+class IndexLoadStatus:
+    """Presence and queryability status for a repository index."""
+
+    repo: str
+    owner: str
+    name: str
+    backend: str
+    index_present: bool
+    loadable: bool
+    status: str
+    load_error: Optional[str] = None
+    hint: Optional[str] = None
+    indexed_at: str = ""
+    symbol_count: Optional[int] = None
+    file_count: Optional[int] = None
+    languages: Optional[dict[str, int]] = None
+    index_version: Optional[int] = None
+    git_head: str = ""
+    display_name: str = ""
+    source_root: str = ""
+
+    def as_fields(self, include_empty: bool = False) -> dict:
+        """Return status fields suitable for tool/listing payloads."""
+        fields = {
+            "index_present": self.index_present,
+            "loadable": self.loadable,
+            "status": self.status,
+            "backend": self.backend,
+        }
+        if include_empty or self.load_error:
+            fields["load_error"] = self.load_error
+        if include_empty or self.hint:
+            fields["hint"] = self.hint
+        return fields
+
+
 @functools.lru_cache(maxsize=16)
 def _load_index_json_cached(index_path: str, mtime_ns: int) -> Optional[dict]:
     """Cache parsed JSON keyed on (path, mtime). mtime_ns ensures
@@ -596,6 +633,48 @@ class IndexStore:
         """Return True if an index exists (SQLite or JSON)."""
         return self._sqlite.has_index(owner, name) or self._index_path(owner, name).exists()
 
+    def inspect_index(self, owner: str, name: str, branch: str = "") -> IndexLoadStatus:
+        """Return index presence/loadability without changing load_index's contract."""
+        sqlite_status = self._sqlite.inspect_index(owner, name, branch=branch)
+        if sqlite_status.loadable:
+            return sqlite_status
+
+        if not branch:
+            index_path = self._index_path(owner, name)
+            if index_path.exists():
+                data = _load_index_json_cached(str(index_path), index_path.stat().st_mtime_ns)
+                if data:
+                    return IndexLoadStatus(
+                        repo=data.get("repo", f"{owner}/{name}"),
+                        owner=owner,
+                        name=name,
+                        backend="json",
+                        index_present=True,
+                        loadable=True,
+                        status="loadable",
+                        indexed_at=data.get("indexed_at", ""),
+                        symbol_count=len(data.get("symbols", [])),
+                        file_count=len(data.get("source_files", [])),
+                        languages=data.get("languages", {}),
+                        index_version=data.get("index_version"),
+                        git_head=data.get("git_head", ""),
+                        display_name=data.get("display_name", ""),
+                        source_root=data.get("source_root", ""),
+                    )
+                return IndexLoadStatus(
+                    repo=f"{owner}/{name}",
+                    owner=owner,
+                    name=name,
+                    backend="json",
+                    index_present=True,
+                    loadable=False,
+                    status="json_invalid",
+                    load_error="json_invalid",
+                    hint="Re-index this repository to rebuild the unreadable JSON index.",
+                )
+
+        return sqlite_status
+
     def load_index(self, owner: str, name: str, branch: str = "") -> Optional[CodeIndex]:
         """Load index from storage. Prefers SQLite, auto-migrates from JSON.
 
@@ -759,6 +838,10 @@ class IndexStore:
             "file_count": file_count,
             "languages": data.get("languages", {}),
             "index_version": data.get("index_version", 1),
+            "index_present": True,
+            "loadable": True,
+            "status": "loadable",
+            "backend": "json",
         }
         if data.get("git_head"):
             repo_entry["git_head"] = data["git_head"]
@@ -775,6 +858,7 @@ class IndexStore:
         """List all indexed repositories (SQLite + legacy JSON)."""
         repos = []
         seen_slugs: set[str] = set()
+        json_files_to_migrate: list[Path] = []
         _pairs = parse_path_map()
 
         # Pass 1: SQLite databases
@@ -786,10 +870,42 @@ class IndexStore:
             seen_slugs.add(slug)
             try:
                 entry = self._sqlite._list_repo_from_db(db_file, _pairs)
+                json_path = self.base_path / f"{slug}.json"
+                if entry and entry.get("loadable") is False and json_path.exists():
+                    try:
+                        with open(json_path, "r", encoding="utf-8") as f:
+                            data = json.load(f)
+                        json_entry = self._repo_entry_from_data(data, _pairs)
+                        if json_entry:
+                            repos.append(json_entry)
+                            json_files_to_migrate.append(json_path)
+                            continue
+                    except Exception:
+                        pass
                 if entry:
                     repos.append(entry)
             except Exception:
                 logger.debug("Skipping corrupted DB: %s", db_file, exc_info=True)
+                parts = slug.split("-", 1)
+                owner, name = parts if len(parts) == 2 else ("local", slug)
+                status = self._sqlite.inspect_index(owner, name)
+                entry = {
+                    "repo": status.repo,
+                    **status.as_fields(include_empty=True),
+                }
+                json_path = self.base_path / f"{slug}.json"
+                if json_path.exists():
+                    try:
+                        with open(json_path, "r", encoding="utf-8") as f:
+                            data = json.load(f)
+                        json_entry = self._repo_entry_from_data(data, _pairs)
+                        if json_entry:
+                            repos.append(json_entry)
+                            json_files_to_migrate.append(json_path)
+                            continue
+                    except Exception:
+                        pass
+                repos.append(entry)
 
         # Pass 2: legacy JSON — eagerly migrate to SQLite so that every
         # repo is in the canonical format before any tool can interact with it.
@@ -800,8 +916,6 @@ class IndexStore:
         if not any(self.base_path.glob("*.json")):
             repos.sort(key=lambda r: r["repo"])
             return repos
-
-        json_files_to_migrate: list[Path] = []
 
         for meta_file in self.base_path.glob("*.meta.json"):
             slug = meta_file.name.removesuffix(".meta.json")
@@ -844,8 +958,8 @@ class IndexStore:
             if len(parts) != 2:
                 continue
             owner, name = parts
-            if self._sqlite.has_index(owner, name):
-                continue  # already migrated
+            if self._sqlite.inspect_index(owner, name).loadable:
+                continue  # already migrated and loadable
             try:
                 logger.info("Eager-migrating %s from JSON to SQLite", json_path)
                 self._sqlite.migrate_from_json(json_path, owner, name)

--- a/src/jcodemunch_mcp/storage/index_store.py
+++ b/src/jcodemunch_mcp/storage/index_store.py
@@ -854,6 +854,26 @@ class IndexStore:
                 repo_entry["source_root"] = remap(data["source_root"], _pairs if _pairs is not None else parse_path_map())
         return repo_entry
 
+    def _try_json_fallback(
+        self,
+        slug: str,
+        _pairs,
+        json_files_to_migrate: list[Path],
+    ) -> Optional[dict]:
+        """Return a legacy JSON listing entry when SQLite is unloadable."""
+        json_path = self.base_path / f"{slug}.json"
+        if not json_path.exists():
+            return None
+        try:
+            with open(json_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            entry = self._repo_entry_from_data(data, _pairs)
+            if entry:
+                json_files_to_migrate.append(json_path)
+            return entry
+        except Exception:
+            return None
+
     def list_repos(self) -> list[dict]:
         """List all indexed repositories (SQLite + legacy JSON)."""
         repos = []
@@ -870,18 +890,10 @@ class IndexStore:
             seen_slugs.add(slug)
             try:
                 entry = self._sqlite._list_repo_from_db(db_file, _pairs)
-                json_path = self.base_path / f"{slug}.json"
-                if entry and entry.get("loadable") is False and json_path.exists():
-                    try:
-                        with open(json_path, "r", encoding="utf-8") as f:
-                            data = json.load(f)
-                        json_entry = self._repo_entry_from_data(data, _pairs)
-                        if json_entry:
-                            repos.append(json_entry)
-                            json_files_to_migrate.append(json_path)
-                            continue
-                    except Exception:
-                        pass
+                if entry and entry.get("loadable") is False:
+                    if json_entry := self._try_json_fallback(slug, _pairs, json_files_to_migrate):
+                        repos.append(json_entry)
+                        continue
                 if entry:
                     repos.append(entry)
             except Exception:
@@ -893,18 +905,9 @@ class IndexStore:
                     "repo": status.repo,
                     **status.as_fields(include_empty=True),
                 }
-                json_path = self.base_path / f"{slug}.json"
-                if json_path.exists():
-                    try:
-                        with open(json_path, "r", encoding="utf-8") as f:
-                            data = json.load(f)
-                        json_entry = self._repo_entry_from_data(data, _pairs)
-                        if json_entry:
-                            repos.append(json_entry)
-                            json_files_to_migrate.append(json_path)
-                            continue
-                    except Exception:
-                        pass
+                if json_entry := self._try_json_fallback(slug, _pairs, json_files_to_migrate):
+                    repos.append(json_entry)
+                    continue
                 repos.append(entry)
 
         # Pass 2: legacy JSON — eagerly migrate to SQLite so that every

--- a/src/jcodemunch_mcp/storage/sqlite_store.py
+++ b/src/jcodemunch_mcp/storage/sqlite_store.py
@@ -1278,7 +1278,11 @@ class SQLiteIndexStore:
             if not meta:
                 return None
 
-            stored_version = int(meta.get("index_version", "0"))
+            try:
+                stored_version = int(meta.get("index_version", "0"))
+            except (TypeError, ValueError):
+                logger.warning("Corrupt index version for %s/%s", owner, name)
+                return None
             if stored_version > cast(int, _INDEX_VERSION):
                 logger.warning("Index version %d > current %d for %s/%s", stored_version, _INDEX_VERSION, owner, name)
                 return None
@@ -1321,6 +1325,113 @@ class SQLiteIndexStore:
             post_mtime_ns = 0
         _cache_put(owner, safe_name, post_mtime_ns, index, branch)
         return index
+
+    def inspect_index(self, owner: str, name: str, branch: str = ""):
+        """Check SQLite index presence and compatibility without loading rows."""
+        _ensure_index_store_deps()
+        from .index_store import IndexLoadStatus
+
+        safe_name = self._safe_repo_component(name, "name")
+        db_path = self._db_path(owner, safe_name)
+        repo_id = f"{owner}/{safe_name}"
+        if not db_path.exists():
+            return IndexLoadStatus(
+                repo=repo_id,
+                owner=owner,
+                name=safe_name,
+                backend="none",
+                index_present=False,
+                loadable=False,
+                status="missing",
+                load_error="missing",
+                hint="Call index_folder to index this repository.",
+            )
+
+        try:
+            conn = self._connect(db_path)
+            try:
+                meta = self._read_meta(conn)
+                if not meta:
+                    return IndexLoadStatus(
+                        repo=repo_id,
+                        owner=owner,
+                        name=safe_name,
+                        backend="sqlite",
+                        index_present=True,
+                        loadable=False,
+                        status="sqlite_missing_meta",
+                        load_error="sqlite_missing_meta",
+                        hint="Re-index this repository to rebuild missing SQLite metadata.",
+                    )
+
+                try:
+                    stored_version = int(meta.get("index_version", "0"))
+                except (TypeError, ValueError):
+                    return IndexLoadStatus(
+                        repo=meta.get("repo", repo_id),
+                        owner=owner,
+                        name=safe_name,
+                        backend="sqlite",
+                        index_present=True,
+                        loadable=False,
+                        status="sqlite_corrupt",
+                        load_error="sqlite_corrupt",
+                        hint="Re-index this repository to rebuild corrupt SQLite metadata.",
+                        indexed_at=meta.get("indexed_at", ""),
+                        display_name=meta.get("display_name", ""),
+                        source_root=meta.get("source_root", ""),
+                    )
+
+                symbol_count = conn.execute("SELECT COUNT(*) FROM symbols").fetchone()[0]
+                file_count = conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
+                try:
+                    languages = json.loads(meta.get("languages", "{}"))
+                except (TypeError, json.JSONDecodeError):
+                    logger.warning("Corrupted languages JSON in metadata, defaulting to empty")
+                    languages = {}
+                base_kwargs = {
+                    "repo": meta.get("repo", repo_id),
+                    "owner": owner,
+                    "name": safe_name,
+                    "backend": "sqlite",
+                    "index_present": True,
+                    "indexed_at": meta.get("indexed_at", ""),
+                    "symbol_count": symbol_count,
+                    "file_count": file_count,
+                    "languages": languages,
+                    "index_version": stored_version,
+                    "git_head": meta.get("git_head", ""),
+                    "display_name": meta.get("display_name", ""),
+                    "source_root": meta.get("source_root", ""),
+                }
+                if stored_version > cast(int, _INDEX_VERSION):
+                    return IndexLoadStatus(
+                        **base_kwargs,
+                        loadable=False,
+                        status="sqlite_future_version",
+                        load_error="sqlite_future_version",
+                        hint="Re-index this repository with the current server version.",
+                    )
+                return IndexLoadStatus(
+                    **base_kwargs,
+                    loadable=True,
+                    status="loadable",
+                )
+            finally:
+                conn.close()
+        except sqlite3.DatabaseError:
+            logger.debug("Failed to inspect SQLite index: %s", db_path, exc_info=True)
+            return IndexLoadStatus(
+                repo=repo_id,
+                owner=owner,
+                name=safe_name,
+                backend="sqlite",
+                index_present=True,
+                loadable=False,
+                status="sqlite_corrupt",
+                load_error="sqlite_corrupt",
+                hint="Re-index this repository to rebuild the corrupt SQLite index.",
+            )
 
     def has_index(self, owner: str, name: str) -> bool:
         """Return True if a .db file exists for this repo."""
@@ -1694,6 +1805,14 @@ class SQLiteIndexStore:
                     repos.append(entry)
             except Exception:
                 logger.debug("Skipping corrupted DB: %s", db_file, exc_info=True)
+                slug = db_file.stem
+                parts = slug.split("-", 1)
+                owner, name = parts if len(parts) == 2 else ("local", slug)
+                status = self.inspect_index(owner, name)
+                repos.append({
+                    "repo": status.repo,
+                    **status.as_fields(include_empty=True),
+                })
         repos.sort(key=lambda repo: repo["repo"])
         return repos
 
@@ -1701,9 +1820,18 @@ class SQLiteIndexStore:
         """Read repo metadata from a .db file for list_repos."""
         if _pairs is None:
             _pairs = parse_path_map()
+        slug = db_path.stem
+        parts = slug.split("-", 1)
+        owner, name = parts if len(parts) == 2 else ("local", slug)
         conn = self._connect(db_path)
         try:
             meta = self._read_meta(conn)
+            if not meta or not meta.get("repo"):
+                status = self.inspect_index(owner, name)
+                return {
+                    "repo": status.repo,
+                    **status.as_fields(include_empty=True),
+                }
             symbol_count = conn.execute("SELECT COUNT(*) FROM symbols").fetchone()[0]
             file_count = conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
             # Read branch info if branch tables exist
@@ -1728,20 +1856,48 @@ class SQLiteIndexStore:
         finally:
             conn.close()
 
-        if not meta or not meta.get("repo"):
-            return None
-        languages = json.loads(meta.get("languages", "{}"))
         entry = {
             "repo": meta.get("repo", ""),
             "indexed_at": meta.get("indexed_at", ""),
             "symbol_count": symbol_count,
             "file_count": file_count,
-            "languages": languages,
-            "index_version": int(meta.get("index_version", "0")),
             "git_head": meta.get("git_head", ""),
             "display_name": meta.get("display_name", ""),
             "source_root": remap(meta.get("source_root", ""), _pairs),
+            "index_present": True,
+            "backend": "sqlite",
         }
+
+        try:
+            index_version = int(meta.get("index_version", "0"))
+        except (TypeError, ValueError):
+            entry.update({
+                "loadable": False,
+                "status": "sqlite_corrupt",
+                "load_error": "sqlite_corrupt",
+                "hint": "Re-index this repository to rebuild corrupt SQLite metadata.",
+            })
+            if branches:
+                entry["branches"] = branches
+            return entry
+
+        try:
+            languages = json.loads(meta.get("languages", "{}"))
+        except (TypeError, json.JSONDecodeError):
+            logger.warning("Corrupted languages JSON in metadata, defaulting to empty")
+            languages = {}
+
+        loadable = index_version <= cast(int, _INDEX_VERSION)
+        status = "loadable" if loadable else "sqlite_future_version"
+        entry.update({
+            "languages": languages,
+            "index_version": index_version,
+            "loadable": loadable,
+            "status": status,
+        })
+        if not loadable:
+            entry["load_error"] = status
+            entry["hint"] = "Re-index this repository with the current server version."
         if branches:
             entry["branches"] = branches
         return entry

--- a/src/jcodemunch_mcp/tools/_utils.py
+++ b/src/jcodemunch_mcp/tools/_utils.py
@@ -76,6 +76,40 @@ def resolve_repo(repo: str, storage_path: Optional[str] = None) -> tuple[str, st
     return candidates[0].split("/", 1)
 
 
+def index_status_to_tool_error(status) -> dict:
+    """Convert an index status probe into a consistent tool error."""
+    hint = status.hint or "Re-index this repository to rebuild the index."
+    return {
+        "error": f"Repository index is not loadable: {status.repo}",
+        "repo": status.repo,
+        "index_present": status.index_present,
+        "loadable": status.loadable,
+        "status": status.status,
+        "load_error": status.load_error or status.status,
+        "hint": hint,
+    }
+
+
+def load_repo_index_or_error(
+    repo: str,
+    storage_path: Optional[str] = None,
+    branch: str = "",
+) -> tuple[Optional[object], Optional[dict], Optional[object]]:
+    """Resolve and load a repo index, returning a structured error on failure."""
+    try:
+        owner, name = resolve_repo(repo, storage_path)
+    except ValueError as e:
+        return None, {"error": str(e)}, None
+
+    store = IndexStore(base_path=storage_path)
+    index = store.load_index(owner, name, branch=branch)
+    if index is not None:
+        return index, None, None
+
+    status = store.inspect_index(owner, name, branch=branch)
+    return None, index_status_to_tool_error(status), status
+
+
 def resolve_fqn(
     repo: str, fqn: str, storage_path: Optional[str] = None
 ) -> tuple[Optional[str], Optional[str]]:
@@ -93,7 +127,9 @@ def resolve_fqn(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return None, f"Repository not indexed: {owner}/{name}"
+        status = store.inspect_index(owner, name)
+        err = index_status_to_tool_error(status)
+        return None, f"{err['error']} ({err['load_error']}). {err['hint']}"
     if not getattr(index, "source_root", None):
         return None, "Index has no source_root (remote indexes don't support FQN resolution)"
     psr4 = build_psr4_map(index.source_root)

--- a/src/jcodemunch_mcp/tools/assemble_task_context.py
+++ b/src/jcodemunch_mcp/tools/assemble_task_context.py
@@ -25,7 +25,7 @@ import time
 from typing import Optional
 
 from ..storage import IndexStore, record_savings, estimate_savings, cost_avoided
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from .get_context_bundle import _count_tokens
 
 logger = logging.getLogger(__name__)
@@ -207,7 +207,7 @@ def assemble_task_context(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     # ── Intent classification ──────────────────────────────────────────
     if intent is None:

--- a/src/jcodemunch_mcp/tools/check_delete_safe.py
+++ b/src/jcodemunch_mcp/tools/check_delete_safe.py
@@ -23,7 +23,7 @@ import time
 from typing import Optional
 
 from ..storage import IndexStore, record_savings, estimate_savings, cost_avoided
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 
 logger = logging.getLogger(__name__)
 
@@ -157,7 +157,7 @@ def check_delete_safe(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     target = _resolve_target(index, symbol)
     if target is None:

--- a/src/jcodemunch_mcp/tools/check_references.py
+++ b/src/jcodemunch_mcp/tools/check_references.py
@@ -9,7 +9,7 @@ import time
 from typing import Optional
 
 from ..storage import IndexStore
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 
 
 def _check_single(
@@ -199,7 +199,7 @@ def check_references(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     if identifiers is not None:
         return _check_batch(

--- a/src/jcodemunch_mcp/tools/digest.py
+++ b/src/jcodemunch_mcp/tools/digest.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import Optional
 
 from ..storage import IndexStore
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +132,9 @@ def compose_digest(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        if hasattr(store, "inspect_index"):
+            return index_status_to_tool_error(store.inspect_index(owner, name))
+        return {"error": f"Repository index is not loadable: {owner}/{name}"}
 
     state_path = _state_path(owner, name, storage_path)
     state = _read_state(state_path)

--- a/src/jcodemunch_mcp/tools/digest.py
+++ b/src/jcodemunch_mcp/tools/digest.py
@@ -132,9 +132,7 @@ def compose_digest(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        if hasattr(store, "inspect_index"):
-            return index_status_to_tool_error(store.inspect_index(owner, name))
-        return {"error": f"Repository index is not loadable: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     state_path = _state_path(owner, name, storage_path)
     state = _read_state(state_path)

--- a/src/jcodemunch_mcp/tools/embed_repo.py
+++ b/src/jcodemunch_mcp/tools/embed_repo.py
@@ -12,7 +12,7 @@ from typing import Callable, Optional
 
 from .. import config as _config
 from ..storage import IndexStore
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 
 logger = logging.getLogger(__name__)
 
@@ -250,7 +250,7 @@ def embed_repo(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     from ..storage.embedding_store import EmbeddingStore
     db_path = store._sqlite._db_path(owner, name)

--- a/src/jcodemunch_mcp/tools/find_dead_code.py
+++ b/src/jcodemunch_mcp/tools/find_dead_code.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 from ..storage import IndexStore
 from ..parser.imports import resolve_specifier
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from ..parser.context._route_utils import ENTRY_POINT_DECORATOR_RE
 
 
@@ -185,7 +185,7 @@ def find_dead_code(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     if index.imports is None:
         return {

--- a/src/jcodemunch_mcp/tools/find_hot_paths.py
+++ b/src/jcodemunch_mcp/tools/find_hot_paths.py
@@ -36,7 +36,7 @@ import sqlite3
 import time
 from typing import Optional
 
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from ..storage import IndexStore
 
 
@@ -67,9 +67,12 @@ def find_hot_paths(
         return {"error": str(e)}
 
     store = IndexStore(base_path=storage_path)
+    status = store.inspect_index(owner, name)
+    if not status.loadable:
+        return index_status_to_tool_error(status)
     db_path = store._sqlite._db_path(owner, name)  # type: ignore[attr-defined]
     if not db_path.exists():
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     conn = sqlite3.connect(f"file:{db_path}?mode=ro&immutable=1", uri=True)
     conn.row_factory = sqlite3.Row

--- a/src/jcodemunch_mcp/tools/find_implementations.py
+++ b/src/jcodemunch_mcp/tools/find_implementations.py
@@ -19,7 +19,7 @@ import time
 from typing import Optional
 
 from ..storage import IndexStore, record_savings, estimate_savings, cost_avoided
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from .get_class_hierarchy import _build_class_maps
 
 logger = logging.getLogger(__name__)
@@ -167,7 +167,7 @@ def find_implementations(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     target = _resolve_target_symbol(index, symbol)
     if target is None:

--- a/src/jcodemunch_mcp/tools/find_importers.py
+++ b/src/jcodemunch_mcp/tools/find_importers.py
@@ -9,7 +9,7 @@ from ..parser.imports import (
     expand_barrel_leaves,
     resolve_specifier,
 )
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from .package_registry import (
     build_package_registry,
     extract_root_package_from_specifier,
@@ -300,7 +300,7 @@ def find_importers(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     repo_id = f"{owner}/{name}"
 

--- a/src/jcodemunch_mcp/tools/find_references.py
+++ b/src/jcodemunch_mcp/tools/find_references.py
@@ -6,7 +6,7 @@ import time
 from typing import Optional
 
 from ..storage import IndexStore, result_cache_get, result_cache_put
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 
 
 def _build_import_name_index(index) -> dict[str, list[tuple[str, dict]]]:
@@ -320,7 +320,7 @@ def find_references(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     if identifiers is not None:
         result = _find_references_batch(identifiers, index, max_results, owner, name, start)

--- a/src/jcodemunch_mcp/tools/find_similar_symbols.py
+++ b/src/jcodemunch_mcp/tools/find_similar_symbols.py
@@ -26,7 +26,7 @@ from fnmatch import fnmatch
 from typing import Optional
 
 from ..storage import IndexStore, record_savings, estimate_savings, cost_avoided
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from .get_context_bundle import _count_tokens
 
 logger = logging.getLogger(__name__)
@@ -211,7 +211,7 @@ def find_similar_symbols(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     # Collect candidates with all the per-symbol fields we'll need
     candidates: list[dict] = []

--- a/src/jcodemunch_mcp/tools/find_unused_paths.py
+++ b/src/jcodemunch_mcp/tools/find_unused_paths.py
@@ -54,7 +54,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from .find_dead_code import _is_test_file, _is_entry_point_filename
 from ..storage import IndexStore
 
@@ -133,9 +133,12 @@ def find_unused_paths(
         return {"error": str(e)}
 
     store = IndexStore(base_path=storage_path)
+    status = store.inspect_index(owner, name)
+    if not status.loadable:
+        return index_status_to_tool_error(status)
     db_path = store._sqlite._db_path(owner, name)  # type: ignore[attr-defined]
     if not db_path.exists():
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     cutoff = (datetime.now(timezone.utc) - timedelta(days=since_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
 

--- a/src/jcodemunch_mcp/tools/get_blast_radius.py
+++ b/src/jcodemunch_mcp/tools/get_blast_radius.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from ..storage import IndexStore, result_cache_get, result_cache_put
 from ..parser.imports import resolve_specifier
-from ._utils import resolve_repo, resolve_fqn
+from ._utils import index_status_to_tool_error, resolve_repo, resolve_fqn
 from .package_registry import extract_root_package_from_specifier
 from ._call_graph import build_symbols_by_file, _word_match, find_direct_callers, bfs_callers
 from .find_dead_code import _is_test_file
@@ -191,7 +191,7 @@ def get_blast_radius(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     if index.imports is None:
         return {

--- a/src/jcodemunch_mcp/tools/get_call_hierarchy.py
+++ b/src/jcodemunch_mcp/tools/get_call_hierarchy.py
@@ -4,7 +4,7 @@ import time
 from typing import Optional
 
 from ..storage import IndexStore
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from .get_blast_radius import _build_reverse_adjacency, _find_symbol
 from ._call_graph import build_symbols_by_file, bfs_callers, bfs_callees
 
@@ -46,7 +46,7 @@ def get_call_hierarchy(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     if index.imports is None:
         return {

--- a/src/jcodemunch_mcp/tools/get_changed_symbols.py
+++ b/src/jcodemunch_mcp/tools/get_changed_symbols.py
@@ -11,7 +11,7 @@ from typing import Optional
 from ..storage import IndexStore
 from ..parser import parse_file, get_language_for_path
 from ..parser.symbols import compute_content_hash
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from .get_blast_radius import _build_reverse_adjacency, _bfs_importers
 
 logger = logging.getLogger(__name__)
@@ -125,7 +125,7 @@ def get_changed_symbols(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     if not index.source_root:
         return {

--- a/src/jcodemunch_mcp/tools/get_class_hierarchy.py
+++ b/src/jcodemunch_mcp/tools/get_class_hierarchy.py
@@ -6,7 +6,7 @@ from collections import deque
 from typing import Optional
 
 from ..storage import IndexStore
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 
 # Patterns to extract base class / interface names from signatures
 _EXTENDS_RE = re.compile(
@@ -95,7 +95,7 @@ def get_class_hierarchy(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     class_by_name, children_of = _build_class_maps(index.symbols)
 

--- a/src/jcodemunch_mcp/tools/get_context_bundle.py
+++ b/src/jcodemunch_mcp/tools/get_context_bundle.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from ..storage import IndexStore, record_savings, estimate_savings, cost_avoided as _cost_avoided
 from ..parser.imports import resolve_specifier
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_fqn, resolve_repo
 
 _BYTES_PER_TOKEN = 4
 
@@ -289,7 +289,7 @@ def get_context_bundle(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     # Resolve all symbols
     resolved: list[dict] = []

--- a/src/jcodemunch_mcp/tools/get_coupling_metrics.py
+++ b/src/jcodemunch_mcp/tools/get_coupling_metrics.py
@@ -4,7 +4,7 @@ import time
 from typing import Optional
 
 from ..storage import IndexStore
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from .get_dependency_graph import _build_adjacency
 
 
@@ -50,7 +50,7 @@ def get_coupling_metrics(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     if not index.imports:
         return {

--- a/src/jcodemunch_mcp/tools/get_dependency_cycles.py
+++ b/src/jcodemunch_mcp/tools/get_dependency_cycles.py
@@ -4,7 +4,7 @@ import time
 from typing import Optional
 
 from ..storage import IndexStore
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from .get_dependency_graph import _build_adjacency
 
 
@@ -107,7 +107,7 @@ def get_dependency_cycles(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     if not index.imports:
         return {

--- a/src/jcodemunch_mcp/tools/get_dependency_graph.py
+++ b/src/jcodemunch_mcp/tools/get_dependency_graph.py
@@ -10,7 +10,7 @@ from ..parser.imports import (
     expand_barrel_leaves,
     resolve_specifier,
 )
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from .package_registry import extract_root_package_from_specifier
 
 
@@ -121,7 +121,7 @@ def get_dependency_graph(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     if index.imports is None:
         return {

--- a/src/jcodemunch_mcp/tools/get_file_content.py
+++ b/src/jcodemunch_mcp/tools/get_file_content.py
@@ -4,7 +4,7 @@ import time
 from typing import Optional
 
 from ..storage import IndexStore, cost_avoided, estimate_savings, record_savings
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 
 
 def get_file_content(
@@ -26,7 +26,7 @@ def get_file_content(
     index = store.load_index(owner, name)
 
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
     if not index.has_source_file(file_path):
         return {"error": f"File not found: {file_path}"}
 

--- a/src/jcodemunch_mcp/tools/get_file_outline.py
+++ b/src/jcodemunch_mcp/tools/get_file_outline.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from ..storage import IndexStore, record_savings, estimate_savings, cost_avoided
 from ..parser import Symbol, build_symbol_tree
-from ._utils import resolve_repo
+from ._utils import load_repo_index_or_error
 
 
 def _get_file_outline_single(
@@ -152,17 +152,12 @@ def get_file_outline(
 
     start = time.perf_counter()
 
-    try:
-        owner, name = resolve_repo(repo, storage_path)
-    except ValueError as e:
-        return {"error": str(e)}
-
     # Load index ONCE for both modes
+    index, error, _status = load_repo_index_or_error(repo, storage_path)
+    if error:
+        return error
+    owner, name = index.owner, index.name
     store = IndexStore(base_path=storage_path)
-    index = store.load_index(owner, name)
-
-    if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
 
     if file_paths is not None:
         return _get_file_outline_batch(file_paths, index, owner, name, store, start)

--- a/src/jcodemunch_mcp/tools/get_file_risk.py
+++ b/src/jcodemunch_mcp/tools/get_file_risk.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from typing import Optional
 
 from ..storage import IndexStore
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 
 logger = logging.getLogger(__name__)
 
@@ -176,7 +176,7 @@ def get_file_risk(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     # Normalize file path.
     if file_path not in index.source_files:

--- a/src/jcodemunch_mcp/tools/get_file_tree.py
+++ b/src/jcodemunch_mcp/tools/get_file_tree.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from .. import config as _config
 from ..storage import IndexStore, record_savings, estimate_savings, cost_avoided
-from ._utils import resolve_repo
+from ._utils import load_repo_index_or_error
 
 # Fallback used only when config is not yet loaded (e.g. tests that bypass main()).
 _DEFAULT_MAX_FILES = 500
@@ -42,17 +42,10 @@ def get_file_tree(
         max_files = _config.get("file_tree_max_files", _DEFAULT_MAX_FILES)
     max_files = max(1, max_files)  # guard against 0 or negative
 
-    try:
-        owner, name = resolve_repo(repo, storage_path)
-    except ValueError as e:
-        return {"error": str(e)}
-
-    # Load index
-    store = IndexStore(base_path=storage_path)
-    index = store.load_index(owner, name)
-
-    if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+    index, error, _status = load_repo_index_or_error(repo, storage_path)
+    if error:
+        return error
+    owner, name = index.owner, index.name
 
     # Filter files by prefix
     all_files = [f for f in index.source_files if f.startswith(path_prefix)]

--- a/src/jcodemunch_mcp/tools/get_impact_preview.py
+++ b/src/jcodemunch_mcp/tools/get_impact_preview.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import Optional
 
 from ..storage import IndexStore
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from .get_blast_radius import _build_reverse_adjacency, _find_symbol
 from ._call_graph import build_symbols_by_file, find_direct_callers
 
@@ -50,7 +50,7 @@ def get_impact_preview(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     if index.imports is None:
         return {

--- a/src/jcodemunch_mcp/tools/get_layer_violations.py
+++ b/src/jcodemunch_mcp/tools/get_layer_violations.py
@@ -5,7 +5,7 @@ from pathlib import PurePosixPath
 from typing import Optional
 
 from ..storage import IndexStore
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from .get_dependency_graph import _build_adjacency
 
 
@@ -104,7 +104,7 @@ def get_layer_violations(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     if not index.imports:
         return {

--- a/src/jcodemunch_mcp/tools/get_ranked_context.py
+++ b/src/jcodemunch_mcp/tools/get_ranked_context.py
@@ -5,7 +5,7 @@ from fnmatch import fnmatch
 from typing import Optional
 
 from ..storage import IndexStore, record_savings, estimate_savings, cost_avoided as _cost_avoided
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from .get_context_bundle import _count_tokens
 from .search_symbols import (
     _tokenize,
@@ -127,7 +127,7 @@ def get_ranked_context(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     # BM25 corpus — cached on CodeIndex
     query_terms = _tokenize(query) or [query.lower()]

--- a/src/jcodemunch_mcp/tools/get_redaction_log.py
+++ b/src/jcodemunch_mcp/tools/get_redaction_log.py
@@ -39,7 +39,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from ..storage import IndexStore
 
 
@@ -78,9 +78,12 @@ def get_redaction_log(
         return {"error": str(exc)}
 
     store = IndexStore(base_path=storage_path)
+    status = store.inspect_index(owner, name)
+    if not status.loadable:
+        return index_status_to_tool_error(status)
     db_path = store._sqlite._db_path(owner, name)  # type: ignore[attr-defined]
     if not db_path.exists():
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     cutoff = (datetime.now(timezone.utc) - timedelta(days=since_days)).strftime(
         "%Y-%m-%dT%H:%M:%SZ"

--- a/src/jcodemunch_mcp/tools/get_related_symbols.py
+++ b/src/jcodemunch_mcp/tools/get_related_symbols.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from ..storage import IndexStore
 from ..parser.imports import resolve_specifier
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 
 # Weights for each relatedness signal
 _W_SAME_FILE = 3.0
@@ -75,7 +75,7 @@ def get_related_symbols(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     target = index.get_symbol(symbol_id)
     if not target:

--- a/src/jcodemunch_mcp/tools/get_repo_map.py
+++ b/src/jcodemunch_mcp/tools/get_repo_map.py
@@ -10,7 +10,7 @@ from fnmatch import fnmatch
 from typing import Optional
 
 from ..storage import IndexStore, record_savings, estimate_savings, cost_avoided
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from .get_context_bundle import _count_tokens
 from .pagerank import compute_pagerank, compute_in_out_degrees
 
@@ -73,7 +73,7 @@ def get_repo_map(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     # Apply scope filter to the file list used for graph computation
     source_files = index.source_files

--- a/src/jcodemunch_mcp/tools/get_repo_outline.py
+++ b/src/jcodemunch_mcp/tools/get_repo_outline.py
@@ -11,7 +11,7 @@ from .. import config as _config
 from ..storage import IndexStore, record_savings, estimate_savings, cost_avoided
 from ..storage.index_store import _get_git_head
 from ..parser.imports import resolve_specifier
-from ._utils import resolve_repo
+from ._utils import load_repo_index_or_error
 from .pagerank import compute_pagerank
 
 
@@ -33,16 +33,11 @@ def get_repo_outline(
     """
     start = time.perf_counter()
 
-    try:
-        owner, name = resolve_repo(repo, storage_path)
-    except ValueError as e:
-        return {"error": str(e)}
-
+    index, error, _status = load_repo_index_or_error(repo, storage_path)
+    if error:
+        return error
+    owner, name = index.owner, index.name
     store = IndexStore(base_path=storage_path)
-    index = store.load_index(owner, name)
-
-    if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
 
     # Compute directory-level stats
     # For large repos, use 2-level grouping so agents get useful navigation hints.

--- a/src/jcodemunch_mcp/tools/get_runtime_coverage.py
+++ b/src/jcodemunch_mcp/tools/get_runtime_coverage.py
@@ -31,7 +31,7 @@ import sqlite3
 import time
 from typing import Optional
 
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from ..storage import IndexStore
 
 
@@ -63,9 +63,12 @@ def get_runtime_coverage(
         return {"error": str(e)}
 
     store = IndexStore(base_path=storage_path)
+    status = store.inspect_index(owner, name)
+    if not status.loadable:
+        return index_status_to_tool_error(status)
     db_path = store._sqlite._db_path(owner, name)  # type: ignore[attr-defined]
     if not db_path.exists():
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     scope = f"file:{file_path}" if file_path else "repo"
     response: dict = {

--- a/src/jcodemunch_mcp/tools/get_symbol.py
+++ b/src/jcodemunch_mcp/tools/get_symbol.py
@@ -6,7 +6,7 @@ import time
 from typing import Optional
 
 from ..storage import IndexStore, record_savings, estimate_savings, cost_avoided as _cost_avoided
-from ._utils import resolve_repo, resolve_fqn
+from ._utils import index_status_to_tool_error, resolve_repo, resolve_fqn
 
 
 def _make_meta(timing_ms: float, **kwargs) -> dict:
@@ -62,7 +62,7 @@ def get_symbol_source(
     index = store.load_index(owner, name)
 
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     symbols_out = []
     errors_out = []

--- a/src/jcodemunch_mcp/tools/get_symbol_diff.py
+++ b/src/jcodemunch_mcp/tools/get_symbol_diff.py
@@ -4,7 +4,7 @@ import time
 from typing import Optional
 
 from ..storage import IndexStore
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 
 
 def get_symbol_diff(
@@ -43,9 +43,9 @@ def get_symbol_diff(
     index_b = store.load_index(owner_b, name_b)
 
     if not index_a:
-        return {"error": f"Repository not indexed: {owner_a}/{name_a}"}
+        return index_status_to_tool_error(store.inspect_index(owner_a, name_a))
     if not index_b:
-        return {"error": f"Repository not indexed: {owner_b}/{name_b}"}
+        return index_status_to_tool_error(store.inspect_index(owner_b, name_b))
 
     # Build lookup maps keyed by (name, kind) — using the first match when dupes exist
     def _sym_map(index) -> dict[tuple, dict]:

--- a/src/jcodemunch_mcp/tools/get_symbol_importance.py
+++ b/src/jcodemunch_mcp/tools/get_symbol_importance.py
@@ -5,7 +5,7 @@ from fnmatch import fnmatch
 from typing import Optional
 
 from ..storage import IndexStore, record_savings, estimate_savings, cost_avoided
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from .pagerank import compute_pagerank, compute_in_out_degrees
 
 # Kind priority for picking the representative symbol per file
@@ -46,7 +46,7 @@ def get_symbol_importance(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     if not index.imports:
         return {

--- a/src/jcodemunch_mcp/tools/get_untested_symbols.py
+++ b/src/jcodemunch_mcp/tools/get_untested_symbols.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from ..storage import IndexStore
 from ..parser.imports import resolve_specifier
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from ._call_graph import _word_match, build_symbols_by_file
 from .find_dead_code import _is_test_file
 
@@ -117,7 +117,7 @@ def get_untested_symbols(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     if index.imports is None:
         return {

--- a/src/jcodemunch_mcp/tools/plan_turn.py
+++ b/src/jcodemunch_mcp/tools/plan_turn.py
@@ -4,8 +4,7 @@ import heapq
 import time
 from typing import Optional
 
-from ..storage.sqlite_store import SQLiteIndexStore
-from ._utils import resolve_repo
+from ._utils import load_repo_index_or_error
 from .search_symbols import (
     _tokenize,
     _compute_bm25,
@@ -50,15 +49,10 @@ def plan_turn(
     if len(query) > 500:
         return {"error": f"Query too long ({len(query)} chars, max 500)"}
 
-    try:
-        owner, name = resolve_repo(repo, storage_path)
-    except ValueError as e:
-        return {"error": str(e)}
-
-    store = SQLiteIndexStore(base_path=storage_path)
-    index = store.load_index(owner, name)
-    if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+    index, error, _status = load_repo_index_or_error(repo, storage_path)
+    if error:
+        return error
+    owner, name = index.owner, index.name
 
     # Get BM25 cache
     cache = index._bm25_cache

--- a/src/jcodemunch_mcp/tools/register_edit.py
+++ b/src/jcodemunch_mcp/tools/register_edit.py
@@ -4,8 +4,8 @@ import time
 import logging
 from typing import Optional
 
-from ..storage.sqlite_store import SQLiteIndexStore
-from ._utils import resolve_repo
+from ..storage import IndexStore
+from ._utils import index_status_to_tool_error, resolve_repo
 
 _logger = logging.getLogger(__name__)
 
@@ -40,10 +40,10 @@ def register_edit(
     except ValueError as e:
         return {"error": str(e)}
 
-    store = SQLiteIndexStore(base_path=storage_path)
+    store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     # Get journal for recording
     if _journal is None:

--- a/src/jcodemunch_mcp/tools/resolve_repo.py
+++ b/src/jcodemunch_mcp/tools/resolve_repo.py
@@ -127,22 +127,29 @@ def resolve_repo(path: str, storage_path: Optional[str] = None) -> dict:
     for candidate in candidates:
         repo_id = _compute_repo_id(candidate)
         owner, name = repo_id.split("/", 1)
-        if store.has_index(owner, name):
+        status = store.inspect_index(owner, name)
+        if status.index_present:
             # Read metadata from sidecar or full index
             entry = _read_repo_metadata(store, owner, name)
             elapsed = (time.perf_counter() - start) * 1000
             result = {
                 "found": True,
-                "indexed": True,
+                "indexed": status.loadable,
                 "repo": repo_id,
-                "source_root": entry.get("source_root", ""),
-                "display_name": entry.get("display_name", ""),
-                "symbol_count": entry.get("symbol_count", 0),
-                "file_count": entry.get("file_count", 0),
-                "languages": entry.get("languages", {}),
-                "indexed_at": entry.get("indexed_at", ""),
+                **status.as_fields(),
                 "_meta": {"timing_ms": round(elapsed, 1)},
             }
+            metadata = {
+                "source_root": entry.get("source_root") or status.source_root,
+                "display_name": entry.get("display_name") or status.display_name,
+                "symbol_count": entry.get("symbol_count", status.symbol_count),
+                "file_count": entry.get("file_count", status.file_count),
+                "languages": entry.get("languages", status.languages),
+                "indexed_at": entry.get("indexed_at") or status.indexed_at,
+            }
+            for key, value in metadata.items():
+                if value is not None and value != "":
+                    result[key] = value
             return result
 
     # Not indexed — return the computed ID for the best candidate

--- a/src/jcodemunch_mcp/tools/search_columns.py
+++ b/src/jcodemunch_mcp/tools/search_columns.py
@@ -5,7 +5,7 @@ import time
 from typing import Optional
 
 from .. import config as _config
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 from ..storage.index_store import IndexStore
 from ..storage.token_tracker import estimate_savings, record_savings, cost_avoided
 
@@ -62,7 +62,7 @@ def search_columns(
     index = store.load_index(owner, name)
 
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     # Collect column metadata from all providers
     column_sources = _collect_all_columns(index.context_metadata)

--- a/src/jcodemunch_mcp/tools/search_symbols.py
+++ b/src/jcodemunch_mcp/tools/search_symbols.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from ..storage import IndexStore, CodeIndex, record_savings, estimate_savings, cost_avoided
 from ..parser.imports import resolve_specifier
-from ._utils import resolve_repo, resolve_fqn
+from ._utils import resolve_repo, resolve_fqn, index_status_to_tool_error
 
 BYTES_PER_TOKEN = 4
 
@@ -558,7 +558,7 @@ def search_symbols(
     index = store.load_index(owner, name)
 
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     # Feature 5: Search result cache
     # Skip cache for debug/semantic modes (these need fresh data)

--- a/src/jcodemunch_mcp/tools/search_text.py
+++ b/src/jcodemunch_mcp/tools/search_text.py
@@ -6,7 +6,7 @@ import time
 from typing import Optional
 
 from ..storage import IndexStore, record_savings, estimate_savings, cost_avoided
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 
 # Detect nested quantifiers that cause catastrophic backtracking in Python's re engine.
 # Matches patterns like (a+)+, (a*)+, (a+)*, (?:a+){2,}, etc.
@@ -85,7 +85,7 @@ def search_text(
     index = store.load_index(owner, name)
 
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     # Pre-compile file pattern into a single regex (avoids double fnmatch per file)
     files = index.source_files

--- a/src/jcodemunch_mcp/tools/suggest_queries.py
+++ b/src/jcodemunch_mcp/tools/suggest_queries.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from ..storage import IndexStore
 from ..parser.imports import resolve_specifier
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 
 
 def suggest_queries(
@@ -39,7 +39,7 @@ def suggest_queries(
     store = IndexStore(base_path=storage_path)
     index = store.load_index(owner, name)
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     symbols = index.symbols
     if not symbols:

--- a/src/jcodemunch_mcp/tools/summarize_repo.py
+++ b/src/jcodemunch_mcp/tools/summarize_repo.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from ..storage import IndexStore
 from ..summarizer import summarize_symbols
-from ._utils import resolve_repo
+from ._utils import index_status_to_tool_error, resolve_repo
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ def summarize_repo(
     index = store.load_index(owner, name)
 
     if not index:
-        return {"error": f"Repository not indexed: {owner}/{name}"}
+        return index_status_to_tool_error(store.inspect_index(owner, name))
 
     if not index.symbols:
         return {

--- a/tests/test_assemble_task_context.py
+++ b/tests/test_assemble_task_context.py
@@ -166,6 +166,9 @@ class TestAssembleErrors:
             storage_path=storage,
         )
         assert "error" in result
+        assert result["loadable"] is False
+        assert result["status"] == "missing"
+        assert result["load_error"] == "missing"
 
     def test_invalid_intent(self, tmp_path):
         repo, storage = _make_repo(tmp_path, _REPO)

--- a/tests/test_check_delete_safe.py
+++ b/tests/test_check_delete_safe.py
@@ -146,6 +146,9 @@ class TestCheckDeleteSafeErrors:
         storage = str(tmp_path / ".index")
         result = check_delete_safe("nope/repo", symbol="X", storage_path=storage)
         assert "error" in result
+        assert result["loadable"] is False
+        assert result["status"] == "missing"
+        assert result["load_error"] == "missing"
 
     def test_unknown_symbol(self, tmp_path):
         repo, storage = _make_repo(tmp_path, _SAFE_REPO)

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
+from jcodemunch_mcp.storage.index_store import IndexLoadStatus
 from jcodemunch_mcp.tools import digest as digest_mod
 
 
@@ -153,6 +154,17 @@ class TestComposeDigestErrors:
         class _NullStore:
             def __init__(self, base_path=None): pass
             def load_index(self, *a, **kw): return None
+            def inspect_index(self, owner, name):
+                return IndexLoadStatus(
+                    repo=f"{owner}/{name}",
+                    owner=owner,
+                    name=name,
+                    backend="none",
+                    index_present=False,
+                    loadable=False,
+                    status="missing",
+                    load_error="missing",
+                )
 
         monkeypatch.setattr(digest_mod, "IndexStore", _NullStore)
         monkeypatch.setattr(digest_mod, "resolve_repo", lambda r, sp=None: ("local", "name"))

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -159,7 +159,7 @@ class TestComposeDigestErrors:
 
         result = digest_mod.compose_digest("anything")
         assert "error" in result
-        assert "not indexed" in result["error"]
+        assert "not loadable" in result["error"]
 
 
 class TestStateFileHelpers:

--- a/tests/test_find_implementations.py
+++ b/tests/test_find_implementations.py
@@ -145,6 +145,9 @@ class TestFindImplementationsErrors:
         storage = str(tmp_path / ".index")
         result = find_implementations("nope/repo", symbol="X", storage_path=storage)
         assert "error" in result
+        assert result["loadable"] is False
+        assert result["status"] == "missing"
+        assert result["load_error"] == "missing"
 
     def test_unknown_symbol(self, tmp_path):
         repo, storage = _make_repo(tmp_path, _INHERITANCE_REPO)

--- a/tests/test_fqn.py
+++ b/tests/test_fqn.py
@@ -181,4 +181,4 @@ class TestResolveFqnIntegration:
     def test_repo_not_found(self):
         resolved, err = resolve_fqn("nonexistent/repo", "App\\Models\\User")
         assert resolved is None
-        assert "not indexed" in err.lower()
+        assert "not loadable" in err.lower()

--- a/tests/test_get_file_tree.py
+++ b/tests/test_get_file_tree.py
@@ -1,7 +1,10 @@
 """Tests for get_file_tree language labeling behavior."""
 
+import sqlite3
+
 from jcodemunch_mcp.parser import Symbol
 from jcodemunch_mcp.storage import IndexStore
+from jcodemunch_mcp.storage.sqlite_store import _cache_evict
 from jcodemunch_mcp.tools.get_file_tree import get_file_tree
 
 
@@ -98,6 +101,48 @@ def _make_index_with_n_files(tmp_path, owner, name, n):
         languages={"python": n},
     )
     return source_files
+
+
+def test_get_file_tree_reports_unloadable_index_actionably(tmp_path):
+    """Unloadable indexes should return remediation details, not a generic miss."""
+    _make_index_with_n_files(tmp_path, "tree", "broken", 1)
+    store = IndexStore(base_path=str(tmp_path))
+    db_path = store._sqlite._db_path("tree", "broken")
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("DELETE FROM meta")
+        conn.commit()
+    finally:
+        conn.close()
+    _cache_evict("tree", "broken")
+
+    result = get_file_tree("tree/broken", storage_path=str(tmp_path))
+
+    assert result["error"] != "Repository not indexed: tree/broken"
+    assert result["load_error"] == "sqlite_missing_meta"
+    assert result["status"] == "sqlite_missing_meta"
+    assert "Re-index" in result["hint"]
+
+
+def test_get_file_tree_reports_corrupt_index_version_actionably(tmp_path):
+    """Fatal corrupt SQLite metadata should return remediation details, not raise."""
+    _make_index_with_n_files(tmp_path, "tree", "corrupt", 1)
+    store = IndexStore(base_path=str(tmp_path))
+    db_path = store._sqlite._db_path("tree", "corrupt")
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("UPDATE meta SET value = ? WHERE key = ?", ("not-an-int", "index_version"))
+        conn.commit()
+    finally:
+        conn.close()
+    _cache_evict("tree", "corrupt")
+
+    result = get_file_tree("tree/corrupt", storage_path=str(tmp_path))
+
+    assert result["error"] != "Repository not indexed: tree/corrupt"
+    assert result["load_error"] == "sqlite_corrupt"
+    assert result["status"] == "sqlite_corrupt"
+    assert "Re-index" in result["hint"]
 
 
 class TestGetFileTreeTruncation:

--- a/tests/test_local_integration.py
+++ b/tests/test_local_integration.py
@@ -512,6 +512,10 @@ def test_list_repos_eagerly_migrates_json(tmp_path):
     repos = store.list_repos()
     assert len(repos) == 1
     assert repos[0]["repo"] == "local/test-abc123"
+    assert repos[0]["index_present"] is True
+    assert repos[0]["loadable"] is True
+    assert repos[0]["status"] == "loadable"
+    assert "load_error" not in repos[0]
 
     # After list_repos, the .db must exist (eager migration happened).
     db_path = tmp_path / "local-test-abc123.db"
@@ -523,6 +527,30 @@ def test_list_repos_eagerly_migrates_json(tmp_path):
     # The original .json should be renamed to .json.migrated
     assert not json_path.exists(), ".json should be gone after migration"
     assert (tmp_path / "local-test-abc123.json.migrated").exists()
+
+
+def test_list_repos_uses_json_fallback_when_sqlite_meta_is_missing(tmp_path):
+    """A valid legacy JSON index remains loadable when SQLite metadata is damaged."""
+    json_path = _write_legacy_json(tmp_path)
+    sqlite_store = SQLiteIndexStore(base_path=str(tmp_path))
+    db_path = sqlite_store._db_path("local", "test-abc123")
+    conn = sqlite_store._connect(db_path)
+    try:
+        conn.execute("DELETE FROM meta")
+        conn.commit()
+    finally:
+        conn.close()
+
+    store = IndexStore(base_path=str(tmp_path))
+    repos = store.list_repos()
+
+    assert len(repos) == 1
+    assert repos[0]["repo"] == "local/test-abc123"
+    assert repos[0]["loadable"] is True
+    assert repos[0]["status"] == "loadable"
+    assert "load_error" not in repos[0]
+    assert db_path.exists(), ".db must exist after JSON fallback migration"
+    assert not json_path.exists(), ".json should be migrated after fallback"
 
 
 def test_save_index_cleans_up_zombie_json(tmp_path):

--- a/tests/test_resolve_repo.py
+++ b/tests/test_resolve_repo.py
@@ -1,9 +1,12 @@
 """Tests for resolve_repo tool."""
 
 import hashlib
+import sqlite3
 
 import pytest
 
+from jcodemunch_mcp.storage import INDEX_VERSION, IndexStore
+from jcodemunch_mcp.storage.sqlite_store import _cache_evict
 from jcodemunch_mcp.tools.resolve_repo import resolve_repo, _compute_repo_id
 from jcodemunch_mcp.watcher import _local_repo_id
 from jcodemunch_mcp.tools.index_folder import index_folder
@@ -27,6 +30,28 @@ class TestComputeRepoId:
 
 
 class TestResolveRepo:
+    def _index_project(self, tmp_path, name="loadability"):
+        project = tmp_path / name
+        project.mkdir()
+        (project / "main.py").write_text("def hello(): pass\n")
+        store_path = str(tmp_path / "store")
+
+        index_folder(str(project), use_ai_summaries=False, storage_path=store_path)
+        repo_id = _compute_repo_id(project)
+        owner, repo_name = repo_id.split("/", 1)
+        return project, store_path, owner, repo_name
+
+    def _mutate_sqlite_meta(self, store_path, owner, name, sql, params=()):
+        store = IndexStore(base_path=store_path)
+        db_path = store._sqlite._db_path(owner, name)
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute(sql, params)
+            conn.commit()
+        finally:
+            conn.close()
+        _cache_evict(owner, name)
+
     def test_resolve_exact_indexed_root(self, tmp_path):
         """Resolving an indexed root returns indexed: true with metadata."""
         project = tmp_path / "myproject"
@@ -43,6 +68,42 @@ class TestResolveRepo:
         assert result["symbol_count"] >= 1
         assert result["file_count"] >= 1
         assert "hint" not in result
+
+    def test_resolve_future_version_index_reports_unloadable(self, tmp_path):
+        """A present but future-version SQLite index is not queryable."""
+        project, store_path, owner, name = self._index_project(tmp_path, "futurever")
+        self._mutate_sqlite_meta(
+            store_path,
+            owner,
+            name,
+            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+            ("index_version", str(INDEX_VERSION + 100)),
+        )
+
+        result = resolve_repo(str(project), storage_path=store_path)
+
+        assert result["found"] is True
+        assert result["index_present"] is True
+        assert result["indexed"] is False
+        assert result["loadable"] is False
+        assert result["status"] == "sqlite_future_version"
+        assert result["load_error"] == "sqlite_future_version"
+        assert result["hint"]
+
+    def test_resolve_missing_meta_index_reports_unloadable(self, tmp_path):
+        """A present SQLite index without metadata is not queryable."""
+        project, store_path, owner, name = self._index_project(tmp_path, "missingmeta")
+        self._mutate_sqlite_meta(store_path, owner, name, "DELETE FROM meta")
+
+        result = resolve_repo(str(project), storage_path=store_path)
+
+        assert result["found"] is True
+        assert result["index_present"] is True
+        assert result["indexed"] is False
+        assert result["loadable"] is False
+        assert result["status"] == "sqlite_missing_meta"
+        assert result["load_error"] == "sqlite_missing_meta"
+        assert result["hint"]
 
     def test_resolve_subdirectory_via_git(self, tmp_path, monkeypatch):
         """Resolving a subdirectory finds the repo via git root."""

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -215,6 +215,94 @@ def test_list_repos(tmp_path):
     assert any(r["repo"] == "local/proj-a" for r in repos)
 
 
+def test_list_repos_marks_missing_meta_repo_unloadable(tmp_path):
+    """SQLite list_repos keeps damaged repos visible with status details."""
+    store = SQLiteIndexStore(base_path=str(tmp_path))
+    store.save_index(
+        owner="local", name="broken",
+        source_files=["a.py"], symbols=[_make_symbol("f")],
+        raw_files={"a.py": "x"}, display_name="Broken",
+    )
+    db_path = store._db_path("local", "broken")
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("DELETE FROM meta")
+        conn.commit()
+    finally:
+        conn.close()
+
+    repos = store.list_repos()
+    broken = next(r for r in repos if r["repo"] == "local/broken")
+
+    assert broken["loadable"] is False
+    assert broken["status"] == "sqlite_missing_meta"
+    assert broken["load_error"] == "sqlite_missing_meta"
+    assert "Re-index" in broken["hint"]
+
+
+def test_list_repos_marks_invalid_index_version_unloadable(tmp_path):
+    """SQLite list_repos does not report corrupt version metadata as loadable."""
+    store = SQLiteIndexStore(base_path=str(tmp_path))
+    store.save_index(
+        owner="local", name="broken-version",
+        source_files=["a.py"], symbols=[_make_symbol("f")],
+        raw_files={"a.py": "x"}, display_name="Broken Version",
+    )
+    db_path = store._db_path("local", "broken-version")
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("UPDATE meta SET value = ? WHERE key = ?", ("not-an-int", "index_version"))
+        conn.commit()
+    finally:
+        conn.close()
+
+    repos = store.list_repos()
+    broken = next(r for r in repos if r["repo"] == "local/broken-version")
+
+    assert broken["loadable"] is False
+    assert broken["status"] == "sqlite_corrupt"
+    assert broken["load_error"] == "sqlite_corrupt"
+    assert "Re-index" in broken["hint"]
+
+
+def test_list_repos_marks_corrupt_database_unloadable(tmp_path):
+    """SQLite list_repos keeps corrupt DB files visible with status details."""
+    store = SQLiteIndexStore(base_path=str(tmp_path))
+    db_path = tmp_path / "local-corrupt-db.db"
+    db_path.write_text("not a sqlite database", encoding="utf-8")
+
+    repos = store.list_repos()
+    corrupt = next(r for r in repos if r["repo"] == "local/corrupt-db")
+
+    assert corrupt["loadable"] is False
+    assert corrupt["status"] == "sqlite_corrupt"
+    assert corrupt["load_error"] == "sqlite_corrupt"
+    assert "Re-index" in corrupt["hint"]
+
+
+def test_inspect_index_tolerates_invalid_languages_metadata(tmp_path):
+    """SQLite inspect_index treats non-fatal languages metadata like load_index."""
+    store = SQLiteIndexStore(base_path=str(tmp_path))
+    store.save_index(
+        owner="local", name="broken-languages",
+        source_files=["a.py"], symbols=[_make_symbol("f")],
+        raw_files={"a.py": "x"}, display_name="Broken Languages",
+    )
+    db_path = store._db_path("local", "broken-languages")
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("UPDATE meta SET value = ? WHERE key = ?", ("{not-json", "languages"))
+        conn.commit()
+    finally:
+        conn.close()
+
+    status = store.inspect_index("local", "broken-languages")
+
+    assert status.loadable is True
+    assert status.status == "loadable"
+    assert status.languages == {}
+
+
 def test_get_symbol_content(tmp_path):
     """get_symbol_content reads by byte offset from content cache."""
     store = SQLiteIndexStore(base_path=str(tmp_path))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2,9 +2,11 @@
 
 import pytest
 import json
+import sqlite3
 from pathlib import Path
 
 from jcodemunch_mcp.storage import IndexStore, CodeIndex
+from jcodemunch_mcp.storage.sqlite_store import _cache_evict
 from jcodemunch_mcp.parser import Symbol
 
 
@@ -135,6 +137,67 @@ def test_list_repos_includes_optional_metadata(tmp_path):
     repos = store.list_repos()
     assert repos[0]["display_name"] == "demo"
     assert repos[0]["source_root"] == "/tmp/demo"
+
+
+def test_list_repos_marks_unloadable_sqlite_repo_and_preserves_sort(tmp_path):
+    """A damaged SQLite repo remains listed with loadability diagnostics."""
+    store = IndexStore(base_path=str(tmp_path))
+
+    for name in ["broken", "healthy"]:
+        store.save_index(
+            owner="local",
+            name=name,
+            source_files=["main.py"],
+            symbols=[],
+            raw_files={"main.py": ""},
+            languages={"python": 1},
+        )
+
+    db_path = store._sqlite._db_path("local", "broken")
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("DELETE FROM meta")
+        conn.commit()
+    finally:
+        conn.close()
+    _cache_evict("local", "broken")
+
+    repos = store.list_repos()
+    repo_ids = [entry["repo"] for entry in repos]
+
+    assert repo_ids == sorted(repo_ids)
+    assert repo_ids == ["local/broken", "local/healthy"]
+
+    broken = repos[0]
+    assert broken["loadable"] is False
+    assert broken["status"] == "sqlite_missing_meta"
+    assert broken["load_error"] == "sqlite_missing_meta"
+    assert "Re-index" in broken["hint"]
+
+
+def test_list_repos_marks_corrupt_sqlite_db_and_preserves_sort(tmp_path):
+    """IndexStore.list_repos keeps corrupt DB files visible with diagnostics."""
+    store = IndexStore(base_path=str(tmp_path))
+    store.save_index(
+        owner="local",
+        name="healthy",
+        source_files=["main.py"],
+        symbols=[],
+        raw_files={"main.py": ""},
+        languages={"python": 1},
+    )
+    (tmp_path / "local-corrupt-db.db").write_text("not a sqlite database", encoding="utf-8")
+
+    repos = store.list_repos()
+    repo_ids = [entry["repo"] for entry in repos]
+
+    assert repo_ids == sorted(repo_ids)
+    assert repo_ids == ["local/corrupt-db", "local/healthy"]
+    corrupt = repos[0]
+    assert corrupt["loadable"] is False
+    assert corrupt["status"] == "sqlite_corrupt"
+    assert corrupt["load_error"] == "sqlite_corrupt"
+    assert "Re-index" in corrupt["hint"]
 
 
 def test_delete_index(tmp_path):


### PR DESCRIPTION
## Summary
- Distinguishes present-but-unloadable repository indexes from truly missing repositories.
- Keeps damaged SQLite indexes visible in `list_repos()` with machine-stable status fields and remediation hints.
- Updates query tools to return actionable loadability errors instead of generic `Repository not indexed` messages.

## Why
`resolve_repo()` could report a repository as indexed when only an index artifact existed, even if that index was not loadable by query tools. That created false positives: discovery said a repo was available, while follow-up tools failed with generic missing-index errors. Operators needed a truthful status layer that preserves visibility for broken indexes and tells users how to recover.

## What
- Added an index loadability status probe that preserves `load_index()`'s existing return contract.
- Updated `resolve_repo()` so `indexed` means queryable, while exposing `index_present`, `loadable`, `status`, `load_error`, `backend`, and `hint` for diagnostics.
- Updated `list_repos()` and SQLite listing paths so damaged indexes remain visible, including missing metadata, future versions, corrupt metadata, and corrupt database files.
- Added JSON fallback handling when a legacy JSON index is still valid but the SQLite metadata is damaged.
- Replaced generic missing-index responses across tools with shared actionable unloadable-index errors.
- Added regression coverage for loadability status, corrupt metadata, corrupt SQLite files, JSON fallback, and representative tool errors.

## Before and After

| Before | After |
|---|---|
| `resolve_repo()` could return `indexed: true` when an index file existed but could not be loaded. | `resolve_repo()` returns `indexed: false`, `index_present: true`, and loadability diagnostics for present-but-broken indexes. |
| Tools returned `Repository not indexed` for damaged indexes. | Tools return `Repository index is not loadable` with `status`, `load_error`, and `hint`. |
| `list_repos()` could hide corrupt SQLite databases. | `list_repos()` keeps corrupt or incompatible indexes visible with `loadable: false`. |
| Invalid SQLite `index_version` metadata could be treated as loadable or raise during tool execution. | Invalid `index_version` is reported as `sqlite_corrupt` and handled without crashing tools. |
| A damaged SQLite index could mask a valid legacy JSON fallback. | Valid legacy JSON fallback remains usable and can migrate back to SQLite. |

---

Co-authored-by: GPT 5.5 high