### PR TITLE
fix: watcher standby failover takeover resilience

### DIFF
--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -3541,6 +3541,7 @@ async def _auto_watch_if_needed(name: str, arguments: dict, storage_path: Option
     if maybe_takeover is not None:
         result = await maybe_takeover(folder)
         if result.get("status") in {"started", "already_watched"}:
+            await _watcher_manager.ensure_indexed(folder)
             return
 
     # Race-safe reindex, then start watching

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -3536,6 +3536,13 @@ async def _auto_watch_if_needed(name: str, arguments: dict, storage_path: Option
     if _watcher_manager.is_watched(folder):
         return
 
+    # Opportunistic standby takeover before indexing
+    maybe_takeover = getattr(_watcher_manager, "maybe_takeover", None)
+    if maybe_takeover is not None:
+        result = await maybe_takeover(folder)
+        if result.get("status") in {"started", "already_watched"}:
+            return
+
     # Race-safe reindex, then start watching
     try:
         await _watcher_manager.ensure_indexed(folder)

--- a/src/jcodemunch_mcp/watcher.py
+++ b/src/jcodemunch_mcp/watcher.py
@@ -650,7 +650,7 @@ class WatcherManager:
                     # Retry standby folders on fallback interval
                     for folder in list(self._standby):
                         await self.maybe_takeover(folder)
-                    sleep_seconds = 5.0 if not self._standby else min(5.0, self._takeover_retry_seconds)
+                    sleep_seconds = self._takeover_retry_seconds if self._standby else 5.0
                     await asyncio.sleep(sleep_seconds)
                 # Inner loop exited normally — reset restart counter
                 _restart_count = 0
@@ -680,6 +680,13 @@ class WatcherManager:
         """Signal the manager loop to stop."""
         if self._stop_event:
             self._stop_event.set()
+        for folder, task in list(self._active.items()):
+            task.cancel()
+            self._active.pop(folder, None)
+            self._watched.discard(folder)
+            if folder in self._locked:
+                self._locked.discard(folder)
+                _release_lock(folder, self._storage_path)
         # Clear all standby state
         for folder in list(self._standby):
             self._clear_standby(folder)

--- a/src/jcodemunch_mcp/watcher.py
+++ b/src/jcodemunch_mcp/watcher.py
@@ -102,6 +102,33 @@ def _acquire_lock(folder_path: str, storage_path: Optional[str]) -> bool:
 def _release_lock(folder_path: str, storage_path: Optional[str]) -> None:
     """Release and remove the watcher-slot lock for the given folder."""
     process_locks.release(_WATCHER_SCOPE, folder_path, storage_path)
+    _touch_watcher_signal(folder_path, storage_path)
+
+
+def _watcher_signal_path(folder_path: str, storage_path: Optional[str]) -> Path:
+    """Return the per-folder watcher release signal path."""
+    return process_locks.lock_path(_WATCHER_SCOPE, folder_path, storage_path).with_suffix(".signal")
+
+
+def _touch_watcher_signal(folder_path: str, storage_path: Optional[str]) -> None:
+    """Notify standby watcher managers that a folder lock may be available."""
+    signal_path = _watcher_signal_path(folder_path, storage_path)
+    payload = {
+        "scope": _WATCHER_SCOPE,
+        "target": folder_path,
+        "pid": os.getpid(),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    tmp_path = signal_path.with_name(f"{signal_path.name}.{os.getpid()}.tmp")
+    try:
+        tmp_path.write_text(json.dumps(payload), encoding="utf-8")
+        tmp_path.replace(signal_path)
+    except OSError:
+        logger.debug("Failed to touch watcher signal for %s", folder_path, exc_info=True)
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -343,6 +370,12 @@ class WatcherManager:
         self._log_file_handle = log_file_handle
         self._on_reindex = on_reindex
         self._stop_event: Optional[asyncio.Event] = None
+        # Standby tracking for failover
+        self._standby: set[str] = set()
+        self._standby_tasks: dict[str, asyncio.Task] = {}
+        self._last_takeover_attempt: dict[str, float] = {}
+        self._takeover_retry_seconds = 30.0
+        self._takeover_throttle_seconds = 1.0
 
     # ── Public API ──────────────────────────────────────────────────────────
 
@@ -353,6 +386,106 @@ class WatcherManager:
     def list_folders(self) -> list[str]:
         """Return sorted list of watched folders."""
         return sorted(self._watched)
+
+    # ── Standby helpers ──────────────────────────────────────────────────────
+
+    def _mark_standby(self, folder: str) -> None:
+        self._standby.add(folder)
+        task = self._standby_tasks.get(folder)
+        if task is None or task.done():
+            self._standby_tasks[folder] = asyncio.create_task(
+                self._standby_signal_loop(folder),
+                name=f"watch-standby:{folder}",
+            )
+
+    async def _standby_signal_loop(self, folder: str) -> None:
+        signal_path = _watcher_signal_path(folder, self._storage_path)
+        signal_dir = signal_path.parent
+        try:
+            from watchfiles import awatch
+        except ImportError:
+            return
+
+        while True:
+            if self._stop_event is not None and self._stop_event.is_set():
+                return
+            try:
+                async for changes in awatch(str(signal_dir), recursive=False, step=200):
+                    if self._stop_event is not None and self._stop_event.is_set():
+                        return
+                    changed_paths = {str(Path(path)) for _, path in changes}
+                    if str(signal_path) in changed_paths:
+                        await self.maybe_takeover(folder)
+                        if folder in self._watched:
+                            return
+            except asyncio.CancelledError:
+                raise  # Propagate without logging — cancellation is normal shutdown
+            except Exception:
+                logger.warning(
+                    "Watcher standby signal loop failed for %s, restarting in 5s",
+                    folder,
+                    exc_info=True,
+                )
+                await asyncio.sleep(5.0)
+
+    def _clear_standby(self, folder: str) -> None:
+        self._standby.discard(folder)
+        task = self._standby_tasks.pop(folder, None)
+        if task is not None:
+            task.cancel()
+        self._last_takeover_attempt.pop(folder, None)
+
+    def _start_watch_task(self, folder: str) -> asyncio.Task:
+        task = asyncio.create_task(
+            _watch_single(
+                folder_path=folder,
+                debounce_ms=self._debounce_ms,
+                use_ai_summaries=self._use_ai_summaries,
+                storage_path=self._storage_path,
+                extra_ignore_patterns=self._extra_ignore_patterns,
+                follow_symlinks=self._follow_symlinks,
+                on_reindex=self._on_reindex,
+                quiet=self._quiet,
+                log_file_handle=self._log_file_handle,
+            ),
+            name=f"watch:{folder}",
+        )
+        self._active[folder] = task
+        self._watched.add(folder)
+        return task
+
+    async def maybe_takeover(self, folder: str) -> dict:
+        """Try to become the active watcher for a standby folder."""
+        folder = str(Path(folder).expanduser().resolve())
+        if folder in self._watched:
+            return {"status": "already_watched", "folder": folder}
+
+        now = time.monotonic()
+        last_attempt = self._last_takeover_attempt.get(folder, 0.0)
+        if now - last_attempt < self._takeover_throttle_seconds:
+            return {"status": "throttled", "folder": folder}
+        self._last_takeover_attempt[folder] = now
+
+        if not _acquire_lock(folder, self._storage_path):
+            self._mark_standby(folder)
+            return {"status": "lock_failed", "folder": folder, "standby": True}
+
+        self._locked.add(folder)
+        try:
+            self._clear_standby(folder)
+            self._start_watch_task(folder)
+            _watcher_output(
+                f"WatcherManager: standby took over {folder}",
+                quiet=self._quiet,
+                log_file_handle=self._log_file_handle,
+            )
+            return {"status": "started", "folder": folder}
+        except Exception:
+            self._locked.discard(folder)
+            _release_lock(folder, self._storage_path)
+            raise
+
+    # ── Folder management ────────────────────────────────────────────────────
 
     async def add_folder(self, folder: str) -> dict:
         """Add a folder to watch, acquiring lock and starting watch task.
@@ -367,33 +500,20 @@ class WatcherManager:
 
         # Acquire lock
         if not _acquire_lock(folder, self._storage_path):
-            return {"status": "lock_failed", "folder": folder}
+            self._mark_standby(folder)
+            return {"status": "lock_failed", "folder": folder, "standby": True}
 
         self._locked.add(folder)
+        self._clear_standby(folder)
 
         try:
-            task = asyncio.create_task(
-                _watch_single(
-                    folder_path=folder,
-                    debounce_ms=self._debounce_ms,
-                    use_ai_summaries=self._use_ai_summaries,
-                    storage_path=self._storage_path,
-                    extra_ignore_patterns=self._extra_ignore_patterns,
-                    follow_symlinks=self._follow_symlinks,
-                    on_reindex=self._on_reindex,
-                    quiet=self._quiet,
-                    log_file_handle=self._log_file_handle,
-                ),
-                name=f"watch:{folder}",
-            )
-            self._active[folder] = task
-            self._watched.add(folder)
+            self._start_watch_task(folder)
             _watcher_output(
                 f"WatcherManager: started watching {folder}",
                 quiet=self._quiet,
                 log_file_handle=self._log_file_handle,
             )
-            return {"status": "started", "folder": folder, "task": task}
+            return {"status": "started", "folder": folder, "task": self._active[folder]}
         except Exception as exc:
             # Clean up on failure
             self._locked.discard(folder)
@@ -408,6 +528,9 @@ class WatcherManager:
         folder = str(Path(folder).expanduser().resolve())
 
         if folder not in self._watched:
+            # Also cancel any orphaned standby task so a future lock release
+            # does not unexpectedly restart watching for this folder.
+            self._clear_standby(folder)
             return {"status": "not_watched", "folder": folder}
 
         # Cancel and await task
@@ -505,6 +628,9 @@ class WatcherManager:
         _MAX_RESTARTS = 5
 
         while True:
+            # Exit immediately if already stopped
+            if self._stop_event.is_set():
+                break
             try:
                 while not self._stop_event.is_set():
                     # Check for crashed tasks and restart them
@@ -518,22 +644,14 @@ class WatcherManager:
                                     quiet=self._quiet,
                                     log_file_handle=self._log_file_handle,
                                 )
-                                # Restart
-                                new_task = asyncio.create_task(
-                                    _watch_single(
-                                        folder_path=folder,
-                                        debounce_ms=self._debounce_ms,
-                                        use_ai_summaries=self._use_ai_summaries,
-                                        storage_path=self._storage_path,
-                                        extra_ignore_patterns=self._extra_ignore_patterns,
-                                        follow_symlinks=self._follow_symlinks,
-                                        quiet=self._quiet,
-                                        log_file_handle=self._log_file_handle,
-                                    ),
-                                    name=f"watch:{folder}",
-                                )
-                                self._active[folder] = new_task
-                    await asyncio.sleep(5.0)
+                                # Restart — cancel the dead task and start a replacement
+                                task.cancel()
+                                self._start_watch_task(folder)
+                    # Retry standby folders on fallback interval
+                    for folder in list(self._standby):
+                        await self.maybe_takeover(folder)
+                    sleep_seconds = 5.0 if not self._standby else min(5.0, self._takeover_retry_seconds)
+                    await asyncio.sleep(sleep_seconds)
                 # Inner loop exited normally — reset restart counter
                 _restart_count = 0
             except asyncio.CancelledError:
@@ -562,6 +680,9 @@ class WatcherManager:
         """Signal the manager loop to stop."""
         if self._stop_event:
             self._stop_event.set()
+        # Clear all standby state
+        for folder in list(self._standby):
+            self._clear_standby(folder)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_watcher_dynamic.py
+++ b/tests/test_watcher_dynamic.py
@@ -244,6 +244,7 @@ class TestAutoWatchPathFromPathArg:
         # Mock watcher manager
         mock_mgr = AsyncMock(spec=WatcherManager)
         mock_mgr.is_watched.return_value = False
+        mock_mgr.maybe_takeover = AsyncMock(return_value={"status": "lock_failed"})
         mock_mgr.ensure_indexed = AsyncMock(return_value={"status": "indexed"})
         mock_mgr.add_folder = AsyncMock(return_value={"status": "started"})
 
@@ -272,6 +273,7 @@ class TestAutoWatchPathFromRepoArg:
         # Mock watcher manager
         mock_mgr = AsyncMock(spec=WatcherManager)
         mock_mgr.is_watched.return_value = False
+        mock_mgr.maybe_takeover = AsyncMock(return_value={"status": "lock_failed"})
         mock_mgr.ensure_indexed = AsyncMock(return_value={"status": "indexed"})
         mock_mgr.add_folder = AsyncMock(return_value={"status": "started"})
 
@@ -301,6 +303,7 @@ class TestAutoWatchTriggersOnUnwatched:
         # Mock watcher manager
         mock_mgr = AsyncMock(spec=WatcherManager)
         mock_mgr.is_watched.return_value = False  # Not watched
+        mock_mgr.maybe_takeover = AsyncMock(return_value={"status": "lock_failed"})
         mock_mgr.ensure_indexed = AsyncMock(return_value={"status": "indexed"})
         mock_mgr.add_folder = AsyncMock(return_value={"status": "started"})
 

--- a/tests/test_watcher_lock.py
+++ b/tests/test_watcher_lock.py
@@ -210,6 +210,45 @@ class TestAcquireReleaseLock:
 
 
 # ---------------------------------------------------------------------------
+# TestWatcherSignalFile
+# ---------------------------------------------------------------------------
+
+class TestWatcherSignalFile:
+    def test_signal_path_is_next_to_lock_file(self, tmp_path):
+        from jcodemunch_mcp.watcher import _watcher_signal_path
+        from jcodemunch_mcp.storage import process_locks
+
+        folder = _make_folder(tmp_path)
+        storage = tmp_path / "storage"
+
+        lock_path = process_locks.lock_path("watcher", str(folder), str(storage))
+        signal_path = _watcher_signal_path(str(folder), str(storage))
+
+        assert signal_path.parent == lock_path.parent
+        assert signal_path.name == lock_path.name.replace(".lock", ".signal")
+
+    def test_release_lock_touches_signal_file(self, tmp_path):
+        from jcodemunch_mcp.watcher import _acquire_lock, _release_lock, _watcher_signal_path
+
+        folder = _make_folder(tmp_path)
+        storage = tmp_path / "storage"
+        folder_s = str(folder)
+        storage_s = str(storage)
+
+        assert _acquire_lock(folder_s, storage_s)
+        signal_path = _watcher_signal_path(folder_s, storage_s)
+        assert not signal_path.exists()
+
+        _release_lock(folder_s, storage_s)
+
+        assert signal_path.exists()
+        payload = json.loads(signal_path.read_text(encoding="utf-8"))
+        assert payload["scope"] == "watcher"
+        assert payload["target"] == folder_s
+        assert payload["pid"] == os.getpid()
+
+
+# ---------------------------------------------------------------------------
 # TestIdleTimeoutWatchdog
 # ---------------------------------------------------------------------------
 
@@ -539,6 +578,247 @@ class TestWindowsSignalHandling:
             "for async-safe event loop integration. "
             f"Windows block:\n{windows_block}"
         )
+
+
+# ---------------------------------------------------------------------------
+# TestWatcherManagerStandby
+# ---------------------------------------------------------------------------
+
+class TestWatcherManagerStandby:
+    @pytest.mark.asyncio
+    async def test_add_folder_registers_standby_when_lock_is_held(self, tmp_path, monkeypatch):
+        from jcodemunch_mcp import watcher
+
+        folder = _make_folder(tmp_path)
+        manager = watcher.WatcherManager(storage_path=str(tmp_path / "storage"), quiet=True)
+
+        monkeypatch.setattr(watcher, "_acquire_lock", lambda folder_path, storage_path: False)
+
+        async def never_called_watch_single(**kwargs):
+            raise AssertionError("watch task should not start when lock is held")
+
+        monkeypatch.setattr(watcher, "_watch_single", never_called_watch_single)
+
+        result = await manager.add_folder(str(folder))
+
+        assert result["status"] == "lock_failed"
+        assert result["standby"] is True
+        assert str(folder.resolve()) in manager._standby
+        assert str(folder.resolve()) not in manager._watched
+
+        manager.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_clears_standby_state(self, tmp_path, monkeypatch):
+        from jcodemunch_mcp import watcher
+
+        folder = _make_folder(tmp_path)
+        manager = watcher.WatcherManager(storage_path=str(tmp_path / "storage"), quiet=True)
+        monkeypatch.setattr(watcher, "_acquire_lock", lambda folder_path, storage_path: False)
+
+        await manager.add_folder(str(folder))
+        manager.stop()
+
+        assert not manager._standby
+
+    @pytest.mark.asyncio
+    async def test_maybe_takeover_starts_watcher_after_lock_becomes_available(self, tmp_path, monkeypatch):
+        from jcodemunch_mcp import watcher
+
+        folder = _make_folder(tmp_path)
+        folder_s = str(folder.resolve())
+        manager = watcher.WatcherManager(storage_path=str(tmp_path / "storage"), quiet=True)
+        lock_results = iter([False, True])
+        started = asyncio.Event()
+
+        monkeypatch.setattr(watcher, "_acquire_lock", lambda folder_path, storage_path: next(lock_results))
+
+        async def fake_watch_single(**kwargs):
+            started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(watcher, "_watch_single", fake_watch_single)
+
+        first = await manager.add_folder(folder_s)
+
+        assert first["status"] == "lock_failed"
+        assert folder_s in manager._standby
+
+        takeover = await manager.maybe_takeover(folder_s)
+
+        assert takeover["status"] == "started"
+        assert folder_s in manager._watched
+        assert folder_s in manager._locked
+        assert folder_s not in manager._standby
+        # Yield to event loop to allow the scheduled watch task to start
+        await asyncio.sleep(0)
+        assert started.is_set()
+
+        manager.stop()
+        for task in list(manager._active.values()):
+            task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_add_folder_starts_standby_signal_task(self, tmp_path, monkeypatch):
+        from jcodemunch_mcp import watcher
+
+        folder = _make_folder(tmp_path)
+        folder_s = str(folder.resolve())
+        manager = watcher.WatcherManager(storage_path=str(tmp_path / "storage"), quiet=True)
+
+        monkeypatch.setattr(watcher, "_acquire_lock", lambda folder_path, storage_path: False)
+
+        async def fake_signal_loop(folder):
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(manager, "_standby_signal_loop", fake_signal_loop)
+        result = await manager.add_folder(folder_s)
+
+        assert result["status"] == "lock_failed"
+        assert folder_s in manager._standby_tasks
+
+        manager.stop()
+
+    @pytest.mark.asyncio
+    async def test_run_retries_standby_folders_on_fallback_interval(self, tmp_path, monkeypatch):
+        from jcodemunch_mcp import watcher
+
+        folder = _make_folder(tmp_path)
+        folder_s = str(folder.resolve())
+        manager = watcher.WatcherManager(storage_path=str(tmp_path / "storage"), quiet=True)
+        # Set stop_event AFTER __init__ so run() doesn't create its own
+        stop_evt = asyncio.Event()
+        manager._stop_event = stop_evt
+        manager._standby.add(folder_s)
+        manager._takeover_retry_seconds = 0.05
+        attempts = 0
+
+        async def fake_maybe_takeover(folder):
+            nonlocal attempts
+            attempts += 1
+            stop_evt.set()
+            return {"status": "lock_failed", "folder": folder, "standby": True}
+
+        monkeypatch.setattr(manager, "maybe_takeover", fake_maybe_takeover)
+
+        run_task = asyncio.create_task(manager.run())
+        await asyncio.wait_for(run_task, timeout=5.0)
+
+        assert attempts == 1
+
+    @pytest.mark.asyncio
+    async def test_remove_folder_clears_standby_task(self, tmp_path, monkeypatch):
+        """remove_folder must cancel the standby signal loop even when folder was never locked."""
+        from jcodemunch_mcp import watcher
+
+        folder = _make_folder(tmp_path)
+        folder_s = str(folder.resolve())
+        manager = watcher.WatcherManager(storage_path=str(tmp_path / "storage"), quiet=True)
+
+        # Simulate a folder that was added but only got as far as standby
+        # (lock was held by another process at add_folder time)
+        monkeypatch.setattr(watcher, "_acquire_lock", lambda fp, sp: False)
+
+        async def fake_signal_loop(f):
+            await asyncio.Event().wait()  # would loop forever if not cancelled
+
+        monkeypatch.setattr(manager, "_standby_signal_loop", fake_signal_loop)
+
+        add_result = await manager.add_folder(folder_s)
+        assert add_result["status"] == "lock_failed"
+        assert folder_s in manager._standby
+        assert folder_s in manager._standby_tasks
+
+        # remove_folder should cancel the orphaned standby task
+        remove_result = await manager.remove_folder(folder_s)
+        assert remove_result["status"] == "not_watched"
+        assert folder_s not in manager._standby
+        assert folder_s not in manager._standby_tasks
+
+        manager.stop()
+
+    @pytest.mark.asyncio
+    async def test_add_folder_clears_standby_on_lock_success(self, tmp_path, monkeypatch):
+        """add_folder must clear standby state when lock acquisition succeeds."""
+        from jcodemunch_mcp import watcher
+
+        folder = _make_folder(tmp_path)
+        folder_s = str(folder.resolve())
+        manager = watcher.WatcherManager(storage_path=str(tmp_path / "storage"), quiet=True)
+        lock_results = iter([False, True])
+
+        monkeypatch.setattr(watcher, "_acquire_lock", lambda fp, sp: next(lock_results))
+
+        async def fake_watch_single(**kwargs):
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(watcher, "_watch_single", fake_watch_single)
+
+        async def fake_signal_loop(f):
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(manager, "_standby_signal_loop", fake_signal_loop)
+
+        first = await manager.add_folder(folder_s)
+        assert first["status"] == "lock_failed"
+        assert folder_s in manager._standby
+        assert folder_s in manager._standby_tasks
+
+        second = await manager.add_folder(folder_s)
+        assert second["status"] == "started"
+        assert folder_s in manager._watched
+        assert folder_s not in manager._standby
+        assert folder_s not in manager._standby_tasks
+
+        manager.stop()
+        for task in list(manager._active.values()):
+            task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_maybe_takeover_throttles_rapid_calls(self, tmp_path, monkeypatch):
+        """Two rapid maybe_takeover calls should return 'throttled' on the second."""
+        from jcodemunch_mcp import watcher
+
+        folder = _make_folder(tmp_path)
+        folder_s = str(folder.resolve())
+        manager = watcher.WatcherManager(storage_path=str(tmp_path / "storage"), quiet=True)
+        manager._takeover_throttle_seconds = 10.0
+
+        monkeypatch.setattr(watcher, "_acquire_lock", lambda fp, sp: False)
+
+        first = await manager.maybe_takeover(folder_s)
+        assert first["status"] == "lock_failed"
+
+        second = await manager.maybe_takeover(folder_s)
+        assert second["status"] == "throttled"
+
+        manager.stop()
+
+    @pytest.mark.asyncio
+    async def test_maybe_takeover_on_unknown_folder(self, tmp_path, monkeypatch):
+        """maybe_takeover on a folder never passed through add_folder should still work."""
+        from jcodemunch_mcp import watcher
+
+        folder = _make_folder(tmp_path)
+        folder_s = str(folder.resolve())
+        manager = watcher.WatcherManager(storage_path=str(tmp_path / "storage"), quiet=True)
+
+        monkeypatch.setattr(watcher, "_acquire_lock", lambda fp, sp: True)
+
+        async def fake_watch_single(**kwargs):
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(watcher, "_watch_single", fake_watch_single)
+
+        result = await manager.maybe_takeover(folder_s)
+        assert result["status"] == "started"
+        assert folder_s in manager._watched
+        assert folder_s in manager._locked
+        assert folder_s not in manager._standby
+
+        manager.stop()
+        for task in list(manager._active.values()):
+            task.cancel()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_watcher_lock.py
+++ b/tests/test_watcher_lock.py
@@ -707,6 +707,63 @@ class TestWatcherManagerStandby:
         assert attempts == 1
 
     @pytest.mark.asyncio
+    async def test_run_uses_configured_standby_retry_interval(self, tmp_path, monkeypatch):
+        from jcodemunch_mcp import watcher
+
+        folder = _make_folder(tmp_path)
+        folder_s = str(folder.resolve())
+        manager = watcher.WatcherManager(storage_path=str(tmp_path / "storage"), quiet=True)
+        stop_evt = asyncio.Event()
+        manager._stop_event = stop_evt
+        manager._standby.add(folder_s)
+        manager._takeover_retry_seconds = 9.0
+        sleeps = []
+
+        async def fake_maybe_takeover(folder):
+            stop_evt.set()
+            return {"status": "lock_failed", "folder": folder, "standby": True}
+
+        async def fake_sleep(seconds):
+            sleeps.append(seconds)
+
+        monkeypatch.setattr(manager, "maybe_takeover", fake_maybe_takeover)
+        monkeypatch.setattr(watcher.asyncio, "sleep", fake_sleep)
+
+        await manager.run()
+
+        assert sleeps == [9.0]
+
+    @pytest.mark.asyncio
+    async def test_stop_releases_active_locks(self, tmp_path, monkeypatch):
+        from jcodemunch_mcp import watcher
+
+        folder = _make_folder(tmp_path)
+        folder_s = str(folder.resolve())
+        storage = tmp_path / "storage"
+        manager = watcher.WatcherManager(storage_path=str(storage), quiet=True)
+        released = []
+
+        monkeypatch.setattr(watcher, "_acquire_lock", lambda fp, sp: True)
+
+        def fake_release_lock(fp, sp):
+            released.append((fp, sp))
+
+        async def fake_watch_single(**kwargs):
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(watcher, "_release_lock", fake_release_lock)
+        monkeypatch.setattr(watcher, "_watch_single", fake_watch_single)
+
+        result = await manager.add_folder(folder_s)
+        assert result["status"] == "started"
+
+        manager.stop()
+
+        assert released == [(folder_s, str(storage))]
+        assert folder_s not in manager._locked
+        assert folder_s not in manager._watched
+
+    @pytest.mark.asyncio
     async def test_remove_folder_clears_standby_task(self, tmp_path, monkeypatch):
         """remove_folder must cancel the standby signal loop even when folder was never locked."""
         from jcodemunch_mcp import watcher

--- a/tests/test_watcher_serve.py
+++ b/tests/test_watcher_serve.py
@@ -977,3 +977,116 @@ class TestDefaultUseAiSummaries:
     def test_off_string_maps_to_false(self):
         """'off' string normalizes to False."""
         assert self._call("off") is False
+
+
+class TestAutoWatchTakeover:
+    """Tests for opportunistic standby takeover via _auto_watch_if_needed."""
+
+    @pytest.mark.asyncio
+    async def test_auto_watch_pokes_standby_takeover_before_indexing(self, tmp_path, monkeypatch):
+        from jcodemunch_mcp import server
+
+        folder = tmp_path / "repo"
+        folder.mkdir()
+        calls = []
+
+        class FakeWatcherManager:
+            def is_watched(self, folder_arg):
+                return False
+
+            async def maybe_takeover(self, folder_arg):
+                calls.append(("maybe_takeover", folder_arg))
+                return {"status": "started", "folder": folder_arg}
+
+            async def ensure_indexed(self, folder_arg):
+                calls.append(("ensure_indexed", folder_arg))
+
+            async def add_folder(self, folder_arg):
+                calls.append(("add_folder", folder_arg))
+
+        monkeypatch.setattr(server, "_watcher_manager", FakeWatcherManager())
+        monkeypatch.setattr(server.config_module, "get", lambda key, default=None: True if key == "watch" else default)
+
+        await server._auto_watch_if_needed("search_symbols", {"path": str(folder)}, None)
+
+        assert calls == [("maybe_takeover", str(folder.resolve()))]
+
+    @pytest.mark.asyncio
+    async def test_auto_watch_falls_through_when_takeover_fails(self, tmp_path, monkeypatch):
+        from jcodemunch_mcp import server
+
+        folder = tmp_path / "repo"
+        folder.mkdir()
+        calls = []
+
+        class FakeWatcherManager:
+            def is_watched(self, folder_arg):
+                return False
+
+            async def maybe_takeover(self, folder_arg):
+                calls.append(("maybe_takeover", folder_arg))
+                return {"status": "lock_failed", "folder": folder_arg, "standby": True}
+
+            async def ensure_indexed(self, folder_arg, **kwargs):
+                calls.append(("ensure_indexed", folder_arg))
+
+            async def add_folder(self, folder_arg):
+                calls.append(("add_folder", folder_arg))
+                return {"status": "started", "folder": folder_arg}
+
+        monkeypatch.setattr(server, "_watcher_manager", FakeWatcherManager())
+        monkeypatch.setattr(server.config_module, "get", lambda key, default=None: True if key == "watch" else default)
+
+        await server._auto_watch_if_needed("search_symbols", {"path": str(folder)}, None)
+
+        resolved = str(folder.resolve())
+        assert calls == [
+            ("maybe_takeover", resolved),
+            ("ensure_indexed", resolved),
+            ("add_folder", resolved),
+        ]
+
+
+class TestWatcherStandbyFailover:
+    """End-to-end standby failover lifecycle test."""
+
+    @pytest.mark.asyncio
+    async def test_second_server_can_take_over_after_first_releases_lock(self, tmp_path, monkeypatch):
+        from jcodemunch_mcp import server
+        from jcodemunch_mcp.watcher import WatcherManager
+
+        folder = tmp_path / "repo"
+        folder.mkdir()
+        storage = tmp_path / "storage"
+        started = []
+
+        async def fake_watch_single(**kwargs):
+            started.append(kwargs["folder_path"])
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(server, "watch_folders", object())
+        monkeypatch.setattr(server, "WatcherManager", WatcherManager)
+
+        import jcodemunch_mcp.watcher as watcher_mod
+        monkeypatch.setattr(watcher_mod, "_watch_single", fake_watch_single)
+
+        manager1 = WatcherManager(storage_path=str(storage), quiet=True)
+        manager2 = WatcherManager(storage_path=str(storage), quiet=True)
+
+        first = await manager1.add_folder(str(folder))
+        second = await manager2.add_folder(str(folder))
+
+        assert first["status"] == "started"
+        assert second["status"] == "lock_failed"
+        assert second["standby"] is True
+
+        await manager1.remove_folder(str(folder))
+        takeover = await manager2.maybe_takeover(str(folder))
+
+        assert takeover["status"] == "started"
+        assert str(folder.resolve()) in manager2._watched
+
+        manager1.stop()
+        manager2.stop()
+        for task in list(manager1._active.values()) + list(manager2._active.values()):
+            task.cancel()

--- a/tests/test_watcher_serve.py
+++ b/tests/test_watcher_serve.py
@@ -983,7 +983,7 @@ class TestAutoWatchTakeover:
     """Tests for opportunistic standby takeover via _auto_watch_if_needed."""
 
     @pytest.mark.asyncio
-    async def test_auto_watch_pokes_standby_takeover_before_indexing(self, tmp_path, monkeypatch):
+    async def test_auto_watch_indexes_after_standby_takeover_before_tool_runs(self, tmp_path, monkeypatch):
         from jcodemunch_mcp import server
 
         folder = tmp_path / "repo"
@@ -998,7 +998,7 @@ class TestAutoWatchTakeover:
                 calls.append(("maybe_takeover", folder_arg))
                 return {"status": "started", "folder": folder_arg}
 
-            async def ensure_indexed(self, folder_arg):
+            async def ensure_indexed(self, folder_arg, **kwargs):
                 calls.append(("ensure_indexed", folder_arg))
 
             async def add_folder(self, folder_arg):
@@ -1009,7 +1009,11 @@ class TestAutoWatchTakeover:
 
         await server._auto_watch_if_needed("search_symbols", {"path": str(folder)}, None)
 
-        assert calls == [("maybe_takeover", str(folder.resolve()))]
+        resolved = str(folder.resolve())
+        assert calls == [
+            ("maybe_takeover", resolved),
+            ("ensure_indexed", resolved),
+        ]
 
     @pytest.mark.asyncio
     async def test_auto_watch_falls_through_when_takeover_fails(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Adds resilient standby failover for the embedded watcher so a second server watching the same folder can wait in standby and take over when the active watcher releases its lock.

## Why

Running multiple MCP servers against the same local repo used to leave only one process able to watch the folder. Other servers that lost the watcher lock had no reliable takeover path, so they could remain unwatched until restarted. This made index freshness depend on which server started first and whether that server stayed alive.

## What was done

- Added standby tracking to `WatcherManager` for folders that fail watcher-lock acquisition.
- Added per-folder release signal files so standby managers can wake up promptly after lock release.
- Added opportunistic takeover from `_auto_watch_if_needed()` before normal reindex/watch fallback.
- Preserved freshness by awaiting `ensure_indexed()` before returning from auto-watch after takeover.
- Hardened cleanup so `remove_folder()` and `stop()` clear standby state and release active locks.
- Reused `_start_watch_task()` for restart/takeover paths so `on_reindex` and watcher options stay consistent.
- Added regression coverage for standby registration, takeover, signal files, retry interval behavior, lock cleanup, and auto-watch freshness.

## Before And After

| Area | Before | After |
| --- | --- | --- |
| Second server startup | Lost the watcher lock and stayed unwatched. | Enters standby and can take over later. |
| Active watcher shutdown | Lock release did not notify standby watchers. | Lock release writes a per-folder signal file. |
| Standby takeover | Required another explicit watch attempt or process restart. | Standby managers retry and react to release signals. |
| Auto-watch freshness | Takeover could return before initial indexing finished. | Auto-watch awaits `ensure_indexed()` before tool dispatch. |
| Watcher restart path | Restart logic manually recreated watch tasks. | Restart uses the shared `_start_watch_task()` helper. |
| `stop()` cleanup | Active tasks and locks could remain tracked/held. | Active tasks are cancelled and locks are released. |
| Retry interval | Standby retry interval was capped at 5 seconds. | Standby retry uses `_takeover_retry_seconds`. |
| Test coverage | No standby failover regression coverage. | Added focused tests across watcher lock, serve, and dynamic watcher paths. |