### PR TITLE
fix: restore local-first index identity default, make git identity opt-in

### DIFF
--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -1407,9 +1407,11 @@ def generate_template() -> str:
 
   // "identity_mode": "git",
   //   How index_folder derives the repo identifier for a local path.
-  //   Default is local: `local/<basename>-<hash>`, with no git detection
-  //   or retargeting. Uncomment and set to "git" to opt in to v1.95+
-  //   git identity (`<owner>/<repo>`) and monorepo subdir merging.
+  //   Existing indexes keep their current identity. New indexes default
+  //   to local: `local/<basename>-<hash>`, with no git detection or
+  //   retargeting. Uncomment and set to "git" to opt in to v1.95+ git
+  //   identity (`<owner>/<repo>`) and monorepo subdir merging for new
+  //   indexes.
 
   // "git_root_identity": true,
   //   Deprecated legacy boolean alias for identity_mode. Uncomment and set

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -1405,6 +1405,16 @@ def generate_template() -> str:
   //   Enable context providers for enhanced AI summarization.
   //   Set false to disable (faster indexing, less context).
 
+  // "identity_mode": "git",
+  //   How index_folder derives the repo identifier for a local path.
+  //   Default is local: `local/<basename>-<hash>`, with no git detection
+  //   or retargeting. Uncomment and set to "git" to opt in to v1.95+
+  //   git identity (`<owner>/<repo>`) and monorepo subdir merging.
+
+  // "git_root_identity": true,
+  //   Deprecated legacy boolean alias for identity_mode. Uncomment and set
+  //   true to opt in to git identity when identity_mode is not set.
+
   // === Meta Response Control ===
   // Allowlist of _meta fields to include in responses.
   // [] (default) = no _meta at all (maximum token savings).

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -1407,15 +1407,29 @@ def generate_template() -> str:
 
   // "identity_mode": "git",
   //   How index_folder derives the repo identifier for a local path.
-  //   Existing indexes keep their current identity. New indexes default
-  //   to local: `local/<basename>-<hash>`, with no git detection or
-  //   retargeting. Uncomment and set to "git" to opt in to v1.95+ git
-  //   identity (`<owner>/<repo>`) and monorepo subdir merging for new
-  //   indexes.
+  //   Existing indexes keep their current identity regardless of this
+  //   setting — this only affects NEW indexes.
+  //
+  //   Choices:
+  //     "local" (default) — repo ID is `local/<basename>-<hash>`.
+  //       No git subprocess, no remote detection. Fast and portable.
+  //       Each folder gets its own index. Works for non-git projects,
+  //       local-only clones, and simple git workflows.
+  //
+  //     "git" — repo ID is `<owner>/<repo>` derived from the origin
+  //       remote URL. Runs a git subprocess on every index/reindex.
+  //       Enables monorepo subdir merging (multiple subdirs of the
+  //       same git root share one index). Requires a git working tree
+  //       with an origin remote. Falls back to local when detection
+  //       fails.
+  //
+  //   To switch an existing index: run invalidate_cache first, then
+  //   re-index with the new mode.
 
   // "git_root_identity": true,
-  //   Deprecated legacy boolean alias for identity_mode. Uncomment and set
-  //   true to opt in to git identity when identity_mode is not set.
+  //   Deprecated boolean alias for identity_mode. When identity_mode
+  //   is not set, `true` here is equivalent to `"identity_mode": "git"`.
+  //   Prefer identity_mode for new configurations.
 
   // === Meta Response Control ===
   // Allowlist of _meta fields to include in responses.

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -782,6 +782,12 @@ def _build_tools_list() -> list[Tool]:
                         "type": "array",
                         "items": {"type": "string"},
                         "description": "Optional list of explicit paths to index. When provided, the directory walk is skipped; only these files (and the contents of any directories in the list) are indexed. Entries may be absolute or relative to `path`. Useful for batch-indexing exactly the files an agent already knows about — e.g. the source files git just touched, the changeset for a PR, or an rg / fd match list. Validation matches the walk path (outside-root, traversal, symlink-escape, oversize, unsupported-extension all warn-and-skip)."
+                    },
+                    "identity_mode": {
+                        "type": "string",
+                        "enum": ["config", "local", "git"],
+                        "description": "How to derive the local-folder repo identity. Default config keeps local-first behavior unless an existing git-keyed index or config opts in. Use 'git' to opt in to git-root identity and monorepo subdir merging.",
+                        "default": "config"
                     }
                 },
                 "required": ["path"]
@@ -3702,6 +3708,7 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                     follow_symlinks=arguments.get("follow_symlinks", False),
                     incremental=arguments.get("incremental", True),
                     paths=arguments.get("paths"),
+                    identity_mode=arguments.get("identity_mode", "config"),
                     progress_cb=_progress_cb,
                 )
             )

--- a/src/jcodemunch_mcp/storage/git_root.py
+++ b/src/jcodemunch_mcp/storage/git_root.py
@@ -44,6 +44,14 @@ class IdentityDecision(NamedTuple):
     walk_root: str
 
 
+class IdentityModeConflict(ValueError):
+    """Raised when an existing index blocks an explicit identity-mode switch."""
+
+
+class IdentityModeAmbiguous(ValueError):
+    """Raised when both local and git identity forms match a path."""
+
+
 def _local_repo_name(folder_path: Path) -> str:
     digest = hashlib.sha1(str(folder_path).encode("utf-8")).hexdigest()[:8]
     return f"{folder_path.name}-{digest}"
@@ -71,11 +79,14 @@ def _existing_git_identity(path: Path, store) -> Optional[IdentityDecision]:
         if "/" not in repo_id:
             continue
         owner, name = repo_id.split("/", 1)
-        try:
-            index = store.load_index(owner, name)
-        except Exception:
-            index = None
-        git_root = getattr(index, "git_root", "") if index is not None else ""
+        if "git_root" in entry:
+            git_root = entry.get("git_root", "") or ""
+        else:
+            try:
+                index = store.load_index(owner, name)
+            except Exception:
+                index = None
+            git_root = getattr(index, "git_root", "") if index is not None else ""
         if _contains_path(git_root, path):
             return IdentityDecision(
                 mode="git",
@@ -85,6 +96,47 @@ def _existing_git_identity(path: Path, store) -> Optional[IdentityDecision]:
                 walk_root=str(Path(git_root).resolve()),
             )
     return None
+
+
+def _configured_identity_mode(folder_path: Path) -> str:
+    try:
+        from .. import config as _config
+        configured = _config.get("identity_mode", None, repo=str(folder_path))
+        if isinstance(configured, str) and configured in {"local", "git"}:
+            return configured
+        if _config.get("git_root_identity", False, repo=str(folder_path)):
+            return "git"
+    except Exception:
+        pass
+    return "local"
+
+
+def _identity_conflict_message(existing: IdentityDecision, requested: str) -> str:
+    return (
+        f"Existing index {existing.owner}/{existing.name} uses {existing.mode} identity. "
+        f"invalidate it before recreating this path with {requested} identity."
+    )
+
+
+def _local_identity_if_present(path: Path, local_name: str, store) -> Optional[IdentityDecision]:
+    if store is None:
+        return None
+    try:
+        if not store.inspect_index("local", local_name).index_present:
+            return None
+    except Exception:
+        return None
+    return IdentityDecision(
+        mode="local",
+        owner="local",
+        name=local_name,
+        git_root="",
+        walk_root=str(path),
+    )
+
+
+def _path_has_git_root(folder_path: Path) -> bool:
+    return _find_git_root(folder_path) is not None
 
 
 def resolve_index_identity(
@@ -102,29 +154,34 @@ def resolve_index_identity(
         raise ValueError("identity_mode must be one of: config, local, git")
 
     local_name = _local_repo_name(folder_path)
-    if requested == "config" and store is not None:
-        try:
-            if store.inspect_index("local", local_name).index_present:
-                requested = "local"
-            else:
-                existing_git = _existing_git_identity(folder_path, store)
-                if existing_git is not None:
-                    return existing_git
-        except Exception:
-            logger.debug("existing identity probe failed for %s", folder_path, exc_info=True)
+    configured = _configured_identity_mode(folder_path) if requested == "config" else requested
+    local_existing = _local_identity_if_present(folder_path, local_name, store)
+
+    if requested == "git" and local_existing is not None:
+        raise IdentityModeConflict(_identity_conflict_message(local_existing, "git"))
+
+    should_probe_git_identity = store is not None and (
+        requested == "local" or _path_has_git_root(folder_path)
+    )
+    existing_git = _existing_git_identity(folder_path, store) if should_probe_git_identity else None
+
+    if local_existing is not None and existing_git is not None:
+        raise IdentityModeAmbiguous(
+            "Both local and git identity indexes already match this path. "
+            "Invalidate one of them before indexing or resolving this path."
+        )
 
     if requested == "config":
-        try:
-            from .. import config as _config
-            configured = _config.get("identity_mode", None, repo=str(folder_path))
-            if isinstance(configured, str) and configured in {"local", "git"}:
-                requested = configured
-            elif _config.get("git_root_identity", False, repo=str(folder_path)):
-                requested = "git"
-            else:
-                requested = "local"
-        except Exception:
-            requested = "local"
+        if local_existing is not None:
+            return local_existing
+        if existing_git is not None:
+            return existing_git
+        requested = configured
+    elif requested == "local":
+        if existing_git is not None:
+            raise IdentityModeConflict(_identity_conflict_message(existing_git, "local"))
+        if local_existing is not None:
+            return local_existing
 
     if requested == "git":
         ident = detect_git_root(str(folder_path))

--- a/src/jcodemunch_mcp/storage/git_root.py
+++ b/src/jcodemunch_mcp/storage/git_root.py
@@ -12,6 +12,7 @@ one `elastic/kibana` index lands in v1.96.
 """
 
 import logging
+import hashlib
 import re
 import subprocess
 from pathlib import Path
@@ -31,6 +32,119 @@ class GitRootIdentity(NamedTuple):
     git_root: str
     owner: str
     name: str
+
+
+class IdentityDecision(NamedTuple):
+    """Resolved local-folder index identity."""
+
+    mode: str
+    owner: str
+    name: str
+    git_root: str
+    walk_root: str
+
+
+def _local_repo_name(folder_path: Path) -> str:
+    digest = hashlib.sha1(str(folder_path).encode("utf-8")).hexdigest()[:8]
+    return f"{folder_path.name}-{digest}"
+
+
+def _contains_path(root: str, path: Path) -> bool:
+    if not root:
+        return False
+    try:
+        root_path = Path(root).expanduser().resolve()
+        return path == root_path or path.is_relative_to(root_path)
+    except Exception:
+        return False
+
+
+def _existing_git_identity(path: Path, store) -> Optional[IdentityDecision]:
+    if store is None:
+        return None
+    try:
+        entries = store.list_repos()
+    except Exception:
+        return None
+    for entry in entries:
+        repo_id = entry.get("repo", "")
+        if "/" not in repo_id:
+            continue
+        owner, name = repo_id.split("/", 1)
+        try:
+            index = store.load_index(owner, name)
+        except Exception:
+            index = None
+        git_root = getattr(index, "git_root", "") if index is not None else ""
+        if _contains_path(git_root, path):
+            return IdentityDecision(
+                mode="git",
+                owner=owner,
+                name=name,
+                git_root=str(Path(git_root).resolve()),
+                walk_root=str(Path(git_root).resolve()),
+            )
+    return None
+
+
+def resolve_index_identity(
+    path: str,
+    mode: str = "config",
+    store=None,
+) -> IdentityDecision:
+    """Resolve how a local path should be keyed in the index store."""
+    folder_path = Path(path).expanduser().resolve()
+    if folder_path.is_file():
+        folder_path = folder_path.parent
+
+    requested = (mode or "config").lower()
+    if requested not in {"config", "local", "git"}:
+        raise ValueError("identity_mode must be one of: config, local, git")
+
+    local_name = _local_repo_name(folder_path)
+    if requested == "config" and store is not None:
+        try:
+            if store.inspect_index("local", local_name).index_present:
+                requested = "local"
+            else:
+                existing_git = _existing_git_identity(folder_path, store)
+                if existing_git is not None:
+                    return existing_git
+        except Exception:
+            logger.debug("existing identity probe failed for %s", folder_path, exc_info=True)
+
+    if requested == "config":
+        try:
+            from .. import config as _config
+            configured = _config.get("identity_mode", None, repo=str(folder_path))
+            if isinstance(configured, str) and configured in {"local", "git"}:
+                requested = configured
+            elif _config.get("git_root_identity", False, repo=str(folder_path)):
+                requested = "git"
+            else:
+                requested = "local"
+        except Exception:
+            requested = "local"
+
+    if requested == "git":
+        ident = detect_git_root(str(folder_path))
+        if ident is not None:
+            git_root = str(Path(ident.git_root).resolve())
+            return IdentityDecision(
+                mode="git",
+                owner=ident.owner,
+                name=ident.name,
+                git_root=git_root,
+                walk_root=git_root,
+            )
+
+    return IdentityDecision(
+        mode="local",
+        owner="local",
+        name=local_name,
+        git_root="",
+        walk_root=str(folder_path),
+    )
 
 
 # git@github.com:owner/repo.git   |   https://github.com/owner/repo(.git)

--- a/src/jcodemunch_mcp/storage/index_store.py
+++ b/src/jcodemunch_mcp/storage/index_store.py
@@ -845,6 +845,8 @@ class IndexStore:
         }
         if data.get("git_head"):
             repo_entry["git_head"] = data["git_head"]
+        if data.get("git_root"):
+            repo_entry["git_root"] = data["git_root"]
         if data.get("display_name"):
             repo_entry["display_name"] = data["display_name"]
         if data.get("source_root"):

--- a/src/jcodemunch_mcp/storage/sqlite_store.py
+++ b/src/jcodemunch_mcp/storage/sqlite_store.py
@@ -1862,6 +1862,7 @@ class SQLiteIndexStore:
             "symbol_count": symbol_count,
             "file_count": file_count,
             "git_head": meta.get("git_head", ""),
+            "git_root": meta.get("git_root", ""),
             "display_name": meta.get("display_name", ""),
             "source_root": remap(meta.get("source_root", ""), _pairs),
             "index_present": True,

--- a/src/jcodemunch_mcp/tools/index_folder.py
+++ b/src/jcodemunch_mcp/tools/index_folder.py
@@ -34,6 +34,7 @@ from ..security import (
     SKIP_FILES
 )
 from ..storage import IndexStore
+from ..storage.git_root import resolve_index_identity
 from ..storage.index_store import _file_hash, _file_hash_bytes, _get_git_head, _get_git_branch
 from ..summarizer import summarize_symbols
 from ..reindex_state import WatcherChange
@@ -312,7 +313,11 @@ def _merge_subdir_into_existing(
     }
 
 
-def _resolve_repo_identity(folder_path: Path) -> tuple[str, str, str]:
+def _resolve_repo_identity(
+    folder_path: Path,
+    mode: str = "config",
+    store: Optional[IndexStore] = None,
+) -> tuple[str, str, str]:
     """Resolve the storage identity for an indexing run.
 
     Returns ``(owner, repo_name, git_root)``.  ``git_root`` is the
@@ -329,26 +334,8 @@ def _resolve_repo_identity(folder_path: Path) -> tuple[str, str, str]:
     basename-plus-hash form when no ``.git`` is found anywhere up the
     tree or when the knob is off.
     """
-    if _config.get("git_root_identity", True, repo=str(folder_path)):
-        try:
-            from ..storage.git_root import detect_git_root
-            ident = detect_git_root(str(folder_path))
-        except Exception:
-            logger.debug("git-root detection failed", exc_info=True)
-            ident = None
-        if ident is not None:
-            if ident.owner == "local":
-                # Git working tree without a usable `origin` remote.
-                # Preserve today's basename-plus-hash identity so unrelated
-                # local projects that share a folder basename never
-                # collide.  We still record the git_root on the manifest
-                # for v1.96 merge logic to use.
-                return "local", _local_repo_name(folder_path), ident.git_root
-            # Configured remote — use `<owner>/<name>` identity (matches
-            # what `index_repo <owner>/<name>` produces for the same repo).
-            return ident.owner, ident.name, ident.git_root
-    # No git working tree, or knob disabled: pre-v1.95 basename-plus-hash.
-    return "local", _local_repo_name(folder_path), ""
+    decision = resolve_index_identity(str(folder_path), mode=mode, store=store)
+    return decision.owner, decision.name, decision.git_root
 
 
 from ._indexing_pipeline import (
@@ -766,6 +753,7 @@ def index_folder(
     changed_paths: Optional[list[WatcherChange]] = None,
     paths: Optional[list[str]] = None,
     progress_cb: "Optional[Callable[[int, int, str], None]]" = None,
+    identity_mode: str = "config",
 ) -> dict:
     """Index a local folder containing source code.
 
@@ -783,6 +771,8 @@ def index_folder(
             (change_type, absolute_path) tuples where change_type is one of
             "added", "modified", "deleted".  When provided with incremental=True
             and an existing index, skips full directory discovery (~3s → ~50ms).
+        identity_mode: "config" (default), "local", or "git". Local mode keeps
+            v1.90 path-hash identity; git mode opts in to git-root identity.
 
     Returns:
         Dict with indexing results.
@@ -880,6 +870,17 @@ def index_folder(
     # Redact absolute path from responses when redact_source_root is enabled
     _redact = _config.get("redact_source_root", False)
     _folder_display = folder_path.name if _redact else str(folder_path)
+    store = IndexStore(base_path=storage_path)
+    _pairs_for_identity = parse_path_map()
+    _identity_path = Path(remap(str(folder_path), _pairs_for_identity, reverse=True))
+    _identity_decision = resolve_index_identity(
+        str(_identity_path),
+        mode=identity_mode,
+        store=store,
+    )
+    owner = _identity_decision.owner
+    repo_name = _identity_decision.name
+    _git_root = _identity_decision.git_root
 
     # ── v1.96 git-root retarget ──
     # If git_root_identity is on (default) and `folder_path` resolves into a
@@ -889,14 +890,15 @@ def index_folder(
     # against the same clone coalesce into a single repo index.
     walk_root = folder_path
     _git_root_for_walk = ""
-    # Short-circuit when the knob is off — detect_git_root() spawns a `git`
-    # subprocess and pays its wall-clock cost on every reindex. Callers
-    # who opted out of git-root identity shouldn't have to pay that cost.
     _gr = None
-    if _config.get("git_root_identity", True, repo=str(folder_path)):
+    if _identity_decision.mode == "git" and _identity_decision.git_root:
         try:
-            from ..storage.git_root import detect_git_root as _detect_git_root_for_walk
-            _gr = _detect_git_root_for_walk(str(folder_path))
+            from ..storage.git_root import GitRootIdentity
+            _gr = GitRootIdentity(
+                git_root=_identity_decision.git_root,
+                owner=_identity_decision.owner,
+                name=_identity_decision.name,
+            )
         except Exception:
             logger.debug("git-root detection failed during retarget", exc_info=True)
             _gr = None
@@ -989,12 +991,6 @@ def index_folder(
         # When the watcher provides the exact change set, skip full directory
         # discovery (~3s on Windows) and only process the affected files.
         if changed_paths and incremental:
-            _pairs = parse_path_map()
-            owner, repo_name, _git_root = _resolve_repo_identity(
-                Path(remap(str(folder_path), _pairs, reverse=True))
-            )
-            store = IndexStore(base_path=storage_path)
-
             # Branch detection for watcher fast-path
             _fast_branch = _get_git_branch(folder_path)
             _fast_is_branch_delta = False
@@ -1351,13 +1347,6 @@ def index_folder(
         elif active_providers:
             names = ", ".join(p.name for p in active_providers)
             logger.info("Active context providers: %s", names)
-
-        # Create repo identifier from folder path
-        _pairs = parse_path_map()
-        owner, repo_name, _git_root = _resolve_repo_identity(
-            Path(remap(str(folder_path), _pairs, reverse=True))
-        )
-        store = IndexStore(base_path=storage_path)
 
         # v1.95.0/1.96: collision guard + subdir-merge resolution.
         #

--- a/src/jcodemunch_mcp/tools/index_folder.py
+++ b/src/jcodemunch_mcp/tools/index_folder.py
@@ -34,7 +34,7 @@ from ..security import (
     SKIP_FILES
 )
 from ..storage import IndexStore
-from ..storage.git_root import resolve_index_identity
+from ..storage.git_root import IdentityModeAmbiguous, IdentityModeConflict, resolve_index_identity
 from ..storage.index_store import _file_hash, _file_hash_bytes, _get_git_head, _get_git_branch
 from ..summarizer import summarize_symbols
 from ..reindex_state import WatcherChange
@@ -873,11 +873,14 @@ def index_folder(
     store = IndexStore(base_path=storage_path)
     _pairs_for_identity = parse_path_map()
     _identity_path = Path(remap(str(folder_path), _pairs_for_identity, reverse=True))
-    _identity_decision = resolve_index_identity(
-        str(_identity_path),
-        mode=identity_mode,
-        store=store,
-    )
+    try:
+        _identity_decision = resolve_index_identity(
+            str(_identity_path),
+            mode=identity_mode,
+            store=store,
+        )
+    except (IdentityModeAmbiguous, IdentityModeConflict) as exc:
+        return {"success": False, "error": str(exc)}
     owner = _identity_decision.owner
     repo_name = _identity_decision.name
     _git_root = _identity_decision.git_root

--- a/src/jcodemunch_mcp/tools/resolve_repo.py
+++ b/src/jcodemunch_mcp/tools/resolve_repo.py
@@ -9,18 +9,18 @@ from pathlib import Path
 from typing import Optional
 
 from ..storage import IndexStore
+from ..storage.git_root import resolve_index_identity
 
 logger = logging.getLogger(__name__)
 
 
-def _compute_repo_id(folder_path: Path) -> str:
+def _compute_repo_id(folder_path: Path, store: Optional[IndexStore] = None) -> str:
     """Compute the deterministic repo ID for a directory path.
 
     Same formula as _local_repo_id (watcher.py) and _local_repo_name (index_folder.py).
     """
-    resolved = folder_path.resolve()
-    digest = hashlib.sha1(str(resolved).encode("utf-8")).hexdigest()[:8]
-    return f"local/{resolved.name}-{digest}"
+    decision = resolve_index_identity(str(folder_path), mode="config", store=store)
+    return f"{decision.owner}/{decision.name}"
 
 
 def _git_common_dir(path: Path) -> Optional[Path]:
@@ -125,7 +125,7 @@ def resolve_repo(path: str, storage_path: Optional[str] = None) -> dict:
         candidates.append(git_root)
 
     for candidate in candidates:
-        repo_id = _compute_repo_id(candidate)
+        repo_id = _compute_repo_id(candidate, store=store)
         owner, name = repo_id.split("/", 1)
         status = store.inspect_index(owner, name)
         if status.index_present:
@@ -154,7 +154,7 @@ def resolve_repo(path: str, storage_path: Optional[str] = None) -> dict:
 
     # Not indexed — return the computed ID for the best candidate
     best = candidates[0]
-    repo_id = _compute_repo_id(best)
+    repo_id = _compute_repo_id(best, store=store)
 
     # Worktree-aware canonical-index discovery (issue #277):
     # if the path is a Git worktree, look for already-indexed repos that

--- a/src/jcodemunch_mcp/tools/resolve_repo.py
+++ b/src/jcodemunch_mcp/tools/resolve_repo.py
@@ -15,10 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def _compute_repo_id(folder_path: Path, store: Optional[IndexStore] = None) -> str:
-    """Compute the deterministic repo ID for a directory path.
-
-    Same formula as _local_repo_id (watcher.py) and _local_repo_name (index_folder.py).
-    """
+    """Compute the repo ID that index_folder would use for a directory path."""
     decision = resolve_index_identity(str(folder_path), mode="config", store=store)
     return f"{decision.owner}/{decision.name}"
 

--- a/src/jcodemunch_mcp/watcher.py
+++ b/src/jcodemunch_mcp/watcher.py
@@ -175,9 +175,9 @@ async def _watch_single(
     # _local_repo_id returns "local/name-hash" — the full identifier for reindex_state.
     # IndexStore.load_index(owner, name) requires the split components.
     _pairs = parse_path_map()
-    repo_id = _local_repo_id(remap(folder_path, _pairs, reverse=True))
-    _repo_owner, _repo_store_name = repo_id.split("/", 1)
     store = IndexStore(base_path=storage_path)
+    repo_id = _local_repo_id(remap(folder_path, _pairs, reverse=True), store=store)
+    _repo_owner, _repo_store_name = repo_id.split("/", 1)
 
     # Memory hash cache: rel_path -> content hash (for WatcherChange old_hash passthrough)
     _hash_cache: dict[str, str] = {}
@@ -596,7 +596,8 @@ class WatcherManager:
     async def _do_reindex(self, folder: str, **kwargs) -> dict:
         """Perform the actual reindex operation."""
         _pairs = parse_path_map()
-        repo_id = _local_repo_id(remap(folder, _pairs, reverse=True))
+        store = IndexStore(base_path=self._storage_path)
+        repo_id = _local_repo_id(remap(folder, _pairs, reverse=True), store=store)
         mark_reindex_start(repo_id)
         try:
             result = await asyncio.to_thread(
@@ -902,7 +903,7 @@ async def sync_folders(
     errors = 0
 
     for folder in resolved:
-        repo_id = _local_repo_id(remap(folder, _pairs, reverse=True))
+        repo_id = _local_repo_id(remap(folder, _pairs, reverse=True), store=store)
         print(f"Syncing {folder}...", file=sys.stderr)
         mark_reindex_start(repo_id)
         try:
@@ -1070,7 +1071,8 @@ async def watch_claude_worktrees(
             except (asyncio.CancelledError, Exception):
                 pass
         _pairs = parse_path_map()
-        repo_id = _local_repo_id(remap(folder, _pairs, reverse=True))
+        store = IndexStore(base_path=storage_path)
+        repo_id = _local_repo_id(remap(folder, _pairs, reverse=True), store=store)
         try:
             result = await asyncio.to_thread(
                 invalidate_cache, repo=repo_id, storage_path=storage_path,

--- a/src/jcodemunch_mcp/watcher.py
+++ b/src/jcodemunch_mcp/watcher.py
@@ -939,11 +939,12 @@ async def sync_folders(
 # worktree helpers
 # ---------------------------------------------------------------------------
 
-def _local_repo_id(folder_path: str) -> str:
+def _local_repo_id(folder_path: str, store: Optional[IndexStore] = None) -> str:
     """Compute the repo identifier that index_folder would use for a local path."""
-    p = Path(folder_path).resolve()
-    digest = hashlib.sha1(str(p).encode("utf-8")).hexdigest()[:8]
-    return f"local/{p.name}-{digest}"
+    from .storage.git_root import resolve_index_identity
+
+    decision = resolve_index_identity(folder_path, mode="config", store=store)
+    return f"{decision.owner}/{decision.name}"
 
 
 def parse_git_worktrees(repo_path: str) -> set[str]:

--- a/tests/test_git_root_identity.py
+++ b/tests/test_git_root_identity.py
@@ -10,6 +10,7 @@ the git_root for v1.96 merge logic.
 
 import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -133,7 +134,7 @@ class TestResolveRepoIdentity:
         assert name == "kibana"
         assert git_root == str(repo.resolve())
 
-    def test_clone_without_origin_keeps_basename_hash(self, tmp_path, monkeypatch):
+    def test_clone_without_origin_git_mode_uses_git_root_basename(self, tmp_path, monkeypatch):
         repo = tmp_path / "internal-tool"
         repo.mkdir()
         _git("init", cwd=repo)
@@ -146,8 +147,7 @@ class TestResolveRepoIdentity:
 
         owner, name, git_root = _resolve_repo_identity(repo)
         assert owner == "local"
-        assert name.startswith("internal-tool-")
-        assert len(name.split("-")[-1]) == 8  # 8-char hash suffix
+        assert name == "internal-tool"
         assert git_root == str(repo.resolve())
 
     def test_no_git_uses_basename_hash(self, tmp_path, monkeypatch):
@@ -189,6 +189,32 @@ class TestResolveRepoIdentity:
 
 
 class TestIndexFolderIdentity:
+    def test_knob_off_skips_retarget_git_root_probe(self, tmp_path, monkeypatch):
+        repo = tmp_path / "kibana"
+        repo.mkdir()
+        _git("init", cwd=repo)
+        _set_origin(repo, "https://github.com/elastic/kibana.git")
+        sub = repo / "packages"
+        sub.mkdir()
+        (sub / "p.py").write_text("def p(): pass\n", encoding="utf-8")
+
+        monkeypatch.setattr(
+            config_module, "get",
+            lambda key, default=None, repo=None:
+                False if key == "git_root_identity" else default,
+        )
+
+        with patch("jcodemunch_mcp.storage.git_root.detect_git_root", return_value=None) as mock_detect:
+            result = index_folder(
+                str(sub),
+                use_ai_summaries=False,
+                storage_path=str(tmp_path / "store"),
+                context_providers=False,
+            )
+
+        assert result["success"] is True
+        mock_detect.assert_not_called()
+
     def test_full_clone_index_uses_owner_repo(self, tmp_path):
         repo = tmp_path / "clone-named-anything"
         repo.mkdir()
@@ -197,7 +223,7 @@ class TestIndexFolderIdentity:
         (repo / "main.py").write_text("def hello(): pass\n", encoding="utf-8")
 
         store = tmp_path / "store"
-        result = index_folder(str(repo), use_ai_summaries=False, storage_path=str(store))
+        result = index_folder(str(repo), use_ai_summaries=False, storage_path=str(store), identity_mode="git")
         assert result["success"] is True
         assert result["repo"] == "elastic/kibana"
 
@@ -209,7 +235,7 @@ class TestIndexFolderIdentity:
         (repo / "main.py").write_text("def hello(): pass\n", encoding="utf-8")
 
         store_path = tmp_path / "store"
-        index_folder(str(repo), use_ai_summaries=False, storage_path=str(store_path))
+        index_folder(str(repo), use_ai_summaries=False, storage_path=str(store_path), identity_mode="git")
 
         store = IndexStore(base_path=str(store_path))
         loaded = store.load_index("elastic", "kibana")
@@ -231,10 +257,10 @@ class TestIndexFolderIdentity:
         (sub / "x.py").write_text("def x(): pass\n", encoding="utf-8")
 
         store_path = tmp_path / "store"
-        first = index_folder(str(repo), use_ai_summaries=False, storage_path=str(store_path))
+        first = index_folder(str(repo), use_ai_summaries=False, storage_path=str(store_path), identity_mode="git")
         assert first["success"] is True
 
-        second = index_folder(str(sub), use_ai_summaries=False, storage_path=str(store_path))
+        second = index_folder(str(sub), use_ai_summaries=False, storage_path=str(store_path), identity_mode="git")
         assert second["success"] is True
         assert second["repo"] == "elastic/kibana"
 
@@ -260,11 +286,11 @@ class TestIndexFolderIdentity:
         (scripts / "s.py").write_text("def s(): pass\n", encoding="utf-8")
 
         store_path = tmp_path / "store"
-        first = index_folder(str(packages), use_ai_summaries=False, storage_path=str(store_path))
+        first = index_folder(str(packages), use_ai_summaries=False, storage_path=str(store_path), identity_mode="git")
         assert first["success"] is True
         assert first["repo"] == "elastic/kibana"
 
-        second = index_folder(str(scripts), use_ai_summaries=False, storage_path=str(store_path))
+        second = index_folder(str(scripts), use_ai_summaries=False, storage_path=str(store_path), identity_mode="git")
         assert second["success"] is True
         assert second["repo"] == "elastic/kibana"
 
@@ -287,16 +313,16 @@ class TestIndexFolderIdentity:
         (repo / "main.py").write_text("def a(): pass\n", encoding="utf-8")
 
         store = tmp_path / "store"
-        first = index_folder(str(repo), use_ai_summaries=False, storage_path=str(store))
+        first = index_folder(str(repo), use_ai_summaries=False, storage_path=str(store), identity_mode="git")
         assert first["success"] is True
 
         # Re-index the same path: must succeed.
-        second = index_folder(str(repo), use_ai_summaries=False, storage_path=str(store))
+        second = index_folder(str(repo), use_ai_summaries=False, storage_path=str(store), identity_mode="git")
         assert second["success"] is True
 
     def test_subdir_under_no_origin_repo_merges_via_git_root(self, tmp_path):
         # v1.96: even without an origin remote, two subdirs of the same git
-        # working tree share identity (`local/<git_root_basename>-<hash>`)
+        # working tree share identity (`local/<git_root_basename>`)
         # and merge.  v1.95 gave them different per-subdir identities; that
         # behavior is no longer accessible without `git_root_identity: false`.
         repo = tmp_path / "internal-tool"
@@ -310,9 +336,9 @@ class TestIndexFolderIdentity:
         (b / "g.py").write_text("def b(): pass\n", encoding="utf-8")
 
         store_path = tmp_path / "store"
-        first = index_folder(str(a), use_ai_summaries=False, storage_path=str(store_path))
+        first = index_folder(str(a), use_ai_summaries=False, storage_path=str(store_path), identity_mode="git")
         assert first["success"] is True
-        second = index_folder(str(b), use_ai_summaries=False, storage_path=str(store_path))
+        second = index_folder(str(b), use_ai_summaries=False, storage_path=str(store_path), identity_mode="git")
         assert second["success"] is True
         # Same identity (git_root-derived).
         assert first["repo"] == second["repo"]
@@ -338,10 +364,10 @@ class TestIndexFolderIdentity:
         (repo_b / "b.py").write_text("def b(): pass\n", encoding="utf-8")
 
         store = tmp_path / "store"
-        first = index_folder(str(repo_a), use_ai_summaries=False, storage_path=str(store))
+        first = index_folder(str(repo_a), use_ai_summaries=False, storage_path=str(store), identity_mode="git")
         assert first["success"] is True
 
-        second = index_folder(str(repo_b), use_ai_summaries=False, storage_path=str(store))
+        second = index_folder(str(repo_b), use_ai_summaries=False, storage_path=str(store), identity_mode="git")
         assert second["success"] is False
         assert "already exists" in second["error"]
         assert str(repo_a.resolve()) in second["error"]
@@ -376,13 +402,13 @@ class TestSubdirMerge:
         (scripts / "s.py").write_text("def s(): pass\n", encoding="utf-8")
 
         store_path = tmp_path / "store"
-        index_folder(str(repo), use_ai_summaries=False, storage_path=str(store_path))
+        index_folder(str(repo), use_ai_summaries=False, storage_path=str(store_path), identity_mode="git")
 
         # Edit one packages file, drop the other.
         (packages / "p1.py").write_text("def p1_new(): pass\n", encoding="utf-8")
         (packages / "p2.py").unlink()
 
-        result = index_folder(str(packages), use_ai_summaries=False, storage_path=str(store_path))
+        result = index_folder(str(packages), use_ai_summaries=False, storage_path=str(store_path), identity_mode="git")
         assert result["success"] is True
 
         store = IndexStore(base_path=str(store_path))
@@ -411,8 +437,8 @@ class TestSubdirMerge:
         (repo / "main.py").write_text("def main(): pass\n", encoding="utf-8")
 
         store_path = tmp_path / "store"
-        index_folder(str(packages), use_ai_summaries=False, storage_path=str(store_path))
-        index_folder(str(repo), use_ai_summaries=False, storage_path=str(store_path))
+        index_folder(str(packages), use_ai_summaries=False, storage_path=str(store_path), identity_mode="git")
+        index_folder(str(repo), use_ai_summaries=False, storage_path=str(store_path), identity_mode="git")
 
         store = IndexStore(base_path=str(store_path))
         loaded = store.load_index("elastic", "kibana")
@@ -433,8 +459,8 @@ class TestSubdirMerge:
         (b / "bx.py").write_text("def bx(): pass\n", encoding="utf-8")
 
         store_path = tmp_path / "store"
-        index_folder(str(a), use_ai_summaries=False, storage_path=str(store_path))
-        index_folder(str(b), use_ai_summaries=False, storage_path=str(store_path))
+        index_folder(str(a), use_ai_summaries=False, storage_path=str(store_path), identity_mode="git")
+        index_folder(str(b), use_ai_summaries=False, storage_path=str(store_path), identity_mode="git")
 
         store = IndexStore(base_path=str(store_path))
         loaded = store.load_index("elastic", "kibana")
@@ -475,7 +501,7 @@ class TestSubdirMerge:
         )
 
         # Re-run with v1.96 logic — should rebuild rather than merge.
-        result = index_folder(str(scripts), use_ai_summaries=False, storage_path=str(store_path))
+        result = index_folder(str(scripts), use_ai_summaries=False, storage_path=str(store_path), identity_mode="git")
         assert result["success"] is True
         warnings_text = " ".join(result.get("warnings", []))
         assert "v1.95" in warnings_text or "subdir-relative" in warnings_text

--- a/tests/test_identity_mode.py
+++ b/tests/test_identity_mode.py
@@ -1,0 +1,111 @@
+"""Tests for local-first index identity mode selection."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from jcodemunch_mcp import config as config_module
+from jcodemunch_mcp.storage import IndexStore
+from jcodemunch_mcp.storage import git_root
+
+
+def _git(*args, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True)
+
+
+def _set_origin(path: Path, url: str) -> None:
+    _git("remote", "add", "origin", url, cwd=path)
+
+
+def test_default_config_for_hosted_clone_is_local_without_git_subprocess(tmp_path, monkeypatch):
+    repo = tmp_path / "kibana-clone"
+    repo.mkdir()
+    _git("init", cwd=repo)
+    _set_origin(repo, "https://github.com/elastic/kibana.git")
+    monkeypatch.setattr(
+        config_module,
+        "get",
+        lambda key, default=None, repo=None: None if key == "identity_mode" else False if key == "git_root_identity" else default,
+    )
+
+    store = IndexStore(base_path=str(tmp_path / "store"))
+    with patch.object(git_root.subprocess, "run", side_effect=AssertionError("git subprocess fired")):
+        decision = git_root.resolve_index_identity(str(repo), mode="config", store=store)
+
+    assert decision.mode == "local"
+    assert decision.owner == "local"
+    assert decision.name.startswith("kibana-clone-")
+    assert decision.git_root == ""
+    assert decision.walk_root == str(repo.resolve())
+
+
+def test_explicit_git_mode_uses_origin_identity(tmp_path):
+    repo = tmp_path / "kibana-clone"
+    repo.mkdir()
+    _git("init", cwd=repo)
+    _set_origin(repo, "https://github.com/elastic/kibana.git")
+
+    decision = git_root.resolve_index_identity(
+        str(repo),
+        mode="git",
+        store=IndexStore(base_path=str(tmp_path / "store")),
+    )
+
+    assert decision.mode == "git"
+    assert decision.owner == "elastic"
+    assert decision.name == "kibana"
+    assert decision.git_root == str(repo.resolve())
+    assert decision.walk_root == str(repo.resolve())
+
+
+def test_existing_git_index_is_preserved_in_config_mode(tmp_path):
+    from jcodemunch_mcp.tools.index_folder import index_folder
+
+    repo = tmp_path / "kibana-clone"
+    repo.mkdir()
+    _git("init", cwd=repo)
+    _set_origin(repo, "https://github.com/elastic/kibana.git")
+    (repo / "main.py").write_text("def hello(): pass\n", encoding="utf-8")
+
+    store_path = tmp_path / "store"
+    first = index_folder(
+        str(repo),
+        use_ai_summaries=False,
+        storage_path=str(store_path),
+        context_providers=False,
+        identity_mode="git",
+    )
+    assert first["success"] is True
+    assert first["repo"] == "elastic/kibana"
+
+    decision = git_root.resolve_index_identity(
+        str(repo),
+        mode="config",
+        store=IndexStore(base_path=str(store_path)),
+    )
+
+    assert decision.mode == "git"
+    assert decision.owner == "elastic"
+    assert decision.name == "kibana"
+
+
+def test_config_template_exposes_git_identity_opt_in():
+    template = config_module.generate_template()
+
+    assert '// "identity_mode": "git",' in template
+    assert "Uncomment and set to \"git\" to opt in" in template
+    assert '// "git_root_identity": true,' in template
+
+
+def test_watcher_and_resolve_repo_delegate_to_identity_resolver(tmp_path):
+    from jcodemunch_mcp.tools.resolve_repo import _compute_repo_id
+    from jcodemunch_mcp.watcher import _local_repo_id
+
+    project = tmp_path / "project"
+    project.mkdir()
+    store = IndexStore(base_path=str(tmp_path / "store"))
+    decision = git_root.resolve_index_identity(str(project), mode="config", store=store)
+    expected = f"{decision.owner}/{decision.name}"
+
+    assert _compute_repo_id(project, store=store) == expected
+    assert _local_repo_id(str(project), store=store) == expected

--- a/tests/test_identity_mode.py
+++ b/tests/test_identity_mode.py
@@ -4,6 +4,8 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from jcodemunch_mcp import config as config_module
 from jcodemunch_mcp.storage import IndexStore
 from jcodemunch_mcp.storage import git_root
@@ -37,6 +39,50 @@ def test_default_config_for_hosted_clone_is_local_without_git_subprocess(tmp_pat
     assert decision.name.startswith("kibana-clone-")
     assert decision.git_root == ""
     assert decision.walk_root == str(repo.resolve())
+
+
+def test_default_config_for_non_git_path_does_not_scan_repos(tmp_path, monkeypatch):
+    project = tmp_path / "plain-project"
+    project.mkdir()
+    monkeypatch.setattr(
+        config_module,
+        "get",
+        lambda key, default=None, repo=None: None if key == "identity_mode" else False if key == "git_root_identity" else default,
+    )
+
+    class Status:
+        index_present = False
+
+    class Store:
+        def inspect_index(self, owner, name):
+            return Status()
+
+        def list_repos(self):
+            pytest.fail("repo list scan used")
+
+    decision = git_root.resolve_index_identity(str(project), mode="config", store=Store())
+
+    assert decision.mode == "local"
+    assert decision.owner == "local"
+    assert decision.name.startswith("plain-project-")
+
+
+def test_explicit_git_mode_blocked_by_local_index_without_repo_scan(tmp_path):
+    project = tmp_path / "plain-project"
+    project.mkdir()
+
+    class Status:
+        index_present = True
+
+    class Store:
+        def inspect_index(self, owner, name):
+            return Status()
+
+        def list_repos(self):
+            pytest.fail("repo list scan used")
+
+    with pytest.raises(git_root.IdentityModeConflict):
+        git_root.resolve_index_identity(str(project), mode="git", store=Store())
 
 
 def test_explicit_git_mode_uses_origin_identity(tmp_path):
@@ -89,11 +135,131 @@ def test_existing_git_index_is_preserved_in_config_mode(tmp_path):
     assert decision.name == "kibana"
 
 
+def test_existing_git_index_is_preserved_without_full_index_load(tmp_path, monkeypatch):
+    from jcodemunch_mcp.tools.index_folder import index_folder
+
+    repo = tmp_path / "kibana-clone"
+    repo.mkdir()
+    _git("init", cwd=repo)
+    _set_origin(repo, "https://github.com/elastic/kibana.git")
+    (repo / "main.py").write_text("def hello(): pass\n", encoding="utf-8")
+
+    store_path = tmp_path / "store"
+    first = index_folder(
+        str(repo),
+        use_ai_summaries=False,
+        storage_path=str(store_path),
+        context_providers=False,
+        identity_mode="git",
+    )
+    assert first["success"] is True
+
+    store = IndexStore(base_path=str(store_path))
+    monkeypatch.setattr(store, "load_index", lambda *args, **kwargs: pytest.fail("full index load used"))
+
+    decision = git_root.resolve_index_identity(str(repo), mode="config", store=store)
+
+    assert decision.mode == "git"
+    assert decision.owner == "elastic"
+    assert decision.name == "kibana"
+
+
+def test_existing_local_index_blocks_explicit_git_mode(tmp_path):
+    from jcodemunch_mcp.tools.index_folder import index_folder
+
+    repo = tmp_path / "kibana-clone"
+    repo.mkdir()
+    _git("init", cwd=repo)
+    _set_origin(repo, "https://github.com/elastic/kibana.git")
+    (repo / "main.py").write_text("def hello(): pass\n", encoding="utf-8")
+
+    store_path = tmp_path / "store"
+    first = index_folder(
+        str(repo),
+        use_ai_summaries=False,
+        storage_path=str(store_path),
+        context_providers=False,
+        identity_mode="local",
+    )
+    assert first["success"] is True
+    assert first["repo"].startswith("local/kibana-clone-")
+
+    second = index_folder(
+        str(repo),
+        use_ai_summaries=False,
+        storage_path=str(store_path),
+        context_providers=False,
+        identity_mode="git",
+    )
+
+    assert second["success"] is False
+    assert "Existing index" in second["error"]
+    assert "invalidate" in second["error"]
+
+
+def test_existing_git_index_blocks_explicit_local_mode(tmp_path):
+    from jcodemunch_mcp.tools.index_folder import index_folder
+
+    repo = tmp_path / "kibana-clone"
+    repo.mkdir()
+    _git("init", cwd=repo)
+    _set_origin(repo, "https://github.com/elastic/kibana.git")
+    (repo / "main.py").write_text("def hello(): pass\n", encoding="utf-8")
+
+    store_path = tmp_path / "store"
+    first = index_folder(
+        str(repo),
+        use_ai_summaries=False,
+        storage_path=str(store_path),
+        context_providers=False,
+        identity_mode="git",
+    )
+    assert first["success"] is True
+    assert first["repo"] == "elastic/kibana"
+
+    second = index_folder(
+        str(repo),
+        use_ai_summaries=False,
+        storage_path=str(store_path),
+        context_providers=False,
+        identity_mode="local",
+    )
+
+    assert second["success"] is False
+    assert "Existing index" in second["error"]
+    assert "invalidate" in second["error"]
+
+
+def test_both_identity_forms_are_ambiguous(tmp_path):
+    repo = tmp_path / "kibana-clone"
+    repo.mkdir()
+    _git("init", cwd=repo)
+
+    class Status:
+        index_present = True
+
+    class Store:
+        def inspect_index(self, owner, name):
+            assert owner == "local"
+            assert name.startswith(repo.name)
+            return Status()
+
+        def list_repos(self):
+            return [{"repo": "elastic/kibana", "git_root": str(repo.resolve())}]
+
+        def load_index(self, *args, **kwargs):
+            pytest.fail("full index load used")
+
+    with pytest.raises(git_root.IdentityModeAmbiguous):
+        git_root.resolve_index_identity(str(repo), mode="config", store=Store())
+
+
 def test_config_template_exposes_git_identity_opt_in():
     template = config_module.generate_template()
 
     assert '// "identity_mode": "git",' in template
     assert "Uncomment and set to \"git\" to opt in" in template
+    assert "Existing indexes keep their current identity" in template
     assert '// "git_root_identity": true,' in template
 
 
@@ -109,3 +275,22 @@ def test_watcher_and_resolve_repo_delegate_to_identity_resolver(tmp_path):
 
     assert _compute_repo_id(project, store=store) == expected
     assert _local_repo_id(str(project), store=store) == expected
+
+
+@pytest.mark.asyncio
+async def test_watcher_reindex_passes_store_to_identity_resolver(tmp_path, monkeypatch):
+    from jcodemunch_mcp import watcher
+
+    project = tmp_path / "project"
+    project.mkdir()
+    store_path = tmp_path / "store"
+
+    def fake_local_repo_id(folder_path, store=None):
+        assert store is not None
+        raise RuntimeError("stop after repo-id resolution")
+
+    monkeypatch.setattr(watcher, "_local_repo_id", fake_local_repo_id)
+    manager = watcher.WatcherManager(storage_path=str(store_path))
+
+    with pytest.raises(RuntimeError, match="stop after repo-id resolution"):
+        await manager._do_reindex(str(project))

--- a/tests/test_identity_mode.py
+++ b/tests/test_identity_mode.py
@@ -258,7 +258,8 @@ def test_config_template_exposes_git_identity_opt_in():
     template = config_module.generate_template()
 
     assert '// "identity_mode": "git",' in template
-    assert "Uncomment and set to \"git\" to opt in" in template
+    assert '"local" (default)' in template
+    assert '"git"' in template
     assert "Existing indexes keep their current identity" in template
     assert '// "git_root_identity": true,' in template
 

--- a/tests/test_resolve_repo.py
+++ b/tests/test_resolve_repo.py
@@ -36,7 +36,7 @@ class TestResolveRepo:
         (project / "main.py").write_text("def hello(): pass\n")
         store_path = str(tmp_path / "store")
 
-        index_folder(str(project), use_ai_summaries=False, storage_path=store_path)
+        index_folder(str(project), use_ai_summaries=False, storage_path=store_path, identity_mode="local")
         repo_id = _compute_repo_id(project)
         owner, repo_name = repo_id.split("/", 1)
         return project, store_path, owner, repo_name
@@ -59,7 +59,7 @@ class TestResolveRepo:
         (project / "main.py").write_text("def hello(): pass\n")
         store_path = str(tmp_path / "store")
 
-        index_folder(str(project), use_ai_summaries=False, storage_path=store_path)
+        index_folder(str(project), use_ai_summaries=False, storage_path=store_path, identity_mode="local")
 
         result = resolve_repo(str(project), storage_path=store_path)
         assert result["found"] is True
@@ -116,7 +116,7 @@ class TestResolveRepo:
         (project / "main.py").write_text("def top(): pass\n")
         store_path = str(tmp_path / "store")
 
-        index_folder(str(project), use_ai_summaries=False, storage_path=store_path)
+        index_folder(str(project), use_ai_summaries=False, storage_path=store_path, identity_mode="local")
 
         result = resolve_repo(str(subdir), storage_path=store_path)
         assert result["found"] is True
@@ -198,7 +198,7 @@ class TestWorktreeCanonicalCandidates:
         self._git("commit", "-m", "initial", cwd=canonical)
 
         store_path = str(tmp_path / "store")
-        index_folder(str(canonical), use_ai_summaries=False, storage_path=store_path)
+        index_folder(str(canonical), use_ai_summaries=False, storage_path=store_path, identity_mode="local")
 
         # Create a linked worktree on a new branch (sibling path).
         worktree = tmp_path / "wt-feature"
@@ -230,7 +230,7 @@ class TestWorktreeCanonicalCandidates:
         self._git("commit", "-m", "initial", cwd=canonical)
 
         store_path = str(tmp_path / "store")
-        index_folder(str(canonical), use_ai_summaries=False, storage_path=store_path)
+        index_folder(str(canonical), use_ai_summaries=False, storage_path=store_path, identity_mode="local")
 
         # An unrelated empty directory — not a worktree, not indexed.
         unrelated = tmp_path / "unrelated"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -153,6 +153,7 @@ async def test_call_tool_defaults_index_folder_incremental_true():
         follow_symlinks=False,
         incremental=True,
         paths=None,
+        identity_mode="config",
         progress_cb=None,
     )
 


### PR DESCRIPTION
## Summary

Restores `local` (path-hash) as the default index identity mode, making git-root identity an explicit opt-in via `identity_mode: "git"` or the legacy `git_root_identity: true` config knob. Existing indexes of either kind are automatically preserved -- no migration, no invalidation, no changed repo IDs for current users.

The goal is to prioritize compatibility with the working solution that served all users before v1.95. Users who benefit from git-root identity (monorepo subdir merging, `owner/repo` keying) can opt in through the config file without any loss of functionality. Users who work with simple git clones, local folders, or non-git projects get the behavior they relied on by default, without paying the cost of a `git` subprocess probe on every reindex.

## Why

v1.95 introduced git-root identity as a default-on feature. This improved the monorepo workflow (multiple subdirs of the same git root merge into a single index), but it changed the index keying behavior for every existing user -- including those who never needed it.

The consequences for local-first users were concrete:

- **Default cost.** In the default git-identity mode, every new `index_folder` and watcher reindex still needs a `git` subprocess to detect the git root. v1.108.2 fixed the probe-when-off ordering bug and bounded the slowest subprocess paths, but it intentionally did not change the default identity mode.

- **Identity instability.** A folder that was previously indexed as `local/myproject-a1b2c3d4` could silently re-key as `owner/repo` after a version upgrade, orphaning the old index. Users who scripted around repo IDs or relied on `resolve_repo` stability saw unexpected breakage.

- **Unnecessary coupling.** Non-git projects and local-only clones (no remote, no origin) gained nothing from the git-root probe but still paid its cost and complexity.

The principle here is straightforward: a default should work for everyone, and advanced features should be opt-in. Git-root identity is valuable, but it makes assumptions about the user's environment (has git, has an origin remote, wants monorepo merging) that don't hold universally.

## What We Did

### Centralized identity resolution

Added `resolve_index_identity()` in `storage/git_root.py` -- a single function that decides how a local path maps to an index key. It replaces the scattered identity logic that was duplicated across `index_folder.py`, `resolve_repo.py`, and `watcher.py`.

The resolver supports three modes:

| Mode | Behavior |
| --- | --- |
| `config` (default) | Reads `identity_mode` / `git_root_identity` from config. Falls back to `local` when neither is set. |
| `local` | Path-hash identity (`local/<basename>-<sha1[:8]>`). No git subprocess. |
| `git` | Git-root identity (`<owner>/<repo>`). Runs `detect_git_root()`. Enables monorepo subdir merging. |

### Existing index preservation

The resolver checks the index store before making any decision:

- If a `local/...` index already exists for this path, it's returned as-is -- even if the config says `git`.
- If a git-keyed index (`owner/repo`) already covers this path (via its stored `git_root`), it's returned as-is -- even if the config says `local`.
- If both forms exist (should not happen, but guarded), it raises `IdentityModeAmbiguous` rather than silently picking one.
- Explicitly requesting a mode that conflicts with an existing index raises `IdentityModeConflict` with a message telling the user to `invalidate_cache` first.

This means: **no existing user sees a changed repo ID after this change.** The preservation logic runs before any config check or git probe.

### Config surface

The config template now documents both knobs:

```jsonc
// "identity_mode": "git",
//   How index_folder derives the repo identifier for a local path.
//   Existing indexes keep their current identity regardless of this
//   setting -- this only affects NEW indexes.
//
//   Choices:
//     "local" (default) -- repo ID is `local/<basename>-<hash>`.
//       No git subprocess, no remote detection. Fast and portable.
//       Each folder gets its own index. Works for non-git projects,
//       local-only clones, and simple git workflows.
//
//     "git" -- repo ID is `<owner>/<repo>` derived from the origin
//       remote URL. Runs a git subprocess on every index/reindex.
//       Enables monorepo subdir merging (multiple subdirs of the
//       same git root share one index). Requires a git working tree
//       with an origin remote. Falls back to local when detection
//       fails.
//
//   To switch an existing index: run invalidate_cache first, then
//   re-index with the new mode.

// "git_root_identity": true,
//   Deprecated boolean alias for identity_mode. When identity_mode
//   is not set, `true` here is equivalent to `"identity_mode": "git"`.
//   Prefer identity_mode for new configurations.
```

The `index_folder` MCP tool also accepts an `identity_mode` parameter for per-call override.

### Unified call sites

`_local_repo_id()` in `watcher.py`, `_compute_repo_id()` in `resolve_repo.py`, and `_resolve_repo_identity()` in `index_folder.py` all delegate to the central `resolve_index_identity()`, passing the `store` so the preservation logic can inspect existing indexes.

### Test coverage

- **`test_identity_mode.py`** (296 lines, new): Exercises the resolver directly -- default-local without git subprocess, config-mode preservation, explicit mode conflicts, ambiguous state detection, config template content, and integration with watcher/resolve_repo delegation.
- **`test_git_root_identity.py`** (updated): Git-identity tests now pass `identity_mode="git"` explicitly, reflecting that git identity is opt-in. Added `test_knob_off_skips_retarget_git_root_probe` verifying that the git subprocess is never called when identity is local.

## Before and After

| Area | Before (v1.108.2) | After |
| --- | --- | --- |
| Default identity mode | `git` (`git_root_identity: true`) | `local` (path-hash) |
| Git subprocess on reindex | Runs in default git-identity mode; skipped when explicitly local | Only when `identity_mode: "git"` or existing git index |
| New index for simple clone | `owner/repo` (requires working git + origin) | `local/<basename>-<hash>` (no git probe) |
| New index for non-git folder | `local/<basename>-<hash>` (after failed git probe) | `local/<basename>-<hash>` (no git probe attempted) |
| Existing `local/...` index | Preserved | Preserved |
| Existing `owner/repo` index | Preserved | Preserved (auto-detected from stored `git_root`) |
| Monorepo subdir merging | On by default | Opt-in via `identity_mode: "git"` |
| Identity resolution logic | Duplicated in 3 files | Centralized in `resolve_index_identity()` |
| Config documentation | `git_root_identity` only, default `true` | `identity_mode` + legacy `git_root_identity`, default `local` |
| Conflict guard | None (silent re-keying possible) | `IdentityModeConflict` / `IdentityModeAmbiguous` errors |

## Verification

```
.venv\Scripts\python.exe -m pytest tests/test_identity_mode.py tests/test_git_root_identity.py tests/test_resolve_repo.py tests/test_server.py tests/test_watcher_lock.py tests/test_watcher_serve.py -q
```

---

Co-Authored-By: GPT 5.5 XHIGH <noreply@openai.com>

