### PR TITLE
fix: allow Windows UNC share child indexing

### DIFF
--- a/src/jcodemunch_mcp/tools/index_folder.py
+++ b/src/jcodemunch_mcp/tools/index_folder.py
@@ -128,6 +128,20 @@ def _is_container() -> bool:
     return False
 
 
+def _path_safety_part_count(path: Path) -> int:
+    r"""Count path components for the broad-root guard.
+
+    On Windows, pathlib stores a UNC share root such as ``\\server\share\`` as
+    one anchor component. Treat that anchor as server + share so
+    ``\\server\share\repo`` has the same logical depth as ``C:\Users\repo``,
+    while the share root itself remains too broad.
+    """
+    count = len(path.parts)
+    if os.name == "nt" and str(path.drive).startswith("\\\\"):
+        count += 1
+    return count
+
+
 @lru_cache(maxsize=512)
 def _is_trusted(
     folder_path: Path, trusted_folders: tuple, whitelist_mode: bool = True
@@ -952,7 +966,8 @@ def index_folder(
     # /workspace works out of the box while bare "/" is still rejected.
     container = _is_container()
     _MIN_PATH_PARTS = 2 if container else 3
-    if len(folder_path.parts) < _MIN_PATH_PARTS:
+    path_part_count = _path_safety_part_count(folder_path)
+    if path_part_count < _MIN_PATH_PARTS:
         if not is_trusted:
             error_msg = (
                 f"Resolved path '{folder_path}' is too broad to index safely "
@@ -971,7 +986,7 @@ def index_folder(
         logger.warning(warning_msg)
         warnings.append(warning_msg)
 
-    if container and len(folder_path.parts) < 3:
+    if container and path_part_count < 3:
         warning_msg = (
             f"Container environment detected — allowing shallow path '{folder_path}'. "
             "The minimum path depth has been relaxed from 3 to 2 components."

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1089,6 +1089,78 @@ class TestContainerDetection:
         assert "too broad to index safely" in result["error"]
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows UNC path semantics only")
+class TestWindowsUNCPathSafety:
+    """Windows UNC roots should be treated as server/share plus descendants."""
+
+    def test_unc_repo_at_share_child_is_not_too_broad(self, tmp_path):
+        from jcodemunch_mcp.tools import index_folder as index_folder_module
+
+        unc_repo = Path(r"\\server\share\repo")
+
+        with (
+            patch.object(
+                index_folder_module._config, "load_project_config", return_value=None
+            ),
+            patch.object(
+                index_folder_module._config,
+                "get",
+                side_effect=lambda key, default=None, repo=None: (
+                    [] if key == "trusted_folders" else default
+                ),
+            ),
+            patch(
+                "jcodemunch_mcp.tools.index_folder.Path.resolve",
+                return_value=unc_repo,
+            ),
+            patch("jcodemunch_mcp.tools.index_folder.Path.exists", return_value=True),
+            patch("jcodemunch_mcp.tools.index_folder.Path.is_dir", return_value=True),
+            patch.object(
+                index_folder_module, "discover_local_files", return_value=([], [], {})
+            ),
+        ):
+            result = index_folder_module.index_folder(
+                str(tmp_path / "repo"),
+                use_ai_summaries=False,
+                storage_path=str(tmp_path / "store"),
+            )
+
+        assert "too broad" not in result.get("error", "")
+        assert result["error"] == "No source files found"
+
+    def test_unc_share_root_remains_too_broad(self, tmp_path):
+        from jcodemunch_mcp.tools import index_folder as index_folder_module
+
+        unc_share_root = Path(r"\\server\share")
+
+        with (
+            patch.object(
+                index_folder_module._config, "load_project_config", return_value=None
+            ),
+            patch.object(
+                index_folder_module._config,
+                "get",
+                side_effect=lambda key, default=None, repo=None: (
+                    [] if key == "trusted_folders" else default
+                ),
+            ),
+            patch(
+                "jcodemunch_mcp.tools.index_folder.Path.resolve",
+                return_value=unc_share_root,
+            ),
+            patch("jcodemunch_mcp.tools.index_folder.Path.exists", return_value=True),
+            patch("jcodemunch_mcp.tools.index_folder.Path.is_dir", return_value=True),
+        ):
+            result = index_folder_module.index_folder(
+                str(tmp_path / "share"),
+                use_ai_summaries=False,
+                storage_path=str(tmp_path / "store"),
+            )
+
+        assert result["success"] is False
+        assert "too broad to index safely" in result["error"]
+
+
 class TestIndexFolderGitignoreWarning:
     """index_folder should warn when no root .gitignore exists and file count is large."""
 


### PR DESCRIPTION
## Summary

Fixes #321.

Windows `pathlib` treats a UNC share root like `\\server\share\` as one anchor component, so `\\server\share\repo` has only two `Path.parts`. The broad-root guard currently rejects any non-container path with fewer than three parts, which incorrectly blocks projects mounted directly under a network share or via a mapped drive that resolves to UNC.

This PR adds a small helper for the broad-root safety depth calculation:

- UNC share roots count as server + share for guard-depth purposes.
- `\\server\share\repo` is allowed to proceed through normal indexing.
- `\\server\share` remains rejected as too broad.
- Local drive behavior is unchanged.

## Existing issues / PRs checked

I checked for existing open and closed issues/PRs around `UNC`, `network share`, and `too broad to index safely`; I did not find a duplicate. Related prior work:

- #125 added the broad-root guard after `index_folder(".")` could resolve against the MCP process CWD.
- #175 added `trusted_folders` for intentionally broad roots.

This is narrower than both: a normal Windows UNC project path is misclassified because of `pathlib` UNC anchor semantics.

## Testing

- `PYTHONPATH=src python -m pytest tests/test_tools.py::TestTrustedFolders tests/test_tools.py::TestContainerDetection tests/test_tools.py::TestWindowsUNCPathSafety -q`
- `PYTHONPATH=src python -m pytest tests/test_tools.py -q`
- `uv run pytest tests/ -q` -> `4431 passed, 14 skipped`
- Real Windows repro check with local patch: indexing a mapped drive project path that resolves to `\\server\share\repo` succeeds instead of failing the broad-root guard.