### PR TITLE
fix: OpenAI summarizer honors the circuit breaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to jcodemunch-mcp are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- The OpenAI-compatible summarizer now honors the circuit breaker. Its
+  `summarize_batch` override submitted `_summarize_one_batch` directly,
+  bypassing `_run_batch` and its `_circuit_broken` check, so
+  `summarizer_max_failures` never short-circuited the OpenAI provider the way
+  it does for Anthropic and Gemini. A dead or failing endpoint was hammered for
+  every batch instead of giving up after the configured number of consecutive
+  failures. The override now submits `_run_batch`, so once the breaker trips the
+  remaining batches fall straight through to signature summaries. Regression
+  test in `tests/test_summarizer.py`.
+
 ## [1.108.29] - 2026-06-05 - WRR signal fusion was inert (all weights resolved to 0.0)
 
 ### Fixed

--- a/src/jcodemunch_mcp/summarizer/batch_summarize.py
+++ b/src/jcodemunch_mcp/summarizer/batch_summarize.py
@@ -564,8 +564,12 @@ class OpenAIBatchSummarizer(BaseSummarizer):
 
         completed_count = 0
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            # Submit via _run_batch (not _summarize_one_batch) so the circuit
+            # breaker is honored: once summarizer_max_failures consecutive
+            # batches fail, remaining batches short-circuit to signature
+            # fallback instead of hammering a dead endpoint.
             futures = {
-                executor.submit(self._summarize_one_batch, batch): batch
+                executor.submit(self._run_batch, batch): batch
                 for batch in batches
             }
             for future in as_completed(futures):

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1070,6 +1070,47 @@ def test_no_degradation_warning_when_summaries_usable(caplog):
     assert "fell back to generic signatures" not in caplog.text
 
 
+def test_openai_summarizer_circuit_breaker_trips():
+    """OpenAI provider honors the circuit breaker.
+
+    Regression: the OpenAIBatchSummarizer.summarize_batch override submitted
+    _summarize_one_batch directly, bypassing _run_batch and its
+    _circuit_broken check, so summarizer_max_failures never short-circuited
+    the OpenAI provider the way it does for Anthropic/Gemini. After the
+    default 3 consecutive failures, the remaining batches must short-circuit
+    to signature fallback without further HTTP calls.
+    """
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = RuntimeError("500 Server Error")
+    mock_client = MagicMock()
+    mock_client.post.return_value = mock_response
+
+    # OPENAI_CONCURRENCY=1 forces sequential batch execution so the breaker
+    # trip point is deterministic; OPENAI_BATCH_SIZE=1 gives one symbol/batch.
+    # Both are read inside summarize_batch(), so the call must run while the
+    # patched environment is still in scope.
+    symbols = [_one_symbol(name=f"f{i}", sig=f"def f{i}():") for i in range(10)]
+    with patch.dict(
+        "os.environ",
+        {
+            "OPENAI_API_BASE": "http://localhost:11434/v1",
+            "OPENAI_BATCH_SIZE": "1",
+            "OPENAI_CONCURRENCY": "1",
+        },
+        clear=True,
+    ), patch.object(OpenAIBatchSummarizer, "_init_client"):
+        summarizer = OpenAIBatchSummarizer()
+        summarizer.client = mock_client
+        summarizer.summarize_batch(symbols)
+
+    # Breaker trips after 3 consecutive failures; the other 7 batches never
+    # reach the endpoint.
+    assert mock_client.post.call_count == 3
+    assert summarizer._circuit_broken is True
+    # Every symbol still received a signature fallback.
+    assert [s.summary for s in symbols] == [f"def f{i}():" for i in range(10)]
+
+
 def test_get_model_name_strips_whitespace():
     """get_model_name() strips surrounding whitespace from the model value."""
     with patch(


### PR DESCRIPTION
## What

Make the OpenAI-compatible summarizer honor the circuit breaker, matching the Anthropic and Gemini providers.

## Why

`BaseSummarizer.summarize_batch` runs each batch through `_run_batch`, which checks `_circuit_broken` first and short-circuits to signature fallback once `summarizer_max_failures` consecutive batches have failed. `OpenAIBatchSummarizer` overrides `summarize_batch` (it needs the `OPENAI_BATCH_SIZE` / `OPENAI_CONCURRENCY` env knobs and provider-specific logging), and the override submitted `_summarize_one_batch` to the thread pool **directly**, skipping `_run_batch` entirely.

Result: the breaker never tripped for the OpenAI provider. A dead or failing local endpoint (the common case: Ollama / LM Studio / llama-server not running, wrong port, model not loaded) was hit once per batch for the whole index instead of giving up after N failures. On a large repo that is hundreds or thousands of pointless timeouts.

This was noticed while shipping #323 and intentionally left out of that change to keep it scoped. Filing as its own PR for review.

## Change

One line of behavior: the override now submits `self._run_batch` instead of `self._summarize_one_batch`. `_run_batch` does the breaker check, then delegates to `_summarize_one_batch`, so success-path behavior is identical until the breaker trips.

## Test

`tests/test_summarizer.py::test_openai_summarizer_circuit_breaker_trips`: a mock endpoint that always 500s, 10 single-symbol batches run sequentially (`OPENAI_CONCURRENCY=1`). Asserts the endpoint is hit exactly 3 times (default `summarizer_max_failures`), the breaker trips, and all 10 symbols still get a signature fallback. Against the old code this would hit the endpoint 10 times.

Full summarizer suite: 70 passed.

## Notes

- No version bump in this PR. Bump at merge/release time.
- CHANGELOG entry added under `[Unreleased]`.
