### PR TITLE
feat: index templating-language files over a supported underlying language (#336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,51 @@ All notable changes to jcodemunch-mcp are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Index templating-language files over a supported underlying source
+  language** (issue #336). Files of the form `name.<underlying-ext>.<engine-ext>`
+  — e.g. a Jinja2 template of TypeScript (`foo.ts.j2`), Jinja of Python
+  (`service.py.jinja`), or a Twig template of TS (`widget.ts.twig`) — were
+  previously dropped at discovery as `wrong_extension`, so every real source
+  symbol inside them went unindexed. They are now recognized, the engine
+  constructs are masked **offset-preserving**, and the body is re-parsed as its
+  underlying language so symbols, signatures, imports, and line/byte positions
+  all resolve correctly.
+  - **Engines:** Jinja2 (`.j2`/`.jinja`/`.jinja2`) and Twig (`.twig`) — the
+    first cut, scoped to the engines whose `name.<lang>.<engine>` double-extension
+    convention this feature targets. The masking layer is a pluggable
+    `TemplateEngine` registry (`parser/template_shared.py`), so adding a
+    single-extension HTML-bodied engine (Handlebars/Liquid/Mustache) later is a
+    few lines. EJS (`.ejs`) keeps its existing parser.
+  - **Underlying language is inferred from the middle extension**, so *every*
+    language jCodeMunch already supports works as the template body with no
+    per-language work — the engine extension is stripped and the remaining name
+    is resolved recursively (`foo.ts.j2` → `typescript`). The resolution step
+    runs *after* the existing compound and last-extension checks in
+    `get_language_for_path`, so it can only ever turn an unresolved path into a
+    language — never re-resolve a `.d.ts` / `.blade.php` that already matched.
+  - **Jinja/Twig `{% macro %}` / `{% block %}` definitions** are additionally
+    surfaced as symbols, reusing the dbt directive path
+    (`sql_preprocessor.extract_dbt_directives`, generalized to accept a directive
+    keyword set) rather than a parallel implementation. The underlying body
+    symbols keep their own sub-language tag.
+  - **Offset-preserving mask** mirrors `astro_shared.mask_html_comments_keep_offsets`
+    but fills each hole with an identifier placeholder (`{{ x }}` →
+    same-length `_`), keeping value-position holes (`DEBUG = {{ x }}`) parseable
+    in strict grammars — the offset-preserving form of dbt's `__jinja__`. A hole
+    at a *name* position, or free template text emitted inside a block body, is
+    best-effort (same contract as dbt SQL parsing).
+  - **Bare templates** with no underlying-language extension (`report.j2`) are
+    skipped — there is nothing to parse as source.
+  - Purely additive: previously-skipped files only add symbols, with no
+    `INDEX_VERSION` bump (a re-index picks up the now-recognized files).
+  - New `tests/test_templates.py` (16 cases, incl. non-collision guards for
+    `.d.ts` / `.test.ts` / `.blade.php` / bare `report.j2`) + fixtures under
+    `tests/fixtures/templates/`. Implemented via offset-preserving masking +
+    recursive `parse_file()` delegation (the Razor/Astro pattern), and the
+    `get_language_for_path` resolution branch.
+
 ## [1.108.61] - 2026-06-18 - Every config key is now documented (no more "Other")
 
 ### Fixed

--- a/LANGUAGE_SUPPORT.md
+++ b/LANGUAGE_SUPPORT.md
@@ -81,6 +81,31 @@ These languages are fully indexed and searchable via `search_text`. Symbol extra
 | -------- | -------------- | ------------------------------------------------------------------ |
 | TOML     | `.toml`        | Tables indexed; key-as-symbol extractor planned                    |
 
+### Templating engines (over an underlying language)
+
+A template file named `name.<underlying-ext>.<engine-ext>` is indexed by masking
+the engine's constructs (offset-preserving) and re-parsing the body as its
+underlying language — so a Jinja2 template of TypeScript (`foo.ts.j2`) yields the
+real TypeScript symbols, with correct line/byte positions. The **underlying
+language is inferred from the middle extension**, so any language above works as
+the body. A bare template with no underlying extension (`report.j2`) is skipped.
+
+| Engine     | Extensions                          | Notes                                                                 |
+| ---------- | ----------------------------------- | --------------------------------------------------------------------- |
+| Jinja2     | `.j2`, `.jinja`, `.jinja2`          | `{% macro %}` / `{% block %}` also surfaced as symbols                 |
+| Twig       | `.twig`                             | Shares Jinja delimiters; macro/block extraction applies               |
+
+The engine registry (`parser/template_shared.py`) is pluggable. The first cut
+ships Jinja2 and Twig — the engines whose `name.<lang>.<engine>` double-extension
+convention this feature targets. Single-extension HTML-bodied engines
+(Handlebars/Liquid/Mustache — `page.hbs`, `index.liquid`) carry no underlying
+extension to resolve and can be added on demand.
+
+Caveat (best-effort, same as dbt SQL): a template hole at a *name* position
+(`function {{ name }}()`) erases that symbol's name, and free template text
+emitted inside a block body can disrupt the declaration immediately after it.
+EJS (`.ejs`) keeps its own dedicated parser.
+
 ---
 
 ## Parser Engine

--- a/src/jcodemunch_mcp/parser/extractor.py
+++ b/src/jcodemunch_mcp/parser/extractor.py
@@ -7,7 +7,12 @@ from tree_sitter_language_pack import get_parser
 
 from .astro_shared import mask_html_comments_keep_offsets, split_astro_frontmatter
 from .symbols import Symbol, make_symbol_id, compute_content_hash
-from .languages import LanguageSpec, LANGUAGE_REGISTRY
+from .languages import LanguageSpec, LANGUAGE_REGISTRY, template_underlying_language
+from .template_shared import (
+    TEMPLATE_ENGINES,
+    TEMPLATE_ENGINE_LANGUAGES,
+    mask_template_keep_offsets,
+)
 from .complexity import compute_complexity
 
 
@@ -243,6 +248,8 @@ def parse_file(content: str, filename: str, language: str, source_bytes: Optiona
         symbols = _parse_razor_symbols(source_bytes, filename)
     elif language == "astro":
         symbols = _parse_astro_symbols(source_bytes, filename)
+    elif language in TEMPLATE_ENGINE_LANGUAGES:
+        symbols = _parse_template_symbols(source_bytes, filename, language, repo=repo)
     elif language == "nix":
         symbols = _parse_nix_symbols(source_bytes, filename)
     elif language == "vue":
@@ -4090,6 +4097,56 @@ def _parse_razor_symbols(source_bytes: bytes, filename: str) -> list[Symbol]:
 
     symbols.sort(key=lambda s: (s.line, s.byte_offset, s.name))
     return symbols
+
+
+def _parse_template_symbols(
+    source_bytes: bytes,
+    filename: str,
+    engine_language: str,
+    repo: Optional[str] = None,
+) -> list[Symbol]:
+    """Extract symbols from a templating-engine file over a supported language.
+
+    A template file (e.g. ``foo.ts.j2``) wraps an underlying source language
+    with engine constructs. We (1) optionally extract the engine's own named
+    definitions (Jinja/Twig ``{% macro %}`` / ``{% block %}``), (2) mask the
+    engine constructs while preserving byte offsets and line numbers, then
+    (3) re-parse the masked text as the underlying language. Because the mask is
+    offset-preserving, the underlying symbols already carry correct positions in
+    the template file — no block-offset rewrapping is needed. Mirrors
+    _parse_sql_symbols' ``dbt_directives + sql_body`` composition.
+
+    The underlying language is re-derived from the filename's middle extension
+    (``foo.ts.j2`` → ``typescript``), so any supported language works as the
+    template body. Returns the engine's directive symbols even when the
+    underlying language is absent or unsupported (bare/unparseable body).
+
+    ``repo`` is forwarded into the recursive body parse so the underlying
+    language honors per-project ``.jcodemunch.jsonc`` enable/disable gating.
+    """
+    text = source_bytes.decode("utf-8", errors="replace")
+
+    engine = TEMPLATE_ENGINES.get(engine_language)
+    directive_symbols: list[Symbol] = []
+    if engine is not None and engine.directive_extractor is not None:
+        try:
+            directive_symbols = engine.directive_extractor(
+                text, filename, engine_language
+            )
+        except Exception:
+            directive_symbols = []
+
+    underlying = template_underlying_language(filename)
+    if not underlying:
+        return directive_symbols
+
+    masked = mask_template_keep_offsets(text, engine_language)
+    # Recurse into the underlying language. `underlying` is never a template
+    # engine (its extension carries no engine suffix), so this cannot loop.
+    underlying_symbols = parse_file(
+        masked, filename, underlying, source_bytes=masked.encode("utf-8"), repo=repo
+    )
+    return directive_symbols + underlying_symbols
 
 
 def _parse_astro_symbols(source_bytes: bytes, filename: str) -> list[Symbol]:

--- a/src/jcodemunch_mcp/parser/imports.py
+++ b/src/jcodemunch_mcp/parser/imports.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Optional
 
 from .astro_shared import mask_html_comments_keep_offsets, split_astro_frontmatter
+from .languages import template_underlying_language
+from .template_shared import TEMPLATE_ENGINE_LANGUAGES, mask_template_keep_offsets
 
 
 # ---------------------------------------------------------------------------
@@ -608,6 +610,21 @@ def extract_imports(content: str, file_path: str, language: str) -> list[dict]:
         where ``specifier`` is the raw module/path string and ``names`` are
         the specific identifiers imported from that module.
     """
+    # Template files (foo.ts.j2, widget.ts.twig, …): mask the engine constructs
+    # offset-preserving, then run the underlying language's import extractor on
+    # the result. The underlying language is re-derived from the path, so this is
+    # handled before the generic _LANGUAGE_EXTRACTORS lookup (whose callbacks
+    # receive only `content`).
+    if language in TEMPLATE_ENGINE_LANGUAGES:
+        underlying = template_underlying_language(file_path)
+        underlying_extractor = _LANGUAGE_EXTRACTORS.get(underlying) if underlying else None
+        if underlying_extractor is None:
+            return []
+        try:
+            return underlying_extractor(mask_template_keep_offsets(content, language))
+        except Exception:
+            return []
+
     extractor = _LANGUAGE_EXTRACTORS.get(language)
     if extractor is None:
         return []

--- a/src/jcodemunch_mcp/parser/languages.py
+++ b/src/jcodemunch_mcp/parser/languages.py
@@ -6,6 +6,8 @@ import threading
 from dataclasses import dataclass
 from typing import Optional
 
+from .template_shared import TEMPLATE_ENGINE_LANGUAGES, TEMPLATE_EXTENSIONS
+
 
 @dataclass
 class LanguageSpec:
@@ -1993,6 +1995,26 @@ LANGUAGE_REGISTRY = {
     "dlang": DLANG_SPEC,
 }
 
+# Template-engine languages (jinja/twig) all route through the
+# custom _parse_template_symbols() path in extractor.py, so they need no
+# tree-sitter grammar. A shared placeholder spec (empty node maps) satisfies
+# parse_file()'s `language in LANGUAGE_REGISTRY` gate and makes the engines
+# appear in the auto-generated `languages` config list for enable/disable gating.
+_TEMPLATE_LANG_SPEC = LanguageSpec(
+    ts_language="__template__",
+    symbol_node_types={},
+    name_fields={},
+    param_fields={},
+    return_type_fields={},
+    docstring_strategy="preceding_comment",
+    decorator_node_type=None,
+    container_node_types=[],
+    constant_patterns=[],
+    type_patterns=[],
+)
+for _engine_lang in TEMPLATE_ENGINE_LANGUAGES:
+    LANGUAGE_REGISTRY.setdefault(_engine_lang, _TEMPLATE_LANG_SPEC)
+
 logger = logging.getLogger(__name__)
 
 _APPLIED_EXTENSIONS = False
@@ -2103,9 +2125,11 @@ def get_language_for_path(path: str) -> "Optional[str]":
     Check order:
     1. Well-known OpenAPI/Swagger basenames (openapi.yaml, swagger.json, …).
     2. Ansible path heuristics for YAML inventory/playbook files.
-    3. Compound suffixes (e.g. ``.blade.php``, ``.openapi.yaml``).
-    4. MATLAB vs Objective-C disambiguation for ``.m`` files.
+    3. MATLAB vs Objective-C disambiguation for ``.m`` files.
+    4. Compound suffixes (e.g. ``.blade.php``, ``.openapi.yaml``).
     5. Last extension (e.g. ``.php``).
+    6. Template fallback only — ``name.<lang>.<engine>`` (e.g. ``foo.ts.j2``);
+       runs after 4 and 5 so it can only turn an unresolved path into a language.
     """
     _apply_extra_extensions()
     import os as _os
@@ -2128,4 +2152,43 @@ def get_language_for_path(path: str) -> "Optional[str]":
             return LANGUAGE_EXTENSIONS[compound]
     # 5. Simple extension
     _, ext = _os.path.splitext(lower)
-    return LANGUAGE_EXTENSIONS.get(ext)
+    simple = LANGUAGE_EXTENSIONS.get(ext)
+    if simple is not None:
+        return simple
+    # 6. Template files (fallback only): name.<underlying-ext>.<engine-ext>
+    # (e.g. foo.ts.j2). This sits AFTER the compound (4) and last-extension (5)
+    # checks and fires only for the registered engine extensions, so it can only
+    # ever turn an unresolved path INTO a language — it can never re-resolve an
+    # extension that a check above already matched (e.g. ``.d.ts`` / ``.blade.php``
+    # win at step 4/5 and never reach here). Strip the engine extension and
+    # resolve the remaining name's language; if it resolves, this is a template
+    # over that language and we return the engine name (the custom parser
+    # re-derives the underlying language from the path). A bare template with no
+    # inner language extension (e.g. report.j2) returns None and is skipped —
+    # there is nothing to parse as source.
+    for _engine_ext, _engine_lang in TEMPLATE_EXTENSIONS.items():
+        if base.endswith(_engine_ext):
+            inner = base[: -len(_engine_ext)]
+            if inner and "." in inner and get_language_for_path(inner):
+                return _engine_lang
+            return None
+    return None
+
+
+def template_underlying_language(path: str) -> "Optional[str]":
+    """Return the underlying source language for a template file, or None.
+
+    For ``name.<underlying-ext>.<engine-ext>`` (e.g. ``foo.ts.j2``) this strips
+    the templating-engine extension and resolves the remaining name's language
+    (``typescript``). Returns None when the path is not a template or has no
+    inferable underlying language (a bare ``report.j2``).
+    """
+    _apply_extra_extensions()
+    base = os.path.basename(path.lower())
+    for engine_ext in TEMPLATE_EXTENSIONS:
+        if base.endswith(engine_ext):
+            inner = base[: -len(engine_ext)]
+            if inner and "." in inner:
+                return get_language_for_path(inner)
+            return None
+    return None

--- a/src/jcodemunch_mcp/parser/sql_preprocessor.py
+++ b/src/jcodemunch_mcp/parser/sql_preprocessor.py
@@ -9,6 +9,7 @@ from Jinja blocks before stripping, so the caller can create symbols for them.
 """
 import re
 from dataclasses import dataclass
+from functools import lru_cache
 
 
 # Matches {{ expr }}, {% block %}, and {# comment #} in any order
@@ -19,16 +20,33 @@ JINJA_PATTERN = re.compile(
     re.DOTALL
 )
 
-# dbt directive patterns — extract name and optional params from Jinja blocks.
-# Matches: {% macro name(args) %}, {%- macro name(args) -%}, etc.
-_DBT_DIRECTIVE_RE = re.compile(
-    r'\{%-?\s*'
-    r'(?P<directive>macro|test|snapshot|materialization)'
-    r'\s+(?P<name>\w+)'
-    r'(?:\s*\((?P<params>[^)]*)\))?'  # optional (params)
-    r'[^%]*?-?%\}',
-    re.DOTALL
-)
+# Default dbt directive keywords (macro, test, snapshot, materialization).
+_DEFAULT_DBT_DIRECTIVES = ("macro", "test", "snapshot", "materialization")
+
+
+@lru_cache(maxsize=None)
+def _directive_pattern(directives: tuple[str, ...]) -> "re.Pattern[str]":
+    """Build the Jinja-directive regex for a set of directive keywords.
+
+    The shape ``{% <kw> name(params) %}`` is the same for every Jinja-family
+    engine; only the keyword set differs. Shared by dbt SQL parsing (its default
+    macro/test/snapshot/materialization set) and the generic template parser
+    (which passes ``("macro", "block")``) so the scan/end-tag/docstring/offset
+    logic in :func:`extract_dbt_directives` is reused rather than duplicated.
+    """
+    alternation = "|".join(re.escape(d) for d in directives)
+    return re.compile(
+        r'\{%-?\s*'
+        r'(?P<directive>' + alternation + r')'
+        r'\s+(?P<name>\w+)'
+        r'(?:\s*\((?P<params>[^)]*)\))?'  # optional (params)
+        r'[^%]*?-?%\}',
+        re.DOTALL
+    )
+
+
+# dbt directive matcher — matches {% macro name(args) %}, {%- macro -%}, etc.
+_DBT_DIRECTIVE_RE = _directive_pattern(_DEFAULT_DBT_DIRECTIVES)
 
 # Jinja block comment: {# ... #}
 _JINJA_COMMENT_RE = re.compile(r'\{#(.*?)#\}', re.DOTALL)
@@ -47,18 +65,25 @@ class DbtDirective:
     byte_length: int  # from directive start to endmacro/endsnapshot/etc.
 
 
-def extract_dbt_directives(sql_bytes: bytes) -> list[DbtDirective]:
-    """Extract dbt macro/test/snapshot/materialization directives from Jinja SQL.
+def extract_dbt_directives(
+    sql_bytes: bytes,
+    directive_keywords: tuple[str, ...] = _DEFAULT_DBT_DIRECTIVES,
+) -> list[DbtDirective]:
+    """Extract Jinja ``{% <kw> name(params) %}`` directive blocks as metadata.
 
     Scans for ``{% macro name(params) %}`` and matching ``{% endmacro %}`` blocks,
     and similarly for test, snapshot, and materialization directives.
+
+    ``directive_keywords`` selects which directive shapes to match; it defaults to
+    the dbt set, and the generic template parser passes ``("macro", "block")`` to
+    reuse this same scan/end-tag/docstring/offset path for Jinja/Twig templates.
 
     Returns a list of DbtDirective with name, params, line range, and docstring.
     """
     sql_str = sql_bytes.decode("utf-8", errors="replace")
     directives: list[DbtDirective] = []
 
-    for m in _DBT_DIRECTIVE_RE.finditer(sql_str):
+    for m in _directive_pattern(tuple(directive_keywords)).finditer(sql_str):
         directive = m.group("directive")
         name = m.group("name")
         params = (m.group("params") or "").strip()

--- a/src/jcodemunch_mcp/parser/template_shared.py
+++ b/src/jcodemunch_mcp/parser/template_shared.py
@@ -1,0 +1,182 @@
+"""Shared templating-engine helpers (Jinja2, Twig).
+
+A *template file* wraps an underlying source language with a templating engine's
+constructs — the user's case is TypeScript-under-Jinja (``foo.ts.j2``). To index
+the real underlying symbols we:
+
+1. (optionally) extract the engine's own named definitions — Jinja/Twig
+   ``{% macro %}`` / ``{% block %}`` — as symbols, and
+2. **mask** the engine constructs while preserving byte offsets and line numbers
+   (newline → newline, every other char → space), then re-parse the masked text
+   as the underlying language.
+
+Because the mask is offset-preserving, the underlying-language symbols come back
+with positions that already point at the real lines of the template file — no
+block-offset rewrapping is required (this is what makes templates simpler to
+handle than Astro/Razor, which extract embedded sub-blocks).
+
+This module depends only on :mod:`.symbols` and :mod:`.sql_preprocessor` (both
+leaves), so :mod:`.languages`, :mod:`.extractor`, and :mod:`.imports` can all
+import from it without a cycle.
+
+The first cut ships Jinja2 and Twig — the engines whose ``name.<lang>.<engine>``
+double-extension convention this feature targets. The :class:`TemplateEngine`
+registry is pluggable: adding an engine is a small addition — register a
+:class:`TemplateEngine` in :data:`TEMPLATE_ENGINES` and map its extensions in
+:data:`TEMPLATE_EXTENSIONS`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from .sql_preprocessor import extract_dbt_directives
+from .symbols import Symbol, compute_content_hash, make_symbol_id
+
+
+# --------------------------------------------------------------------------- #
+# Directive extraction (Jinja / Twig)                                          #
+# --------------------------------------------------------------------------- #
+# Reuses sql_preprocessor.extract_dbt_directives — the same Jinja-block scan dbt
+# uses for ``{% macro %}`` — passing the ``{% macro %}`` / ``{% block %}`` keyword
+# set instead of dbt's. Jinja and Twig share these delimiters exactly, so the
+# only template-specific step is mapping the returned DbtDirective rows to
+# Symbols (mirroring _parse_sql_symbols' DbtDirective → Symbol conversion).
+
+# The Jinja/Twig directive keywords we surface as symbols.
+_TEMPLATE_DIRECTIVES = ("macro", "block")
+
+# Directive kind → Symbol kind. A macro is a callable (function); a block is a
+# named, overridable region (constant-like named anchor).
+_DIRECTIVE_KIND = {"macro": "function", "block": "constant"}
+
+
+def extract_jinja_directives(
+    text: str, filename: str, language: str = "jinja"
+) -> list[Symbol]:
+    """Extract ``{% macro %}`` / ``{% block %}`` definitions as Symbols.
+
+    Delegates the scan to :func:`sql_preprocessor.extract_dbt_directives` (the
+    dbt directive path, with the ``macro``/``block`` keyword set) and maps each
+    :class:`~sql_preprocessor.DbtDirective` to a :class:`Symbol`, mirroring the
+    DbtDirective → Symbol conversion in ``extractor._parse_sql_symbols``.
+    Offsets/line numbers refer to the *original* template text (the mask
+    preserves them, so they stay valid).
+    """
+    symbols: list[Symbol] = []
+    for d in extract_dbt_directives(
+        text.encode("utf-8"), directive_keywords=_TEMPLATE_DIRECTIVES
+    ):
+        kind = _DIRECTIVE_KIND[d.directive]
+        signature = (
+            f"{{% {d.directive} {d.name}({d.params}) %}}"
+            if d.params
+            else f"{{% {d.directive} {d.name} %}}"
+        )
+        symbols.append(
+            Symbol(
+                id=make_symbol_id(filename, d.name, kind),
+                file=filename,
+                name=d.name,
+                qualified_name=d.name,
+                kind=kind,
+                language=language,
+                signature=signature,
+                docstring=d.docstring,
+                line=d.line,
+                end_line=d.end_line,
+                byte_offset=d.byte_offset,
+                byte_length=d.byte_length,
+                content_hash=compute_content_hash(
+                    text.encode("utf-8")[d.byte_offset:d.byte_offset + d.byte_length]
+                ),
+                ecosystem_context=f"{language}-template",
+            )
+        )
+    return symbols
+
+
+# --------------------------------------------------------------------------- #
+# Engine registry                                                              #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class TemplateEngine:
+    """A templating engine jCodeMunch can index over an underlying language."""
+
+    name: str                          # engine language name, e.g. "jinja"
+    extensions: tuple[str, ...]        # e.g. (".j2", ".jinja", ".jinja2")
+    mask_pattern: re.Pattern           # spans of engine syntax to blank out
+    # Optional: extract the engine's own named definitions (macros/blocks).
+    directive_extractor: Optional[Callable[[str, str, str], list[Symbol]]] = None
+
+
+# Jinja2 and Twig share delimiters exactly: {{ expr }}, {% tag %}, {# comment #}.
+_JINJA_MASK = re.compile(
+    r"\{\{.*?\}\}"      # {{ expression }}
+    r"|\{%-?.*?-?%\}"   # {% tag %} / {%- tag -%}
+    r"|\{#.*?#\}",      # {# comment #}
+    re.DOTALL,
+)
+
+
+# First cut: Jinja2 + Twig (the `name.<lang>.<engine>` double-extension engines).
+# Single-extension HTML-bodied engines (Handlebars/Liquid/Mustache — page.hbs,
+# index.liquid) don't carry an underlying-language extension for this feature to
+# resolve, and each adds its own delimiter set; the registry is pluggable, so
+# they can be added on demand.
+TEMPLATE_ENGINES: dict[str, TemplateEngine] = {
+    "jinja": TemplateEngine(
+        name="jinja",
+        extensions=(".j2", ".jinja", ".jinja2"),
+        mask_pattern=_JINJA_MASK,
+        directive_extractor=extract_jinja_directives,
+    ),
+    "twig": TemplateEngine(
+        name="twig",
+        extensions=(".twig",),
+        mask_pattern=_JINJA_MASK,
+        directive_extractor=extract_jinja_directives,
+    ),
+}
+
+# extension → engine-language name, e.g. ".j2" → "jinja". Built from the registry
+# so a new engine only has to declare its extensions above.
+TEMPLATE_EXTENSIONS: dict[str, str] = {
+    ext: engine.name
+    for engine in TEMPLATE_ENGINES.values()
+    for ext in engine.extensions
+}
+
+# The set of engine-language names, used by the parser/imports dispatch.
+TEMPLATE_ENGINE_LANGUAGES: frozenset[str] = frozenset(TEMPLATE_ENGINES)
+
+
+def mask_template_keep_offsets(text: str, engine: str) -> str:
+    """Blank out an engine's constructs, preserving byte offsets and line counts.
+
+    Like :func:`astro_shared.mask_html_comments_keep_offsets`, newlines are
+    preserved so line numbers stay aligned. Unlike that helper (which blanks HTML
+    *comments*), template holes sit at code positions, so each non-newline char
+    is replaced with ``_`` rather than a space — an offset-preserving identifier
+    filler. This keeps value-position holes syntactically valid for stricter
+    grammars (``DEBUG = {{ x }}`` → ``DEBUG = _______``, which Python/TS still
+    parse; a space fill would leave an empty RHS and drop the surrounding
+    symbol). It is the offset-preserving form of dbt's ``__jinja__`` placeholder.
+
+    Best-effort caveats (same contract as dbt SQL parsing): a hole at a *name*
+    position (``function {{name}}()``) erases that symbol's name, and free
+    template text emitted inside a block body (e.g. a ``{% macro %}`` that
+    renders prose) can disrupt the declaration immediately following it.
+    """
+    eng = TEMPLATE_ENGINES.get(engine)
+    if eng is None:
+        return text
+
+    def _repl(match: "re.Match[str]") -> str:
+        return "".join("\n" if ch == "\n" else "_" for ch in match.group(0))
+
+    return eng.mask_pattern.sub(_repl, text)

--- a/tests/fixtures/templates/sample.py.jinja
+++ b/tests/fixtures/templates/sample.py.jinja
@@ -1,0 +1,20 @@
+import os
+from typing import Optional
+
+{% macro render_path(name) %}
+{{ name }}
+{% endmacro %}
+
+
+class Settings:
+    """Project settings rendered from a Jinja template."""
+
+    DEBUG = {{ debug_flag }}
+
+    def resolve(self, key: str) -> Optional[str]:
+        prefix = "{{ env_prefix }}"
+        return os.environ.get(prefix + key)
+
+
+def build_settings() -> Settings:
+    return Settings()

--- a/tests/fixtures/templates/sample.ts.j2
+++ b/tests/fixtures/templates/sample.ts.j2
@@ -1,0 +1,21 @@
+import { Helper } from "./helper";
+import type { Config } from "./config";
+
+export interface User {
+  id: number;
+  name: string;
+}
+
+export function buildUser(id: number): User {
+  const label: string = "{{ default_label }}";
+  return { id, name: label };
+}
+
+{% block footer %}
+export const FOOTER = "{{ footer_text }}";
+{% endblock %}
+
+{# A reusable greeting macro rendering prose (free text). #}
+{% macro greeting(name, salutation) %}
+{{ salutation }}, {{ name }}!
+{% endmacro %}

--- a/tests/fixtures/templates/widget.ts.twig
+++ b/tests/fixtures/templates/widget.ts.twig
@@ -1,0 +1,14 @@
+import { Component } from "./component";
+
+{# Twig shares Jinja's delimiters; macro extraction applies. #}
+{% macro field(label) %}
+<label>{{ label }}</label>
+{% endmacro %}
+
+export class Widget extends Component {
+  readonly title: string = "{{ widget_title }}";
+
+  render(): string {
+    return `<div>${this.title}</div>`;
+  }
+}

--- a/tests/test_plan_refactoring.py
+++ b/tests/test_plan_refactoring.py
@@ -1718,8 +1718,10 @@ class TestLanguageCoverage:
         registry_langs = set(LANGUAGE_REGISTRY.keys())
         import_langs = set(_IMPORT_PATTERNS.keys())
 
-        # Data formats are exempt — they have no import syntax
-        exempt = {"toml", "xml", "json", "yaml", "ansible", "openapi"}
+        # Data formats and templating engines are exempt — they have no import
+        # syntax of their own (a template refactor uses the underlying language).
+        from jcodemunch_mcp.parser.template_shared import TEMPLATE_ENGINE_LANGUAGES
+        exempt = {"toml", "xml", "json", "yaml", "ansible", "openapi"} | set(TEMPLATE_ENGINE_LANGUAGES)
         expected = registry_langs - exempt
         missing = expected - import_langs
 
@@ -1734,8 +1736,10 @@ class TestLanguageCoverage:
         registry_langs = set(LANGUAGE_REGISTRY.keys())
         def_langs = set(_DEF_PATTERNS.keys())
 
-        # Data formats are exempt — they have no symbol definitions
-        exempt = {"toml", "xml", "json", "yaml", "ansible", "openapi"}
+        # Data formats and templating engines are exempt — they have no symbol
+        # definitions of their own (a template refactor uses the underlying language).
+        from jcodemunch_mcp.parser.template_shared import TEMPLATE_ENGINE_LANGUAGES
+        exempt = {"toml", "xml", "json", "yaml", "ansible", "openapi"} | set(TEMPLATE_ENGINE_LANGUAGES)
         expected = registry_langs - exempt
         missing = expected - def_langs
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,262 @@
+"""Templating-language indexing tests (Jinja2 / Twig).
+
+A template file of the form ``name.<underlying-ext>.<engine-ext>`` (e.g.
+``foo.ts.j2``) is recognized, the engine constructs are masked offset-preserving,
+and the body is re-parsed as the underlying language. See issue #336.
+"""
+
+from pathlib import Path
+
+from jcodemunch_mcp.parser import parse_file
+from jcodemunch_mcp.parser.imports import extract_imports
+from jcodemunch_mcp.parser.languages import (
+    LANGUAGE_REGISTRY,
+    get_language_for_path,
+    template_underlying_language,
+)
+from jcodemunch_mcp.parser.template_shared import (
+    TEMPLATE_ENGINE_LANGUAGES,
+    mask_template_keep_offsets,
+)
+from jcodemunch_mcp.tools.index_folder import discover_local_files
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "templates"
+
+
+def _read_fixture(name: str) -> str:
+    return (FIXTURE_DIR / name).read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# Recognition / registry                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_engine_languages_in_registry():
+    # First cut ships Jinja2 + Twig only (registry stays pluggable).
+    assert set(TEMPLATE_ENGINE_LANGUAGES) == {"jinja", "twig"}
+    for engine in ("jinja", "twig"):
+        assert engine in LANGUAGE_REGISTRY
+
+
+def test_extension_resolution_infers_engine_and_underlying():
+    cases = {
+        "src/models/user.ts.j2": ("jinja", "typescript"),
+        "settings.py.jinja": ("jinja", "python"),
+        "ui/widget.ts.twig": ("twig", "typescript"),
+        "a/b/service.py.jinja2": ("jinja", "python"),
+    }
+    for path, (engine, underlying) in cases.items():
+        assert get_language_for_path(path) == engine, path
+        assert template_underlying_language(path) == underlying, path
+
+
+def test_bare_template_without_underlying_is_skipped():
+    # No middle language extension -> nothing to parse as source.
+    assert get_language_for_path("report.j2") is None
+    assert get_language_for_path("email.jinja") is None
+    assert template_underlying_language("report.j2") is None
+
+
+def test_plain_source_extension_unchanged():
+    # The template branch must not perturb ordinary files.
+    assert get_language_for_path("foo.ts") == "typescript"
+    assert get_language_for_path("foo.py") == "python"
+    assert template_underlying_language("foo.ts") is None
+
+
+def test_template_fallback_never_reresolves_existing_extension():
+    # The template step runs AFTER the compound and last-extension checks, so a
+    # path that already resolves there must win unchanged and never be hijacked
+    # by the engine-stripping fallback. None of these are template files.
+    non_collisions = {
+        "types/foo.d.ts": "typescript",   # .d.ts -> last-extension .ts
+        "user.test.ts": "typescript",     # .test.ts -> last-extension .ts
+        "View.blade.php": "blade",        # compound .blade.php wins at step 4
+    }
+    for path, expected in non_collisions.items():
+        assert get_language_for_path(path) == expected, path
+        assert template_underlying_language(path) is None, path
+    # A bare .j2 with no inner language extension still skips (turns nothing
+    # into a language) — the fallback only ever upgrades an unresolved path.
+    assert get_language_for_path("report.j2") is None
+
+
+# --------------------------------------------------------------------------- #
+# Symbol extraction (offset preservation)                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_jinja_ts_underlying_symbols_with_correct_lines():
+    content = _read_fixture("sample.ts.j2")
+    symbols = parse_file(content, "src/models/user.ts.j2", "jinja")
+    by_name = {s.name: s for s in symbols}
+
+    # Underlying TypeScript symbols keep their sub-language and exact line numbers.
+    assert "User" in by_name
+    assert by_name["User"].kind == "type"
+    assert by_name["User"].language == "typescript"
+    assert by_name["User"].line == 4
+
+    assert "buildUser" in by_name
+    assert by_name["buildUser"].kind == "function"
+    assert by_name["buildUser"].language == "typescript"
+    # buildUser's body has a value-position {{ hole }} (masked to an identifier
+    # filler); its line is correct only because masking preserves offsets.
+    assert by_name["buildUser"].line == 9
+
+    # Real TypeScript inside a {% block %} (whole-line tags) is still extracted.
+    assert "FOOTER" in by_name
+    assert by_name["FOOTER"].language == "typescript"
+    assert by_name["FOOTER"].line == 15
+
+
+def test_jinja_macro_and_block_extracted_as_symbols():
+    content = _read_fixture("sample.ts.j2")
+    symbols = parse_file(content, "src/models/user.ts.j2", "jinja")
+    by_name = {s.name: s for s in symbols}
+
+    assert "greeting" in by_name
+    assert by_name["greeting"].kind == "function"
+    assert by_name["greeting"].language == "jinja"
+    assert by_name["greeting"].line == 19
+
+    assert "footer" in by_name
+    assert by_name["footer"].kind == "constant"
+    assert by_name["footer"].language == "jinja"
+    assert by_name["footer"].line == 14
+
+
+def test_python_underlying_language():
+    content = _read_fixture("sample.py.jinja")
+    symbols = parse_file(content, "conf/settings.py.jinja", "jinja")
+    by_name = {s.name: s for s in symbols}
+
+    assert by_name["Settings"].kind == "class"
+    assert by_name["Settings"].language == "python"
+    assert by_name["build_settings"].kind == "function"
+    assert by_name["build_settings"].language == "python"
+    # The macro is still surfaced.
+    assert by_name["render_path"].language == "jinja"
+
+
+def test_repo_forwarded_to_underlying_body_parse():
+    # The template body re-parse must honor per-project language gating, so the
+    # repo passed to parse_file has to reach the underlying-language enablement
+    # check (config.is_language_enabled) — not get dropped at the template hop.
+    from unittest.mock import patch
+
+    seen: list = []
+
+    def _record(language, repo=None):
+        seen.append((language, repo))
+        return True
+
+    with patch("jcodemunch_mcp.config.is_language_enabled", side_effect=_record):
+        parse_file(
+            _read_fixture("sample.ts.j2"),
+            "src/models/user.ts.j2",
+            "jinja",
+            repo="/proj/root",
+        )
+
+    # The underlying TypeScript body was gated with the same repo we passed in.
+    assert ("typescript", "/proj/root") in seen
+
+
+def test_twig_engine_same_delimiters():
+    content = _read_fixture("widget.ts.twig")
+    symbols = parse_file(content, "ui/widget.ts.twig", "twig")
+    by_name = {s.name: s for s in symbols}
+
+    assert by_name["Widget"].kind == "class"
+    assert by_name["Widget"].language == "typescript"
+    # Twig reuses the Jinja directive extractor; the macro tags as twig.
+    assert by_name["field"].kind == "function"
+    assert by_name["field"].language == "twig"
+
+
+def test_bom_and_crlf_preserve_line_numbers():
+    content = "﻿" + _read_fixture("sample.ts.j2").replace("\n", "\r\n")
+    symbols = parse_file(content, "src/models/user.ts.j2", "jinja")
+    by_name = {s.name: s for s in symbols}
+    assert "User" in by_name
+    assert by_name["User"].line == 4
+    assert by_name["buildUser"].line == 9
+
+
+def test_multiline_block_keeps_following_symbol_aligned():
+    content = (
+        "export const A = 1;\n"
+        "{% if cond %}\n"
+        "  {{ extra }}\n"
+        "  {{ more }}\n"
+        "{% endif %}\n"
+        "export function tail(): void {}\n"
+    )
+    symbols = parse_file(content, "x.ts.j2", "jinja")
+    by_name = {s.name: s for s in symbols}
+    assert by_name["tail"].line == 6  # unshifted by the 4-line {% if %} block
+
+
+# --------------------------------------------------------------------------- #
+# Masking primitive                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_mask_preserves_length_and_newlines():
+    text = "a = {{ v }}\n{% if x %}\nkeep me\n{% endif %}\n"
+    masked = mask_template_keep_offsets(text, "jinja")
+    assert len(masked) == len(text)
+    assert masked.count("\n") == text.count("\n")
+    assert "if x" not in masked
+    assert "{{" not in masked and "{%" not in masked
+    assert "keep me" in masked  # inert content between constructs is untouched
+
+
+def test_mask_unknown_engine_is_identity():
+    text = "{{ x }}"
+    assert mask_template_keep_offsets(text, "not-an-engine") == text
+
+
+# --------------------------------------------------------------------------- #
+# Imports                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_imports_extracted_from_template_body():
+    content = _read_fixture("sample.ts.j2")
+    edges = extract_imports(content, "src/models/user.ts.j2", "jinja")
+    specifiers = {e["specifier"] for e in edges}
+    assert "./helper" in specifiers
+    assert "./config" in specifiers
+
+
+def test_imports_with_templated_specifier_do_not_crash():
+    content = 'import { X } from "{{ pkg }}";\nimport { Y } from "./static";\n'
+    edges = extract_imports(content, "m.ts.j2", "jinja")
+    specifiers = {e["specifier"] for e in edges}
+    assert "./static" in specifiers  # static import survives masking
+
+
+# --------------------------------------------------------------------------- #
+# Discovery (end-to-end, hermetic)                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_discovery_indexes_template_not_wrong_extension(tmp_path):
+    (tmp_path / "foo.ts.j2").write_text(
+        _read_fixture("sample.ts.j2"), encoding="utf-8"
+    )
+    (tmp_path / "bare.j2").write_text("nothing parseable here\n", encoding="utf-8")
+    (tmp_path / "plain.ts").write_text("export const k = 1;\n", encoding="utf-8")
+
+    files, _warnings, skip_counts = discover_local_files(tmp_path.resolve())
+    names = {p.name for p in files}
+
+    assert "foo.ts.j2" in names      # recognized as a template
+    assert "plain.ts" in names       # ordinary file still discovered
+    assert "bare.j2" not in names    # bare template skipped
+    # The template was NOT counted as an unsupported extension.
+    assert skip_counts.get("wrong_extension", 0) <= 1  # only bare.j2 may count


### PR DESCRIPTION
Closes #336.

## Summary

Files of the form `name.<underlying-ext>.<engine-ext>` — e.g. a Jinja2 template of TypeScript (`foo.ts.j2`), Jinja of Python (`service.py.jinja`), or a Twig template of TS (`widget.ts.twig`) — were previously dropped at discovery as `wrong_extension`, so every real source symbol inside them went unindexed. They are now recognized: the engine constructs are **masked offset-preserving** and the body is re-parsed as its underlying language, so symbols, signatures, imports, and line/byte positions all resolve correctly.

Because the mask is offset-preserving (each engine hole → same-length filler, newlines kept), the underlying-language symbols come back with positions that already point at the real lines of the template file — no block re-wrapping. That makes this simpler than the Astro/Razor sub-block extractors. Purely additive (these files are skipped today), with **no `INDEX_VERSION` bump**.

## Requested changes from the #336 review

All four review asks are incorporated:

1. **Scoped the first cut to Jinja2 + Twig.** Engines: Jinja2 (`.j2`/`.jinja`/`.jinja2`) and Twig (`.twig`) — the engines whose `name.<lang>.<engine>` double-extension convention this targets. Liquid/Handlebars/Mustache (single-extension, HTML-bodied, no underlying extension to resolve) are dropped from the first cut; the `TemplateEngine` registry (`parser/template_shared.py`) stays pluggable so they can be added on demand.
2. **Guarded the discovery-layer change.** The "strip a known engine extension, recurse on the remainder" step now sits **after** the existing compound and last-extension checks in `get_language_for_path`, and fires only for registered engine extensions — so it can only ever turn `None` into a language and never re-resolve an existing compound extension. Includes non-collision tests for `.d.ts`, `.test.ts`, `.blade.php`, and a bare `report.j2` that correctly skips.
3. **Reused the dbt directive path.** `sql_preprocessor.extract_dbt_directives` is generalized to accept a `directive_keywords` set (default = the dbt macro/test/snapshot/materialization set, so that path is byte-identical); the template parser delegates to it with `("macro", "block")` and maps the returned rows to Symbols, rather than a parallel regex implementation.
4. **Followed the Astro checklist and kept scope tight.** Extension mapping, `_parse_*` recursive delegation, import extractor, `template_shared.py` offset helper, fixtures + regression tests. **No CI or workflow files are touched.**

## Implementation notes

- **Underlying language is inferred from the middle extension** (`foo.ts.j2` → `typescript`) by stripping the engine suffix and resolving the remainder recursively — so every language jCodeMunch already supports works as the body with no per-language work. EJS (`.ejs`) keeps its existing parser.
- **Offset-preserving mask** mirrors `astro_shared.mask_html_comments_keep_offsets` but fills each hole with an identifier placeholder (`{{ x }}` → same-length `_`), keeping value-position holes (`DEBUG = {{ x }}`) parseable in strict grammars — the offset-preserving form of dbt's `__jinja__`. A hole at a *name* position, or free template text emitted inside a block body, is best-effort (same contract as dbt SQL parsing).
- **`{% macro %}` / `{% block %}`** definitions are additionally surfaced as symbols; underlying body symbols keep their own sub-language tag.
- **`repo` is forwarded into the recursive body parse** so the underlying language honors per-project `.jcodemunch.jsonc` enable/disable gating (caught in review of this branch).

## Tests

- New `tests/test_templates.py` — offset preservation, macro/block extraction, BOM/CRLF, imports, non-collision guards (`.d.ts`/`.test.ts`/`.blade.php`/bare `report.j2`), and repo propagation — plus fixtures under `tests/fixtures/templates/`.
- Parser-layer sweep (templates + sql/dbt + astro/razor/import/language/extractor + plan_refactoring) all green.
- `CHANGELOG.md` and `LANGUAGE_SUPPORT.md` updated.

https://claude.ai/code/session_01AZzyK49SHjZvBHf2sV975k