### PR TITLE
feat: advertise MCP readOnlyHint on every tool so plan-mode clients run read tools silently

### DIFF
--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import IO, Any, Optional
 
 from mcp.server import Server
-from mcp.types import Tool, TextContent, Resource, Prompt, PromptMessage, GetPromptResult, CallToolResult
+from mcp.types import Tool, ToolAnnotations, TextContent, Resource, Prompt, PromptMessage, GetPromptResult, CallToolResult
 
 from . import __version__
 from . import config as config_module
@@ -938,6 +938,47 @@ async def list_tools() -> list[Tool]:
     """List all available tools."""
     _signal_handshake()
     return _build_tools_list()
+
+
+# --- MCP read-only annotations --------------------------------------------- #
+# Claude Code's plan mode prompts for approval on every tool it cannot prove is
+# read-only. jcm is read-only by charter, so annotate each tool with
+# ToolAnnotations(readOnlyHint=...) and plan mode runs the query tools silently
+# while still gating the handful that mutate index/session/config state.
+#
+# The write-set is derived from the authoritative counter.STATE_CHANGING_ACTIONS
+# so it can't drift from source. Two names are added on top:
+#   * index_dependency — a real write tool (snapshots + reindexes) that is
+#     missing from counter.STATE_CHANGING_ACTIONS (latent gap in that set).
+#   * order / route — the counter front door can dispatch a state-changing
+#     action, so they are not read-only. (menu stays read-only.)
+_NON_READONLY_TOOLS: frozenset[str] = _counter.STATE_CHANGING_ACTIONS | {
+    "index_dependency",
+    "order",
+    "route",
+}
+
+
+def _apply_readonly_annotations(tools: list[Tool]) -> list[Tool]:
+    """Attach ToolAnnotations(readOnlyHint=...) to any tool lacking annotations.
+
+    Read tools (readOnlyHint=True) run silently in Claude Code plan mode; the
+    write-set (_NON_READONLY_TOOLS) is marked readOnlyHint=False so those still
+    prompt. Tools that already carry annotations are left untouched. Returns a
+    new list; input Tool objects are copied (model_copy) rather than mutated.
+    """
+    annotated: list[Tool] = []
+    for tool in tools:
+        if tool.annotations is None:
+            tool = tool.model_copy(
+                update={
+                    "annotations": ToolAnnotations(
+                        readOnlyHint=tool.name not in _NON_READONLY_TOOLS
+                    )
+                }
+            )
+        annotated.append(tool)
+    return annotated
 
 
 def _build_tools_list() -> list[Tool]:
@@ -3779,7 +3820,7 @@ def _build_tools_list() -> list[Tool]:
         keep = _COUNTER_FRONT_DOOR | _ALWAYS_PRESENT_TOOLS
         tools = [t for t in all_tools if t.name in keep]
         _apply_description_overrides(tools)
-        return tools
+        return _apply_readonly_annotations(tools)
     # Non-counter surfaces keep existing behavior byte-for-byte: the front-door
     # tools stay hidden (still callable via call_tool), so 'full' and the
     # existing tiers are unchanged on upgrade.
@@ -3840,7 +3881,7 @@ def _build_tools_list() -> list[Tool]:
     # Merge descriptions from config (runs after disabled_tools filter)
     _apply_description_overrides(tools)
 
-    return tools
+    return _apply_readonly_annotations(tools)
 
 
 def _apply_description_overrides(tools: list) -> None:

--- a/tests/test_readonly_annotations.py
+++ b/tests/test_readonly_annotations.py
@@ -1,0 +1,73 @@
+"""MCP readOnlyHint annotations for Claude Code plan mode.
+
+Claude Code's plan mode prompts for approval on every tool it cannot prove is
+read-only. jcm is read-only by charter, so every tool now advertises
+ToolAnnotations(readOnlyHint=...): the query tools are True (plan mode runs them
+silently) and the handful that mutate index/session/config state are False (they
+still prompt). This is a regression guard for that fix.
+
+The write-set is derived from the authoritative counter.STATE_CHANGING_ACTIONS
+(plus index_dependency, order, route) so it can't silently drift from source and
+let a mutating tool masquerade as read-only.
+"""
+
+import jcodemunch_mcp.server as server
+from jcodemunch_mcp import counter
+
+
+# Minimum set of mutating tools the annotation logic MUST mark non-read-only.
+# index_dependency is a real write tool (snapshots + reindexes) absent from
+# counter.STATE_CHANGING_ACTIONS; driving off that set keeps this from drifting.
+_EXPECTED_MIN_WRITE = counter.STATE_CHANGING_ACTIONS | {"index_dependency"}
+
+
+def test_non_readonly_set_covers_authoritative_write_actions():
+    """The annotation write-set must cover every state-changing action plus
+    index_dependency. If counter.STATE_CHANGING_ACTIONS grows, this fails until
+    _NON_READONLY_TOOLS is updated — a mutating tool must never default to
+    read-only (which would make plan mode run it silently)."""
+    assert _EXPECTED_MIN_WRITE <= server._NON_READONLY_TOOLS
+
+
+def test_every_tool_has_a_readonly_hint():
+    """Every tool surfaced by tools/list carries an explicit readOnlyHint so
+    plan mode never has to guess."""
+    tools = server._build_tools_list()
+    assert tools, "expected a non-empty tool list"
+    missing = [
+        t.name
+        for t in tools
+        if t.annotations is None or t.annotations.readOnlyHint is None
+    ]
+    assert not missing, f"tools missing readOnlyHint: {missing}"
+
+
+def test_readonly_hint_matches_write_set():
+    """readOnlyHint is True exactly for tools NOT in the write-set, and False
+    for those in it. Guards against a future manual annotation diverging from
+    _NON_READONLY_TOOLS."""
+    tools = server._build_tools_list()
+    for tool in tools:
+        expected_readonly = tool.name not in server._NON_READONLY_TOOLS
+        assert tool.annotations.readOnlyHint is expected_readonly, (
+            f"{tool.name}: readOnlyHint={tool.annotations.readOnlyHint} "
+            f"but expected {expected_readonly}"
+        )
+
+
+def test_representative_read_and_write_tools():
+    """Spot-check named tools that must be present on the default surface:
+    query tools read-only, index/edit tools mutating."""
+    by_name = {t.name: t for t in server._build_tools_list()}
+
+    for read_tool in ("get_symbol_source", "search_symbols", "search_text", "plan_turn"):
+        assert read_tool in by_name, f"{read_tool} unexpectedly absent"
+        assert by_name[read_tool].annotations.readOnlyHint is True, (
+            f"{read_tool} should be read-only"
+        )
+
+    for write_tool in ("index_folder", "register_edit", "index_dependency", "set_tool_tier"):
+        assert write_tool in by_name, f"{write_tool} unexpectedly absent"
+        assert by_name[write_tool].annotations.readOnlyHint is False, (
+            f"{write_tool} should be marked mutating"
+        )


### PR DESCRIPTION
### Problem

MCP clients that gate tool execution (notably Claude Code's plan mode) prompt for
approval on every tool they cannot prove is read-only. jcodemunch's tools carry
no `annotations`, so `tools/list` returns `annotations: null` for all of them and
plan mode asks for approval on every jcm call (`search_symbols`,
`get_symbol_source`, `search_text`, ...). jcm is read-only by charter, so these
prompts are pure friction.

TLDR: no annotation -> client cannot prove read-only -> prompts on every call /
fix: set `readOnlyHint` per tool / upside: silent read tools in plan mode.

### Change

Annotate tools at ONE choke point instead of editing ~87 `Tool(...)` literals.
Every tool gets `ToolAnnotations(readOnlyHint=...)`: read tools `True`,
state-changing tools `False`. The write-set reuses the project's own authoritative
`counter.STATE_CHANGING_ACTIONS` so it cannot drift.

Files:

- `src/jcodemunch_mcp/server.py`
  - Add `ToolAnnotations` to the `mcp.types` import.
  - Add module-level `_NON_READONLY_TOOLS = counter.STATE_CHANGING_ACTIONS | {"index_dependency", "order", "route"}`.
  - Add `_apply_readonly_annotations(tools)` — for each tool without existing
    annotations, attach `ToolAnnotations(readOnlyHint = name not in _NON_READONLY_TOOLS)`
    via a non-mutating `model_copy`.
  - Apply it at both return points of `_build_tools_list()` (the main non-counter
    path and the `counter`-surface early return) so annotations are consistent on
    every surface.
- `tests/test_readonly_annotations.py` (new) — 4 tests:
  - the write-set covers `counter.STATE_CHANGING_ACTIONS | {index_dependency}` (drift guard),
  - every surfaced tool has a non-null `readOnlyHint`,
  - each tool's `readOnlyHint` equals `name not in _NON_READONLY_TOOLS`,
  - representative read tools (`get_symbol_source`, `search_symbols`, `search_text`, `plan_turn`) are `True` and write tools (`index_folder`, `register_edit`, `index_dependency`, `set_tool_tier`) are `False`.
