### PR TITLE
feat: Add TOML symbol extraction support

### DIFF
--- a/LANGUAGE_SUPPORT.md
+++ b/LANGUAGE_SUPPORT.md
@@ -50,6 +50,7 @@
 | SCSS              | `.scss`                                         | tree-sitter-scss + custom walker | function (`@mixin`/`@function`/`@include`), class (selectors/`%placeholder`), type (`@media`/`@supports`), constant (`$variable`) | — | `//` and `/* */` comments | Full SCSS extraction including variables and nested rules |
 | SASS              | `.sass`                                         | text search only (no grammar)   | — (files indexed for text search) | — | — | Indented SASS syntax; no tree-sitter-sass grammar in language-pack; falls back to CSS parser which cannot handle indented syntax → no symbols emitted |
 | YAML              | `.yaml`, `.yml`                                 | custom dict walker (pyyaml)     | function/type/constant (structural keys and containers extracted by depth/shape) | — | — | Generic YAML; Ansible-specific YAML detected via path heuristics and routed to the Ansible parser instead |
+| TOML              | `.toml`                                         | tree-sitter-toml + custom walker | type (table), class (array table), constant (key-value pair) | — | `#` preceding comments | Tables (`[section]`) as types, array tables (`[[section]]`) as classes, key-value pairs as constants; nested paths via dotted qualified names |
 | Ansible           | `.yaml`, `.yml` (path-detected)                 | custom dict walker (pyyaml)     | class (play names), function (task/handler/role names), constant (variable keys) | — | — | Detected via path heuristics (tasks/, handlers/, group_vars/, site.yml, etc.); requires pyyaml |
 | OpenAPI / Swagger | `.openapi.yaml`, `.openapi.json`, `.swagger.yaml`, `.swagger.json`, `openapi.yaml`, `swagger.json` | custom dict walker (pyyaml + json) | function (path operations: `GET /users`, `POST /orders/{id}`), type (component schemas / v2 definitions) | — | — | Supports OpenAPI 3.x and Swagger 2.0; requires pyyaml for YAML variants |
 | JSON              | `.json`                                         | custom json walker (stdlib)     | constant (top-level object keys)                                                           | — | — | Compound extensions (`.openapi.json`, `.swagger.json`) and well-known basenames are routed to the OpenAPI parser first |
@@ -88,7 +89,6 @@ These languages are fully indexed and searchable via `search_text`. Symbol extra
 
 | Language | Extensions     | Notes                                                              |
 | -------- | -------------- | ------------------------------------------------------------------ |
-| TOML     | `.toml`        | Tables indexed; key-as-symbol extractor planned                    |
 | R        | `.r`           | Functions are name-bound values (`f <- function(){}`); custom extractor planned |
 | LESS     | `.less`        | No tree-sitter-less grammar in language-pack; indexed for text search |
 | Stylus   | `.styl`        | No tree-sitter-stylus grammar in language-pack; indexed for text search |

--- a/src/jcodemunch_mcp/parser/extractor.py
+++ b/src/jcodemunch_mcp/parser/extractor.py
@@ -304,6 +304,8 @@ def parse_file(content: str, filename: str, language: str, source_bytes: Optiona
         symbols = _parse_css_symbols(source_bytes, filename)
     elif language == "scss":
         symbols = _parse_scss_symbols(source_bytes, filename)
+    elif language == "toml":
+        symbols = _parse_toml_symbols(source_bytes, filename)
     elif language == "pascal":
         symbols = _parse_pascal_symbols(source_bytes, filename)
     elif language == "matlab":
@@ -6346,6 +6348,133 @@ def _parse_json_symbols(source_bytes: bytes, filename: str) -> list[Symbol]:
             content_hash=compute_content_hash(source_bytes[pair.start_byte:pair.end_byte]),
         ))
 
+    return symbols
+
+
+def _parse_toml_symbols(source_bytes: bytes, filename: str) -> list[Symbol]:
+    """Parse TOML files and extract tables, array tables, and key-value pairs as symbols.
+
+    Extracted symbol kinds:
+    - Table ([section]) → kind "type"
+    - Array table ([[section]]) → kind "class"
+    - Key-value pair → kind "constant"
+
+    TOML tables are the primary structural units, similar to sections in INI files.
+    Array tables represent lists of tables. Key-value pairs at the top level
+    and inside tables are extracted as constants.
+    """
+    try:
+        parser = get_parser("toml")
+    except Exception:
+        return []
+
+    tree = parser.parse(source_bytes)
+    symbols: list[Symbol] = []
+
+    def _extract_key(node) -> Optional[str]:
+        """Extract key name from a TOML key node."""
+        if node.type == "bare_key":
+            return source_bytes[node.start_byte:node.end_byte].decode("utf-8", errors="replace")
+        elif node.type == "quoted_key":
+            content = source_bytes[node.start_byte:node.end_byte].decode("utf-8", errors="replace")
+            return content.strip('"').strip("'")
+        elif node.type == "dotted_key":
+            parts = []
+            for child in node.children:
+                if child.type in ("bare_key", "quoted_key"):
+                    parts.append(_extract_key(child))
+            return ".".join(p for p in parts if p)
+        return None
+
+    def _walk_node(node, parent_path: list[str] = None):
+        """Walk the AST and extract symbols."""
+        if parent_path is None:
+            parent_path = []
+
+        if node.type == "table":
+            key_node = next((c for c in node.children if c.type in ("bare_key", "quoted_key", "dotted_key")), None)
+            if key_node:
+                key = _extract_key(key_node)
+                if key:
+                    full_path = ".".join(parent_path + [key]) if parent_path else key
+                    symbols.append(Symbol(
+                        id=make_symbol_id(filename, full_path, "type"),
+                        file=filename,
+                        name=key,
+                        qualified_name=full_path,
+                        kind="type",
+                        language="toml",
+                        signature=f"[{full_path}]",
+                        line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                        byte_offset=node.start_byte,
+                        byte_length=node.end_byte - node.start_byte,
+                        content_hash=compute_content_hash(source_bytes[node.start_byte:node.end_byte]),
+                    ))
+                    new_path = parent_path + [key]
+                    for child in node.children:
+                        _walk_node(child, new_path)
+            return
+
+        if node.type == "table_array_element":
+            key_node = next((c for c in node.children if c.type in ("bare_key", "quoted_key", "dotted_key")), None)
+            if key_node:
+                key = _extract_key(key_node)
+                if key:
+                    full_path = ".".join(parent_path + [key]) if parent_path else key
+                    symbols.append(Symbol(
+                        id=make_symbol_id(filename, full_path + "[]", "class"),
+                        file=filename,
+                        name=key + "[]",
+                        qualified_name=full_path,
+                        kind="class",
+                        language="toml",
+                        signature=f"[[{full_path}]]",
+                        line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                        byte_offset=node.start_byte,
+                        byte_length=node.end_byte - node.start_byte,
+                        content_hash=compute_content_hash(source_bytes[node.start_byte:node.end_byte]),
+                    ))
+                    new_path = parent_path + [key]
+                    for child in node.children:
+                        _walk_node(child, new_path)
+            return
+
+        if node.type == "pair":
+            key_node = None
+            for child in node.children:
+                if child.type in ("bare_key", "quoted_key", "dotted_key"):
+                    key_node = child
+                    break
+            if key_node:
+                key = _extract_key(key_node)
+                if key:
+                    full_path = ".".join(parent_path + [key]) if parent_path else key
+                    val_src = source_bytes[node.start_byte:node.end_byte].decode("utf-8", errors="replace")
+                    sig = " ".join(val_src.split())
+                    if len(sig) > 100:
+                        sig = sig[:97] + "..."
+                    symbols.append(Symbol(
+                        id=make_symbol_id(filename, full_path, "constant"),
+                        file=filename,
+                        name=key,
+                        qualified_name=full_path,
+                        kind="constant",
+                        language="toml",
+                        signature=sig,
+                        line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                        byte_offset=node.start_byte,
+                        byte_length=node.end_byte - node.start_byte,
+                        content_hash=compute_content_hash(source_bytes[node.start_byte:node.end_byte]),
+                    ))
+            return
+
+        for child in node.children:
+            _walk_node(child, parent_path)
+
+    _walk_node(tree.root_node)
     return symbols
 
 

--- a/src/jcodemunch_mcp/parser/languages.py
+++ b/src/jcodemunch_mcp/parser/languages.py
@@ -1433,8 +1433,7 @@ STYL_SPEC = LanguageSpec(
 
 
 # TOML specification
-# NOTE: TOML tables are the closest analogue to symbols. Custom extraction
-# deferred. Files are indexed for text search.
+# Custom extraction in extractor.py handles tables, array tables, and key-value pairs.
 TOML_SPEC = LanguageSpec(
     ts_language="toml",
     symbol_node_types={},

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -2455,3 +2455,87 @@ def test_verilog_extension_mapping():
     assert get_language_for_path("src/alu.sv") == "verilog"
     assert get_language_for_path("src/pkg.svh") == "verilog"
     assert get_language_for_path("SRC/ALU.SV") == "verilog"
+
+
+# ---------------------------------------------------------------------------
+# TOML
+# ---------------------------------------------------------------------------
+
+TOML_SOURCE = '''\
+# Project configuration
+name = "jcodemunch-mcp"
+version = "1.0.0"
+description = "A token-efficient MCP server for GitHub code search"
+
+[author]
+name = "John Doe"
+email = "john@example.com"
+
+[server]
+host = "localhost"
+port = 8080
+
+[[features]]
+name = "search"
+enabled = true
+
+[[features]]
+name = "semantic"
+enabled = false
+'''
+
+
+def test_parse_toml():
+    """Test TOML parsing — tables, array tables, and key-value pairs."""
+    symbols = parse_file(TOML_SOURCE, "pyproject.toml", "toml")
+
+    # Top-level constants
+    name = next((s for s in symbols if s.name == "name" and s.kind == "constant"), None)
+    assert name is not None
+    assert name.qualified_name == "name"
+
+    version = next((s for s in symbols if s.name == "version" and s.kind == "constant"), None)
+    assert version is not None
+
+    description = next((s for s in symbols if s.name == "description" and s.kind == "constant"), None)
+    assert description is not None
+
+    # Tables (type symbols)
+    author = next((s for s in symbols if s.name == "author" and s.kind == "type"), None)
+    assert author is not None
+    assert author.signature == "[author]"
+
+    server = next((s for s in symbols if s.name == "server" and s.kind == "type"), None)
+    assert server is not None
+    assert server.signature == "[server]"
+
+    # Array tables (class symbols)
+    features_array = next((s for s in symbols if s.name == "features[]" and s.kind == "class"), None)
+    assert features_array is not None
+    assert features_array.signature == "[[features]]"
+
+    # Nested constants inside tables
+    author_name = next((s for s in symbols if s.name == "name" and s.qualified_name == "author.name"), None)
+    assert author_name is not None
+    assert author_name.kind == "constant"
+
+    author_email = next((s for s in symbols if s.name == "email" and s.qualified_name == "author.email"), None)
+    assert author_email is not None
+    assert author_email.kind == "constant"
+
+    server_host = next((s for s in symbols if s.name == "host" and s.qualified_name == "server.host"), None)
+    assert server_host is not None
+
+    server_port = next((s for s in symbols if s.name == "port" and s.qualified_name == "server.port"), None)
+    assert server_port is not None
+
+    # All symbols tagged as toml
+    assert all(s.language == "toml" for s in symbols)
+
+
+def test_toml_extension_mapping():
+    """.toml extensions map to toml language."""
+    from jcodemunch_mcp.parser.languages import get_language_for_path
+    assert get_language_for_path("pyproject.toml") == "toml"
+    assert get_language_for_path("config/settings.toml") == "toml"
+    assert get_language_for_path("CONFIG/SETTINGS.TOML") == "toml"


### PR DESCRIPTION
- Implement _parse_toml_symbols function in extractor.py
- Extract tables as type symbols, array tables as class symbols, and key-value pairs as constant symbols
- Add TOML language routing in parse_file
- Update TOML_SPEC comment in languages.py
- Add comprehensive tests for TOML parsing
- Update LANGUAGE_SUPPORT.md documentation