### PR TITLE
fix: avoid duplicate indexing when auto-watch starts

### DIFF
--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -4673,16 +4673,24 @@ async def _auto_watch_if_needed(name: str, arguments: dict, storage_path: Option
     # Opportunistic standby takeover before indexing
     maybe_takeover = getattr(_watcher_manager, "maybe_takeover", None)
     if maybe_takeover is not None:
-        result = await maybe_takeover(folder)
+        if name == "index_folder":
+            result = await maybe_takeover(folder, initial_index=False)
+        else:
+            result = await maybe_takeover(folder)
         if result.get("status") in {"started", "already_watched"}:
-            await _watcher_manager.ensure_indexed(folder)
+            if name != "index_folder":
+                await _watcher_manager.ensure_indexed(folder)
             return
 
     # Race-safe reindex, then start watching
     try:
-        await _watcher_manager.ensure_indexed(folder)
-        await _watcher_manager.add_folder(folder)
-        logger.debug("Auto-watch: indexed and watching %s", folder)
+        if name == "index_folder":
+            await _watcher_manager.add_folder(folder, initial_index=False)
+            logger.debug("Auto-watch: watching %s; index delegated to index_folder", folder)
+        else:
+            await _watcher_manager.ensure_indexed(folder)
+            await _watcher_manager.add_folder(folder)
+            logger.debug("Auto-watch: indexed and watching %s", folder)
     except Exception:
         logger.debug("Auto-watch failed for %s", folder, exc_info=True)
 

--- a/src/jcodemunch_mcp/watcher.py
+++ b/src/jcodemunch_mcp/watcher.py
@@ -244,8 +244,13 @@ async def _watch_single(
     on_reindex: Optional[Callable[[], None]] = None,
     quiet: bool = False,
     log_file_handle: Optional[IO] = None,
+    initial_index: bool = True,
 ) -> None:
-    """Watch a single folder and re-index on changes."""
+    """Watch a single folder and re-index on changes.
+
+    ``initial_index=False`` is for callers that register the watcher immediately
+    before performing the initial index themselves.
+    """
     _watcher_output(f"Watching {folder_path} (debounce={debounce_ms}ms)", quiet=quiet, log_file_handle=log_file_handle)
 
     # Compute repo identifier for memory hash cache and reindex state.
@@ -282,34 +287,35 @@ async def _watch_single(
         if idx and idx.file_hashes:
             _hash_cache.update(idx.file_hashes)
 
-    # Do an initial incremental index to ensure the index is current
-    _watcher_output(f"  Initial index for {folder_path}...", quiet=quiet, log_file_handle=log_file_handle)
-    mark_reindex_start(repo_id)
-    try:
-        result = await asyncio.to_thread(
-            index_folder,
-            path=folder_path,
-            use_ai_summaries=use_ai_summaries,
-            storage_path=storage_path,
-            extra_ignore_patterns=extra_ignore_patterns,
-            follow_symlinks=follow_symlinks,
-            incremental=True,
-        )
-        if result.get("success"):
-            msg = result.get("message", f"{result.get('symbol_count', '?')} symbols")
-            _watcher_output(f"  Indexed {folder_path}: {msg} ({result.get('duration_seconds', '?')}s)", quiet=quiet, log_file_handle=log_file_handle)
-            # Build hash cache from the index we just created/updated
-            _build_hash_cache()
-            mark_reindex_done(repo_id, result)
-            # Count initial index as activity (only if it actually did work)
-            if on_reindex is not None and result.get("message") != "No changes detected":
-                on_reindex()
-        else:
-            _watcher_output(f"  WARNING: initial index failed for {folder_path}: {result.get('error')}", quiet=quiet, log_file_handle=log_file_handle)
-            mark_reindex_failed(repo_id, result.get("error", "unknown error"))
-    except Exception as exc:
-        mark_reindex_failed(repo_id, str(exc))
-        raise
+    if initial_index:
+        # Do an initial incremental index to ensure the index is current
+        _watcher_output(f"  Initial index for {folder_path}...", quiet=quiet, log_file_handle=log_file_handle)
+        mark_reindex_start(repo_id)
+        try:
+            result = await asyncio.to_thread(
+                index_folder,
+                path=folder_path,
+                use_ai_summaries=use_ai_summaries,
+                storage_path=storage_path,
+                extra_ignore_patterns=extra_ignore_patterns,
+                follow_symlinks=follow_symlinks,
+                incremental=True,
+            )
+            if result.get("success"):
+                msg = result.get("message", f"{result.get('symbol_count', '?')} symbols")
+                _watcher_output(f"  Indexed {folder_path}: {msg} ({result.get('duration_seconds', '?')}s)", quiet=quiet, log_file_handle=log_file_handle)
+                # Build hash cache from the index we just created/updated
+                _build_hash_cache()
+                mark_reindex_done(repo_id, result)
+                # Count initial index as activity (only if it actually did work)
+                if on_reindex is not None and result.get("message") != "No changes detected":
+                    on_reindex()
+            else:
+                _watcher_output(f"  WARNING: initial index failed for {folder_path}: {result.get('error')}", quiet=quiet, log_file_handle=log_file_handle)
+                mark_reindex_failed(repo_id, result.get("error", "unknown error"))
+        except Exception as exc:
+            mark_reindex_failed(repo_id, str(exc))
+            raise
 
     try:
         from watchfiles import awatch, Change
@@ -357,6 +363,10 @@ async def _watch_single(
 
         try:
             # Map watchfiles Change enum to WatcherChange objects with old_hash from memory cache
+            # A watcher registered by index_folder starts before that tool finishes,
+            # so hydrate its cache lazily from the completed external index.
+            if not _hash_cache:
+                _build_hash_cache()
             _change_map = {Change.added: "added", Change.modified: "modified", Change.deleted: "deleted"}
             watcher_changes: list[WatcherChange] = []
             for ct, p in relevant:
@@ -555,7 +565,7 @@ class WatcherManager:
         except Exception:
             logger.debug("Failed to record watcher task crash for %s", folder, exc_info=True)
 
-    def _start_watch_task(self, folder: str) -> asyncio.Task:
+    def _start_watch_task(self, folder: str, *, initial_index: bool = True) -> asyncio.Task:
         task = asyncio.create_task(
             _watch_single(
                 folder_path=folder,
@@ -567,6 +577,7 @@ class WatcherManager:
                 on_reindex=self._on_reindex,
                 quiet=self._quiet,
                 log_file_handle=self._log_file_handle,
+                initial_index=initial_index,
             ),
             name=f"watch:{folder}",
         )
@@ -574,7 +585,7 @@ class WatcherManager:
         self._watched.add(folder)
         return task
 
-    async def maybe_takeover(self, folder: str) -> dict:
+    async def maybe_takeover(self, folder: str, *, initial_index: bool = True) -> dict:
         """Try to become the active watcher for a standby folder."""
         folder = str(Path(folder).expanduser().resolve())
         if folder in self._watched:
@@ -593,7 +604,7 @@ class WatcherManager:
         self._locked.add(folder)
         try:
             self._clear_standby(folder)
-            self._start_watch_task(folder)
+            self._start_watch_task(folder, initial_index=initial_index)
             _watcher_output(
                 f"WatcherManager: standby took over {folder}",
                 quiet=self._quiet,
@@ -607,8 +618,11 @@ class WatcherManager:
 
     # ── Folder management ────────────────────────────────────────────────────
 
-    async def add_folder(self, folder: str) -> dict:
+    async def add_folder(self, folder: str, *, initial_index: bool = True) -> dict:
         """Add a folder to watch, acquiring lock and starting watch task.
+
+        Set initial_index=False when the caller will index the folder after
+        registration.
 
         Returns dict with 'status' and optionally 'task' or 'already_watched' key.
         """
@@ -627,7 +641,7 @@ class WatcherManager:
         self._clear_standby(folder)
 
         try:
-            self._start_watch_task(folder)
+            self._start_watch_task(folder, initial_index=initial_index)
             _watcher_output(
                 f"WatcherManager: started watching {folder}",
                 quiet=self._quiet,

--- a/tests/test_watcher_dynamic.py
+++ b/tests/test_watcher_dynamic.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -50,6 +50,59 @@ class TestManagerAddFolder:
 
         # Cleanup
         await mgr.remove_folder(str(folder))
+
+    @pytest.mark.asyncio
+    async def test_add_folder_can_skip_initial_index(self, tmp_path, monkeypatch):
+        """The caller can start watching when it will perform the initial index."""
+        folder = _make_folder(tmp_path)
+        mgr = WatcherManager(storage_path=str(tmp_path / "storage"), quiet=True)
+        started = asyncio.Event()
+        captured = {}
+
+        async def fake_watch_single(**kwargs):
+            captured.update(kwargs)
+            started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(watcher, "_watch_single", fake_watch_single)
+
+        result = await mgr.add_folder(str(folder), initial_index=False)
+        await started.wait()
+
+        assert result["status"] == "started"
+        assert captured["initial_index"] is False
+
+        await mgr.remove_folder(str(folder))
+
+
+class TestWatchSingleInitialIndex:
+    @pytest.mark.asyncio
+    async def test_initial_index_can_be_skipped(self, tmp_path, monkeypatch):
+        """A watcher registered by index_folder must not index the tree itself."""
+        import watchfiles
+
+        folder = _make_folder(tmp_path)
+
+        async def no_changes(*args, **kwargs):
+            if False:
+                yield None
+
+        index_folder_mock = MagicMock()
+        monkeypatch.setattr(watchfiles, "awatch", no_changes)
+        monkeypatch.setattr(watcher, "index_folder", index_folder_mock)
+
+        await watcher._watch_single(
+            folder_path=str(folder),
+            debounce_ms=100,
+            use_ai_summaries=False,
+            storage_path=str(tmp_path / "storage"),
+            extra_ignore_patterns=None,
+            follow_symlinks=False,
+            quiet=True,
+            initial_index=False,
+        )
+
+        index_folder_mock.assert_not_called()
 
 
 class TestManagerAddDuplicate:
@@ -235,8 +288,8 @@ class TestAutoWatchPathFromPathArg:
     """test_auto_watch_path_from_path_arg — Tools with path arg → correct folder."""
 
     @pytest.mark.asyncio
-    async def test_auto_watch_extracts_path_from_path_arg(self, tmp_path, monkeypatch):
-        """Auto-watch should extract folder from 'path' argument."""
+    async def test_index_folder_registers_watch_without_preindex(self, tmp_path, monkeypatch):
+        """index_folder supplies the initial index, so auto-watch only registers."""
         from jcodemunch_mcp import server
 
         folder = _make_folder(tmp_path)
@@ -253,11 +306,10 @@ class TestAutoWatchPathFromPathArg:
 
         await server._auto_watch_if_needed("index_folder", {"path": str(folder)}, str(tmp_path))
 
-        # Should have called ensure_indexed and add_folder with the correct path
-        mock_mgr.ensure_indexed.assert_called_once()
-        mock_mgr.add_folder.assert_called_once()
-        call_args = mock_mgr.add_folder.call_args[0]
-        assert call_args[0] == str(folder)
+        resolved = str(folder.resolve())
+        mock_mgr.maybe_takeover.assert_awaited_once_with(resolved, initial_index=False)
+        mock_mgr.ensure_indexed.assert_not_awaited()
+        mock_mgr.add_folder.assert_awaited_once_with(resolved, initial_index=False)
 
 
 class TestAutoWatchPathFromRepoArg:


### PR DESCRIPTION
Closes #384.

## Summary

- register `index_folder`'s auto-watch task without a second initial index
- preserve the existing index-before-watch behavior for query tools and standby takeover
- hydrate the watcher's hash cache lazily after the delegated index completes

## Testing

- `python -m pytest tests/ -q` — 6164 passed, 10 skipped
- `python -m ruff check src/jcodemunch_mcp/server.py src/jcodemunch_mcp/watcher.py tests/test_watcher_dynamic.py`
