### PR TITLE
fix: honor configured max file size during folder discovery

### DIFF
--- a/src/jcodemunch_mcp/security.py
+++ b/src/jcodemunch_mcp/security.py
@@ -369,7 +369,10 @@ MAX_FOLDER_FILES_ENV_VAR = "JCODEMUNCH_MAX_FOLDER_FILES"
 MAX_FILE_SIZE_ENV_VAR = "JCODEMUNCH_MAX_FILE_SIZE"
 
 
-def get_max_file_size(max_size: Optional[int] = None) -> int:
+def get_max_file_size(
+    max_size: Optional[int] = None,
+    repo: Optional[str] = None,
+) -> int:
     """Resolve the per-file byte cap from arg or config.
 
     Parity with ``get_max_index_files`` / ``get_max_folder_files``, which is the
@@ -378,6 +381,8 @@ def get_max_file_size(max_size: Optional[int] = None) -> int:
 
     Args:
         max_size: Explicit override. Must be a positive integer when provided.
+        repo: Repo identifier (absolute path or display name). When supplied,
+            the merged project config (`.jcodemunch.jsonc`) is consulted.
 
     Returns:
         Positive byte limit. Falls back to the default if config is unset or
@@ -388,7 +393,7 @@ def get_max_file_size(max_size: Optional[int] = None) -> int:
             raise ValueError("max_size must be a positive integer")
         return max_size
 
-    value = _config.get("max_file_size", DEFAULT_MAX_FILE_SIZE)
+    value = _config.get("max_file_size", DEFAULT_MAX_FILE_SIZE, repo=repo)
     if isinstance(value, int) and value > 0:
         return value
     return DEFAULT_MAX_FILE_SIZE

--- a/src/jcodemunch_mcp/tools/index_folder.py
+++ b/src/jcodemunch_mcp/tools/index_folder.py
@@ -1861,14 +1861,14 @@ def index_folder(
                 walk_root,
                 list(paths),
                 max_files=max_files,
-                max_size=get_max_file_size(),
+                max_size=get_max_file_size(repo=str(walk_root)),
                 follow_symlinks=follow_symlinks,
             )
         else:
             source_files, discover_warnings, skip_counts = discover_local_files(
                 walk_root,
                 max_files=max_files,
-                max_size=get_max_file_size(),
+                max_size=get_max_file_size(repo=str(walk_root)),
                 extra_ignore_patterns=_merged_ignore or None,
                 follow_symlinks=follow_symlinks,
             )

--- a/src/jcodemunch_mcp/tools/index_folder.py
+++ b/src/jcodemunch_mcp/tools/index_folder.py
@@ -1861,12 +1861,14 @@ def index_folder(
                 walk_root,
                 list(paths),
                 max_files=max_files,
+                max_size=get_max_file_size(),
                 follow_symlinks=follow_symlinks,
             )
         else:
             source_files, discover_warnings, skip_counts = discover_local_files(
                 walk_root,
                 max_files=max_files,
+                max_size=get_max_file_size(),
                 extra_ignore_patterns=_merged_ignore or None,
                 follow_symlinks=follow_symlinks,
             )

--- a/tests/test_v1_108_193.py
+++ b/tests/test_v1_108_193.py
@@ -95,10 +95,10 @@ class TestMaxFileSizeIsMovable:
             encoding="utf-8",
         )
 
-        original = config_module._GLOBAL_CONFIG.copy()
-        config_module._GLOBAL_CONFIG.clear()
-        config_module._GLOBAL_CONFIG.update(config_module.DEFAULTS)
-        config_module._GLOBAL_CONFIG["max_file_size"] = source.stat().st_size
+        (project / ".jcodemunch.jsonc").write_text(
+            f'{{"max_file_size": {source.stat().st_size}}}',
+            encoding="utf-8",
+        )
 
         try:
             result = index_folder(
@@ -110,8 +110,7 @@ class TestMaxFileSizeIsMovable:
                 paths=paths,
             )
         finally:
-            config_module._GLOBAL_CONFIG.clear()
-            config_module._GLOBAL_CONFIG.update(original)
+            config_module.invalidate_project_config_cache(str(project))
 
         assert result["success"] is True, result
         assert result["file_count"] == 1

--- a/tests/test_v1_108_193.py
+++ b/tests/test_v1_108_193.py
@@ -75,6 +75,47 @@ class TestMaxFileSizeIsMovable:
         assert "max_size=get_max_file_size()" in src
         assert "max_size=DEFAULT_MAX_FILE_SIZE," not in src.split("def _should_index_file")[0]
 
+    @pytest.mark.parametrize(
+        "paths",
+        [None, ["large.py"]],
+        ids=["full-walk", "explicit-path"],
+    )
+    def test_index_folder_applies_configured_size_to_discovery(
+        self, tmp_path, paths
+    ):
+        from jcodemunch_mcp import config as config_module
+        from jcodemunch_mcp.security import DEFAULT_MAX_FILE_SIZE
+        from jcodemunch_mcp.tools.index_folder import index_folder
+
+        project = tmp_path / "project"
+        project.mkdir()
+        source = project / "large.py"
+        source.write_text(
+            "def marker():\n    return 1\n#" + ("x" * (DEFAULT_MAX_FILE_SIZE + 1)),
+            encoding="utf-8",
+        )
+
+        original = config_module._GLOBAL_CONFIG.copy()
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(config_module.DEFAULTS)
+        config_module._GLOBAL_CONFIG["max_file_size"] = source.stat().st_size
+
+        try:
+            result = index_folder(
+                str(project),
+                use_ai_summaries=False,
+                storage_path=str(tmp_path / "store"),
+                incremental=False,
+                context_providers=False,
+                paths=paths,
+            )
+        finally:
+            config_module._GLOBAL_CONFIG.clear()
+            config_module._GLOBAL_CONFIG.update(original)
+
+        assert result["success"] is True, result
+        assert result["file_count"] == 1
+
 
 # ── the finding underneath it ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- resolve the configured `max_file_size` at the `index_folder()` discovery boundary
- pass it to both full-walk and explicit-path discovery
- add regression coverage for a source file above the default 500 KiB cap on both paths

## Root cause

`get_max_file_size()` was added in v1.108.193, and the watcher fast path already used it. The two normal `index_folder()` discovery calls still omitted `max_size`, though, so Python's import-time `DEFAULT_MAX_FILE_SIZE` default was used and the configured value never reached the file filter.

This made a correctly configured large source file look absent to both `jcodemunch-mcp index <folder>` and `index_folder(paths=[...])`.

Fixes #390.

## Validation

- Before the patch, a 513 KiB Python file with a higher configured limit produced `No source files found` on both discovery paths.
- `.venv\Scripts\python.exe -m pytest tests/test_v1_108_193.py tests/test_security.py tests/test_tools.py -q` ? 221 passed, 4 skipped.
- `.venv\Scripts\ruff.exe check src/jcodemunch_mcp/tools/index_folder.py tests/test_v1_108_193.py` ? passed.
- `git diff --check` ? passed.
- The full suite collected 6,143 tests; the native-Windows run exceeded the 10-minute local limit before producing a completed summary, so repository CI remains the full-suite authority.
