### PR TITLE
fix(hooks): deliver agent-facing output on channels that reach the model

### DIFF
--- a/src/jcodemunch_mcp/cli/hooks.py
+++ b/src/jcodemunch_mcp/cli/hooks.py
@@ -8,6 +8,11 @@ PostToolUse — auto-reindex after Edit/Write to keep the index fresh.
 
 Both read JSON from stdin and write JSON to stdout per the Claude Code
 hooks specification.
+
+Output channel discipline: anything meant for the *model* goes out as
+``hookSpecificOutput.additionalContext`` (see ``_emit_additional_context``).
+Neither stderr-on-exit-0 nor top-level ``systemMessage`` reaches the model —
+both surface to the user — so a nudge written to either is silently inert.
 """
 
 import json
@@ -83,8 +88,8 @@ _MIN_SIZE_BYTES = int(os.environ.get("JCODEMUNCH_HOOK_MIN_SIZE", "4096"))
 def _enforce_mode() -> str:
     """jCodemunch enforcement tier for native file tools (``JCODEMUNCH_ENFORCE``).
 
-    * ``"advisory"`` (default): warn on stderr but **allow** — the v1.108.47
-      behavior. A hard deny here would break Read-before-Edit.
+    * ``"advisory"`` (default): nudge via ``additionalContext`` but **allow** —
+      the v1.108.47 behavior. A hard deny here would break Read-before-Edit.
     * ``"strict"``: **deny** a native Read/Grep that an indexed-repo jcm route
       can already serve. Targeted reads (``offset``/``limit``), tiny files, and
       paths outside every indexed repo still pass, so the escape hatch is always
@@ -106,14 +111,43 @@ def _enforce_mode() -> str:
 def _emit_pretooluse_deny(reason: str) -> int:
     """Emit a Claude Code PreToolUse ``deny`` decision (stdout JSON) and exit 0.
 
-    The deny lives in the JSON decision channel; stderr stays free for advisory
-    hints, and exit code stays 0 so the harness reads the decision, not a crash.
+    The deny lives in the JSON decision channel, and exit code stays 0 so the
+    harness reads the decision, not a crash.
     """
     print(json.dumps({
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "permissionDecision": "deny",
             "permissionDecisionReason": reason,
+        }
+    }))
+    return 0
+
+
+def _emit_additional_context(event_name: str, text: str) -> int:
+    """Deliver ``text`` into the *model's* context for ``event_name``, and exit 0.
+
+    ``hookSpecificOutput.additionalContext`` is the only channel that reaches the
+    model from a hook that exits 0. Claude Code wraps the string in a system
+    reminder and inserts it where the hook fired. Two channels that look
+    equivalent are not:
+
+    * **stderr on exit 0** — routed to the transcript/debug log. On most events
+      it is shown to the user, never to the model. Only exit code 2 feeds stderr
+      back to the model, and on PreToolUse that also blocks the call.
+    * **top-level ``systemMessage``** — a warning shown to *the user*, not the
+      model ("unlike on every other event, where you see the systemMessage and
+      Claude doesn't"). Fine for user-facing notices, useless for steering.
+
+    Supported on SessionStart, Setup, SubagentStart, UserPromptSubmit,
+    UserPromptExpansion, PreToolUse, PostToolUse, PostToolUseFailure,
+    PostToolBatch, Stop, and SubagentStop. NOT on PreCompact — see
+    ``run_precompact``. Strings are capped at 10,000 characters by the harness.
+    """
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": event_name,
+            "additionalContext": text,
         }
     }))
     return 0
@@ -130,7 +164,7 @@ def run_pretooluse() -> int:
         + ``get_symbol_source`` instead.
 
     Strength is set by ``_enforce_mode()`` (``JCODEMUNCH_ENFORCE``): the default
-    ``advisory`` tier warns on stderr but allows (so Read-before-Edit and the
+    ``advisory`` tier nudges the model but allows (so Read-before-Edit and the
     Grep fallback keep working); ``strict`` denies the same calls but only when
     an indexed-repo jcm route can serve them — targeted reads (``offset`` /
     ``limit``), tiny files, non-code files, and paths outside every indexed repo
@@ -206,14 +240,12 @@ def run_pretooluse() -> int:
 
     # Advisory: full-file exploratory read on a large code file — warn but allow.
     # Hard deny breaks the Edit workflow (Claude Code requires Read before Edit).
-    # Stderr text is surfaced to the agent as guidance.
-    print(
+    return _emit_additional_context(
+        "PreToolUse",
         f"jCodemunch hint: this is a {size:,}-byte code file. "
         "Prefer get_file_outline + get_symbol_source for exploration. "
         "Use Read only when you need exact line numbers for Edit.",
-        file=sys.stderr,
     )
-    return 0
 
 
 # ---------------------------------------------------------------------------
@@ -275,7 +307,10 @@ def _path_overlaps(root: str, source_roots: list[str]) -> bool:
 def _nudge_grep(tool_input: dict, cwd: str) -> int:
     """Grep PreToolUse branch: when the search targets an indexed repo, steer
     the agent to the credited jcm retrieval routes first. Allows the Grep
-    regardless (exit 0) — this is a nudge, not a block."""
+    regardless (exit 0, no permissionDecision) — this is a nudge, not a block.
+
+    The nudge rides ``additionalContext`` because that is the only channel a
+    hook exiting 0 has to the model; see ``_emit_additional_context``."""
     if not _grep_nudge_enabled():
         return 0
     roots = _indexed_source_roots()
@@ -286,16 +321,15 @@ def _nudge_grep(tool_input: dict, cwd: str) -> int:
 
     pattern = (tool_input.get("pattern") or "").strip()
     for_pat = f" for `{pattern}`" if pattern else ""
-    print(
+    return _emit_additional_context(
+        "PreToolUse",
         f"jCodemunch: this Grep{for_pat} targets an indexed repo. Exhaust the jcm "
         "routes first, since they're tighter and credited (raw Grep is neither):\n"
         "  - search_text     : same regex/substring scan, ranked + winnowed\n"
         "  - search_symbols  : when hunting a definition (function/class/const/type)\n"
         "  - find_references / find_importers : 'where is X used / who imports this'\n"
         "Fall back to Grep only once those come up empty.",
-        file=sys.stderr,
     )
-    return 0
 
 
 def _strict_grep(tool_input: dict, cwd: str) -> int:
@@ -489,9 +523,18 @@ def run_precompact() -> int:
         except Exception:
             pass  # Landmark enrichment must not block compaction
 
-    # Return snapshot as hook output for context injection.
-    # PreCompact has no hookSpecificOutput variant in Claude Code's schema,
-    # so we use the top-level systemMessage field instead.
+    # PreCompact genuinely has no additionalContext channel — its only JSON
+    # control is the top-level decision/block pair, so systemMessage is the sole
+    # non-blocking output. Note what that means: this snapshot reaches the *user*,
+    # not the post-compaction model, so it does not survive compaction as context
+    # the way the docstring's "context injection" implies.
+    #
+    # The event that CAN inject post-compaction context is SessionStart with
+    # matcher "compact", which fires after compaction completes and does support
+    # hookSpecificOutput.additionalContext. Routing the snapshot there is the real
+    # fix for context survival, but it is a behavioral change (a new hook
+    # registration in `init`) rather than a channel correction, so it stays out of
+    # this bug-fix pass. Tracked separately.
     result = {
         "systemMessage": snapshot_text,
     }
@@ -793,6 +836,14 @@ def run_taskcomplete() -> int:
         if "unreferenced_symbols" in diag:
             parts.append(f"**Unreferenced:** {', '.join(f'`{s}`' for s in diag['unreferenced_symbols'][:5])}")
 
+    # TaskCompleted is the one diagnostic event with no additionalContext channel:
+    # per the hooks reference its only model-facing route is exit code 2, which
+    # feeds stderr back as feedback *and* refuses to mark the task complete.
+    # These findings are advisory (a "possibly orphaned" symbol is often a fresh
+    # helper with its caller still unwritten), so blocking completion on them
+    # would be wrong. Keep systemMessage — a user-facing report is the honest
+    # ceiling here, and the user can act on it — rather than pretend the model
+    # will read it. See _emit_additional_context for the channel matrix.
     result = {"systemMessage": "\n".join(parts)}
     json.dump(result, sys.stdout)
     return 0
@@ -899,6 +950,8 @@ def run_subagentstart() -> int:
     )
     parts.append("\nUse `plan_turn` to get recommended approach for your task.")
 
-    result = {"systemMessage": "\n".join(parts)}
-    json.dump(result, sys.stdout)
-    return 0
+    # additionalContext, not systemMessage: this briefing exists to orient the
+    # subagent, and systemMessage is shown to the user instead of the model.
+    # On SubagentStart the text lands at the start of the subagent's own
+    # conversation, before its first prompt.
+    return _emit_additional_context("SubagentStart", "\n".join(parts))

--- a/src/jcodemunch_mcp/cli/hooks.py
+++ b/src/jcodemunch_mcp/cli/hooks.py
@@ -9,10 +9,11 @@ PostToolUse — auto-reindex after Edit/Write to keep the index fresh.
 Both read JSON from stdin and write JSON to stdout per the Claude Code
 hooks specification.
 
-Output channel discipline: anything meant for the *model* goes out as
-``hookSpecificOutput.additionalContext`` (see ``_emit_additional_context``).
-Neither stderr-on-exit-0 nor top-level ``systemMessage`` reaches the model —
-both surface to the user — so a nudge written to either is silently inert.
+Output channels — the one rule this module turns on: a hook that exits 0 reaches
+the model ONLY via ``hookSpecificOutput.additionalContext``. Both stderr and
+top-level ``systemMessage`` surface to the user instead, so steering text written
+to either is silently inert. Exit 2 does feed stderr to the model, but it also
+blocks the call, which is not what an advisory nudge wants.
 """
 
 import json
@@ -125,24 +126,16 @@ def _emit_pretooluse_deny(reason: str) -> int:
 
 
 def _emit_additional_context(event_name: str, text: str) -> int:
-    """Deliver ``text`` into the *model's* context for ``event_name``, and exit 0.
+    """Emit model-facing additionalContext for an exit-0 hook.
 
-    ``hookSpecificOutput.additionalContext`` is the only channel that reaches the
-    model from a hook that exits 0. Claude Code wraps the string in a system
-    reminder and inserts it where the hook fired. Two channels that look
-    equivalent are not:
+    Not available on every event — PreCompact and TaskCompleted have no such
+    channel.
 
-    * **stderr on exit 0** — routed to the transcript/debug log. On most events
-      it is shown to the user, never to the model. Only exit code 2 feeds stderr
-      back to the model, and on PreToolUse that also blocks the call.
-    * **top-level ``systemMessage``** — a warning shown to *the user*, not the
-      model ("unlike on every other event, where you see the systemMessage and
-      Claude doesn't"). Fine for user-facing notices, useless for steering.
-
-    Supported on SessionStart, Setup, SubagentStart, UserPromptSubmit,
-    UserPromptExpansion, PreToolUse, PostToolUse, PostToolUseFailure,
-    PostToolBatch, Stop, and SubagentStop. NOT on PreCompact — see
-    ``run_precompact``. Strings are capped at 10,000 characters by the harness.
+    Past 10,000 characters the text is NOT truncated: Claude Code writes it to a
+    file and hands the model a path plus a short preview. Nothing is lost, but the
+    model pays a re-read to see it, so keep emissions well under that. Measured on
+    this repo's index: the SubagentStart briefing is ~866 characters, and snapshot
+    plus landmarks ~91.
     """
     print(json.dumps({
         "hookSpecificOutput": {
@@ -307,10 +300,7 @@ def _path_overlaps(root: str, source_roots: list[str]) -> bool:
 def _nudge_grep(tool_input: dict, cwd: str) -> int:
     """Grep PreToolUse branch: when the search targets an indexed repo, steer
     the agent to the credited jcm retrieval routes first. Allows the Grep
-    regardless (exit 0, no permissionDecision) — this is a nudge, not a block.
-
-    The nudge rides ``additionalContext`` because that is the only channel a
-    hook exiting 0 has to the model; see ``_emit_additional_context``."""
+    regardless (exit 0, no permissionDecision) — this is a nudge, not a block."""
     if not _grep_nudge_enabled():
         return 0
     roots = _indexed_source_roots()
@@ -467,24 +457,19 @@ def run_copilot_posttooluse() -> int:
     return 0
 
 
-def run_precompact() -> int:
-    """PreCompact hook: generate session snapshot before context compaction.
+def _build_session_snapshot() -> "tuple[str, bool]":
+    """Render the session snapshot, returning ``(text, used_fallback)``.
 
-    Reads hook JSON from stdin. Builds a compact snapshot of the current
-    session state and returns it as a message for context injection.
+    Shared by ``run_precompact`` (which reports it to the user before compaction)
+    and ``run_sessionstart`` (which injects it into the model afterwards), so the
+    two can never drift into describing the same session differently.
 
-    Returns exit code (always 0 — errors are swallowed to avoid blocking).
+    The hook runs as a SEPARATE process from the MCP server, so the in-process
+    SessionJournal is empty (#334). Read the live journal the server persists
+    incrementally first; fall back to the in-process journal (covers embedded
+    invocations); finally emit an explicit "no live session" message rather than
+    a misleading zero-state snapshot.
     """
-    try:
-        _note_transcript_root(json.load(sys.stdin))  # Also validates stdin
-    except (json.JSONDecodeError, ValueError):
-        return 0
-
-    # The hook runs as a SEPARATE process from the MCP server, so the in-process
-    # SessionJournal is empty (#334). Read the live journal the server persists
-    # incrementally first; fall back to the in-process journal (covers embedded
-    # invocations); finally emit an explicit "no live session" message rather
-    # than a misleading zero-state snapshot.
     snapshot_text = ""
     live_context = None
     try:
@@ -506,40 +491,85 @@ def run_precompact() -> int:
         except Exception:
             snapshot_text = ""
 
-    used_fallback = False
     if not snapshot_text:
         # Honest fallback — never emit a healthy-looking zero-state snapshot.
-        snapshot_text = _precompact_no_journal_message()
-        used_fallback = True
+        return _precompact_no_journal_message(), True
 
     # Enrich with structural landmarks (PageRank top-N) and recently-changed
     # symbols. Seed from the live journal context when we have one so landmarks
     # work out-of-process too; skip entirely on the no-journal fallback.
-    if not used_fallback:
-        try:
-            landmarks = _build_landmark_section(context=live_context)
-            if landmarks:
-                snapshot_text += landmarks
-        except Exception:
-            pass  # Landmark enrichment must not block compaction
+    try:
+        landmarks = _build_landmark_section(context=live_context)
+        if landmarks:
+            snapshot_text += landmarks
+    except Exception:
+        pass  # Landmark enrichment must not block compaction
 
-    # PreCompact genuinely has no additionalContext channel — its only JSON
-    # control is the top-level decision/block pair, so systemMessage is the sole
-    # non-blocking output. Note what that means: this snapshot reaches the *user*,
-    # not the post-compaction model, so it does not survive compaction as context
-    # the way the docstring's "context injection" implies.
-    #
-    # The event that CAN inject post-compaction context is SessionStart with
-    # matcher "compact", which fires after compaction completes and does support
-    # hookSpecificOutput.additionalContext. Routing the snapshot there is the real
-    # fix for context survival, but it is a behavioral change (a new hook
-    # registration in `init`) rather than a channel correction, so it stays out of
-    # this bug-fix pass. Tracked separately.
+    return snapshot_text, False
+
+
+def run_precompact() -> int:
+    """PreCompact hook: report the snapshot to the user before compaction.
+
+    PreCompact has no additionalContext channel, so this cannot reach the model;
+    ``run_sessionstart`` restores it there afterwards.
+
+    Returns exit code (always 0 — errors are swallowed to avoid blocking).
+    """
+    try:
+        _note_transcript_root(json.load(sys.stdin))  # Also validates stdin
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    snapshot_text, _ = _build_session_snapshot()
     result = {
         "systemMessage": snapshot_text,
     }
     json.dump(result, sys.stdout)
     return 0
+
+
+def run_sessionstart() -> int:
+    """SessionStart hook: restore the session snapshot to the model.
+
+    Injects on compact/resume/fork, where the persisted journal still describes
+    this session. Stays silent on startup/clear — an unrelated session's journal
+    would present stale files as current focus.
+
+    Returns exit code (always 0 — errors are swallowed to avoid blocking).
+    """
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    # Earliest hook to fire on a resumed session, so this is the earliest point
+    # a custom-profile transcript root can be learned (#421) — every other hook
+    # waits for a first Read or Edit. Registered BEFORE the source gate, because
+    # the root is a property of the session, not of whether we inject anything.
+    _note_transcript_root(data)
+
+    source = (data.get("source") or "").strip().lower()
+    if source not in {"compact", "resume", "fork"}:
+        return 0  # Fresh session — no prior state worth restoring.
+
+    try:
+        snapshot_text, used_fallback = _build_session_snapshot()
+    except Exception:
+        return 0  # Never block session startup.
+
+    if used_fallback or not snapshot_text.strip():
+        return 0  # Do not inject the user-facing no-journal fallback.
+
+    label = {
+        "compact": "restored after compaction",
+        "resume": "restored on resume",
+        "fork": "carried into this fork",
+    }[source]
+    return _emit_additional_context(
+        "SessionStart",
+        f"## jCodemunch session state ({label})\n\n{snapshot_text}",
+    )
 
 
 def _precompact_no_journal_message() -> str:
@@ -836,14 +866,9 @@ def run_taskcomplete() -> int:
         if "unreferenced_symbols" in diag:
             parts.append(f"**Unreferenced:** {', '.join(f'`{s}`' for s in diag['unreferenced_symbols'][:5])}")
 
-    # TaskCompleted is the one diagnostic event with no additionalContext channel:
-    # per the hooks reference its only model-facing route is exit code 2, which
-    # feeds stderr back as feedback *and* refuses to mark the task complete.
-    # These findings are advisory (a "possibly orphaned" symbol is often a fresh
-    # helper with its caller still unwritten), so blocking completion on them
-    # would be wrong. Keep systemMessage — a user-facing report is the honest
-    # ceiling here, and the user can act on it — rather than pretend the model
-    # will read it. See _emit_additional_context for the channel matrix.
+    # TaskCompleted lacks additionalContext; its only model-facing route is exit 2,
+    # which also refuses task completion. These findings are advisory, so keep them
+    # user-facing rather than blocking on them.
     result = {"systemMessage": "\n".join(parts)}
     json.dump(result, sys.stdout)
     return 0
@@ -950,8 +975,4 @@ def run_subagentstart() -> int:
     )
     parts.append("\nUse `plan_turn` to get recommended approach for your task.")
 
-    # additionalContext, not systemMessage: this briefing exists to orient the
-    # subagent, and systemMessage is shown to the user instead of the model.
-    # On SubagentStart the text lands at the start of the subagent's own
-    # conversation, before its first prompt.
     return _emit_additional_context("SubagentStart", "\n".join(parts))

--- a/src/jcodemunch_mcp/cli/init.py
+++ b/src/jcodemunch_mcp/cli/init.py
@@ -201,6 +201,11 @@ def _enforcement_hooks() -> dict[str, Any]:
             "matcher": "",
             "hooks": [{"type": "command", "command": f"{exe} hook-precompact"}],
         }],
+        # Restore only sources whose persisted journal still describes this session.
+        "SessionStart": [{
+            "matcher": "compact|resume|fork",
+            "hooks": [{"type": "command", "command": f"{exe} hook-sessionstart"}],
+        }],
         "TaskCompleted": [{
             "matcher": "",
             "hooks": [{"type": "command", "command": f"{exe} hook-taskcomplete"}],
@@ -968,6 +973,10 @@ def install_enforcement_hooks(
     """
     path = _settings_json_path()
     data = _read_json(path)
+    # Marker is only the legacy substring fallback; primary duplicate detection is
+    # per-subcommand via _extract_jcm_subcommand, so hooks outside the "hook-p"
+    # prefix (hook-sessionstart, hook-taskcomplete, hook-subagent-start) merge
+    # correctly and are added to an existing install on re-run.
     added = _merge_hooks(data, _enforcement_hooks(), "jcodemunch-mcp hook-p")  # matches hook-pretooluse & hook-posttooluse & hook-precompact
 
     # Persist (or revert) the strict-enforce env flag the hook reads at runtime.

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -9125,6 +9125,12 @@ def main(argv: Optional[list[str]] = None):
         help="SubagentStart hook: inject condensed repo orientation for spawned agents (reads stdin)",
     )
 
+    # --- hook-sessionstart ---
+    subparsers.add_parser(
+        "hook-sessionstart",
+        help="SessionStart hook: re-inject the session snapshot after compaction/resume (reads stdin)",
+    )
+
     # --- watch-claude ---
     wc_parser = subparsers.add_parser(
         "watch-claude",
@@ -9266,7 +9272,7 @@ def main(argv: Optional[list[str]] = None):
     if any(arg in top_level_flags for arg in raw_argv):
         args = parser.parse_args(raw_argv)
     else:
-        known_commands = {"serve", "watch", "hook-event", "hook-pretooluse", "hook-posttooluse", "hook-copilot-posttooluse", "hook-precompact", "hook-taskcomplete", "hook-subagent-start", "watch-claude", "watch-all", "watch-install", "watch-uninstall", "watch-status", "config", "list-repos", "delete-index", "org-report", "org-rollup", "license", "index", "index-file", "import-trace", "import-scip", "claude-md", "init", "install", "install-status", "uninstall", "install-pack", "download-model", "upgrade", "whatsnew", "receipt", "digest", "reflect", "delivery", "parity", "health", "file-risk", "observatory", "keyring", "surface"}
+        known_commands = {"serve", "watch", "hook-event", "hook-pretooluse", "hook-posttooluse", "hook-copilot-posttooluse", "hook-precompact", "hook-taskcomplete", "hook-subagent-start", "hook-sessionstart", "watch-claude", "watch-all", "watch-install", "watch-uninstall", "watch-status", "config", "list-repos", "delete-index", "org-report", "org-rollup", "license", "index", "index-file", "import-trace", "import-scip", "claude-md", "init", "install", "install-status", "uninstall", "install-pack", "download-model", "upgrade", "whatsnew", "receipt", "digest", "reflect", "delivery", "parity", "health", "file-risk", "observatory", "keyring", "surface"}
         # MCP-tool-name typos: route to the right CLI verb with a friendly hint.
         # `index_repo` and `index_folder` are MCP tools, not CLI subcommands.
         _CLI_ALIASES = {
@@ -9810,6 +9816,10 @@ def main(argv: Optional[list[str]] = None):
     if args.command == "hook-subagent-start":
         from .cli.hooks import run_subagentstart
         sys.exit(run_subagentstart())
+
+    if args.command == "hook-sessionstart":
+        from .cli.hooks import run_sessionstart
+        sys.exit(run_sessionstart())
 
     # Apply config defaults for watcher keys: CLI args > config > env vars.
     # config.load_config() is called inside each subcommand handler, but we need

--- a/tests/test_hook_output_channels.py
+++ b/tests/test_hook_output_channels.py
@@ -1,0 +1,186 @@
+"""Regression tests for hook output *channels* (not content).
+
+A hook can compute a perfect nudge and still be inert: on a hook that exits 0,
+only ``hookSpecificOutput.additionalContext`` reaches the model. Both other
+plausible-looking channels surface to the user instead —
+
+* stderr on exit 0 → transcript / debug log
+* top-level ``systemMessage`` → "unlike on every other event, where you see the
+  systemMessage and Claude doesn't"
+
+— so a steering message on either is silently discarded. That is exactly what
+shipped in v1.22.5 (the fix for #241, which correctly stopped hard-blocking Read
+but moved the nudge onto stderr) and stayed broken through v1.108.x: the hook
+fired, computed the right text, and the model never saw a word of it.
+
+The pre-existing tests asserted `"search_text" in err`, which *encoded* the
+defect — they passed precisely because the message went nowhere useful. These
+tests assert the delivery channel directly so a future refactor cannot silently
+re-mute the hooks.
+"""
+
+import io
+import json
+import os
+import sys
+from unittest import mock
+
+import pytest
+
+from jcodemunch_mcp.cli.hooks import (
+    _emit_additional_context,
+    run_pretooluse,
+    run_subagentstart,
+)
+
+
+def _run(func, stdin_text: str) -> tuple[int, str, str]:
+    fake_in, fake_out, fake_err = (
+        io.StringIO(stdin_text), io.StringIO(), io.StringIO(),
+    )
+    with mock.patch.object(sys, "stdin", fake_in), \
+         mock.patch.object(sys, "stdout", fake_out), \
+         mock.patch.object(sys, "stderr", fake_err):
+        rc = func()
+    return rc, fake_out.getvalue(), fake_err.getvalue()
+
+
+def _read_input(path: str) -> str:
+    return json.dumps({
+        "session_id": "s", "hook_event_name": "PreToolUse",
+        "tool_name": "Read", "tool_input": {"file_path": path},
+    })
+
+
+def _grep_input(pattern: str, cwd: str) -> str:
+    return json.dumps({
+        "session_id": "s", "hook_event_name": "PreToolUse",
+        "tool_name": "Grep", "tool_input": {"pattern": pattern}, "cwd": cwd,
+    })
+
+
+@pytest.fixture
+def big_py(tmp_path):
+    f = tmp_path / "big.py"
+    f.write_text("x = 1\n" * 2000)  # comfortably over the 4KB threshold
+    return f
+
+
+class TestEmitAdditionalContext:
+    """The shared helper's wire format."""
+
+    def test_emits_additional_context_on_stdout(self):
+        rc, out, err = _run(
+            lambda: _emit_additional_context("PreToolUse", "hello model"), ""
+        )
+        assert rc == 0
+        assert err == ""
+        assert json.loads(out) == {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": "hello model",
+            }
+        }
+
+    def test_carries_no_permission_decision(self):
+        """Advisory context must not double as a deny — the call still proceeds."""
+        _, out, _ = _run(lambda: _emit_additional_context("PreToolUse", "x"), "")
+        assert "permissionDecision" not in json.loads(out)["hookSpecificOutput"]
+
+    def test_stdout_is_pure_json(self):
+        """Claude Code parses stdout as a single JSON object; stray text breaks it."""
+        _, out, _ = _run(lambda: _emit_additional_context("PreToolUse", "x"), "")
+        json.loads(out)  # would raise on leading/trailing noise
+
+
+class TestReadNudgeReachesModel:
+    def test_read_nudge_uses_additional_context(self, big_py):
+        rc, out, err = _run(run_pretooluse, _read_input(str(big_py)))
+        assert rc == 0
+        hso = json.loads(out)["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert "get_file_outline" in hso["additionalContext"]
+
+    def test_read_nudge_leaves_stderr_empty(self, big_py):
+        """The regression itself: a nudge on stderr is invisible to the model."""
+        _, _, err = _run(run_pretooluse, _read_input(str(big_py)))
+        assert err == ""
+
+    def test_read_nudge_does_not_block(self, big_py):
+        """Advisory must stay advisory — Read-before-Edit depends on it (#241)."""
+        rc, out, _ = _run(run_pretooluse, _read_input(str(big_py)))
+        assert rc == 0  # exit 2 would block AND is the only stderr route to model
+        assert "permissionDecision" not in json.loads(out)["hookSpecificOutput"]
+
+
+class TestGrepNudgeReachesModel:
+    @pytest.fixture(autouse=True)
+    def _indexed(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "jcodemunch_mcp.cli.hooks._indexed_source_roots",
+            lambda: [os.path.normcase(os.path.abspath(str(tmp_path)))],
+        )
+
+    def test_grep_nudge_uses_additional_context(self, tmp_path):
+        rc, out, err = _run(run_pretooluse, _grep_input("foo", str(tmp_path)))
+        assert rc == 0
+        assert err == ""
+        hso = json.loads(out)["hookSpecificOutput"]
+        assert "search_text" in hso["additionalContext"]
+        assert "permissionDecision" not in hso
+
+    def test_silent_paths_stay_fully_silent(self, tmp_path, monkeypatch):
+        """Gating is unchanged: outside an indexed repo, no channel is used."""
+        monkeypatch.setattr(
+            "jcodemunch_mcp.cli.hooks._indexed_source_roots", lambda: []
+        )
+        rc, out, err = _run(run_pretooluse, _grep_input("foo", str(tmp_path)))
+        assert (rc, out, err) == (0, "", "")
+
+
+class TestStrictModeUnaffected:
+    """Strict mode already used a model-facing channel; it must keep working."""
+
+    def test_strict_read_still_denies(self, big_py, monkeypatch, tmp_path):
+        monkeypatch.setenv("JCODEMUNCH_ENFORCE", "strict")
+        monkeypatch.setattr(
+            "jcodemunch_mcp.cli.hooks._indexed_source_roots",
+            lambda: [os.path.normcase(os.path.abspath(str(tmp_path)))],
+        )
+        rc, out, _ = _run(run_pretooluse, _read_input(str(big_py)))
+        assert rc == 0
+        hso = json.loads(out)["hookSpecificOutput"]
+        assert hso["permissionDecision"] == "deny"
+        assert "additionalContext" not in hso  # deny carries its own reason
+
+
+class TestSubagentBriefingReachesSubagent:
+    def test_briefing_uses_additional_context(self, monkeypatch):
+        from jcodemunch_mcp.storage import CodeIndex
+
+        idx = mock.MagicMock(spec=CodeIndex)
+        idx.symbols = [{
+            "id": "a", "name": "main", "kind": "function",
+            "file": "main.py", "line": 1, "language": "python",
+        }]
+        idx.source_files = ["main.py"]
+        idx.imports = {}
+        idx.alias_map = None
+        monkeypatch.setattr("jcodemunch_mcp.storage.IndexStore", type(
+            "MockStore", (), {
+                "__init__": lambda self, **kw: None,
+                "list_repos": lambda self: [{"owner": "test", "name": "repo"}],
+                "load_index": lambda self, o, n: idx,
+            },
+        ))
+
+        rc, out, _ = _run(run_subagentstart, '{"hook_event_name": "SubagentStart"}')
+        assert rc == 0
+        if out:  # no-op when nothing is indexed in the ambient environment
+            payload = json.loads(out)
+            assert "systemMessage" not in payload, (
+                "a briefing the subagent cannot read is pointless"
+            )
+            hso = payload["hookSpecificOutput"]
+            assert hso["hookEventName"] == "SubagentStart"
+            assert "search_symbols" in hso["additionalContext"]

--- a/tests/test_hook_output_channels.py
+++ b/tests/test_hook_output_channels.py
@@ -1,22 +1,7 @@
-"""Regression tests for hook output *channels* (not content).
+"""Regression tests ensuring model-facing hook output uses additionalContext.
 
-A hook can compute a perfect nudge and still be inert: on a hook that exits 0,
-only ``hookSpecificOutput.additionalContext`` reaches the model. Both other
-plausible-looking channels surface to the user instead —
-
-* stderr on exit 0 → transcript / debug log
-* top-level ``systemMessage`` → "unlike on every other event, where you see the
-  systemMessage and Claude doesn't"
-
-— so a steering message on either is silently discarded. That is exactly what
-shipped in v1.22.5 (the fix for #241, which correctly stopped hard-blocking Read
-but moved the nudge onto stderr) and stayed broken through v1.108.x: the hook
-fired, computed the right text, and the model never saw a word of it.
-
-The pre-existing tests asserted `"search_text" in err`, which *encoded* the
-defect — they passed precisely because the message went nowhere useful. These
-tests assert the delivery channel directly so a future refactor cannot silently
-re-mute the hooks.
+These assert the delivery channel, not message content: a hook can compute a
+perfect nudge and still be inert if it writes to stderr or systemMessage.
 """
 
 import io
@@ -30,6 +15,7 @@ import pytest
 from jcodemunch_mcp.cli.hooks import (
     _emit_additional_context,
     run_pretooluse,
+    run_sessionstart,
     run_subagentstart,
 )
 
@@ -176,11 +162,205 @@ class TestSubagentBriefingReachesSubagent:
 
         rc, out, _ = _run(run_subagentstart, '{"hook_event_name": "SubagentStart"}')
         assert rc == 0
-        if out:  # no-op when nothing is indexed in the ambient environment
-            payload = json.loads(out)
-            assert "systemMessage" not in payload, (
-                "a briefing the subagent cannot read is pointless"
-            )
-            hso = payload["hookSpecificOutput"]
-            assert hso["hookEventName"] == "SubagentStart"
-            assert "search_symbols" in hso["additionalContext"]
+        # Unconditional: the mock store guarantees a repo, so silence here means
+        # the patch stopped taking effect, not an unindexed environment. This also
+        # pins the coupling — run_subagentstart does `from ..storage import
+        # IndexStore` at call time, so patching the module attribute is what
+        # works; rebinding it to a from-import at module scope would break this.
+        assert out, "mocked store should have produced a briefing"
+        payload = json.loads(out)
+        assert "systemMessage" not in payload, (
+            "a briefing the subagent cannot read is pointless"
+        )
+        hso = payload["hookSpecificOutput"]
+        assert hso["hookEventName"] == "SubagentStart"
+        assert "search_symbols" in hso["additionalContext"]
+
+
+class TestSessionStartRestoresSnapshot:
+    """SessionStart restores snapshots for continuing sessions."""
+
+    @pytest.fixture
+    def _snapshot(self, monkeypatch):
+        monkeypatch.setattr(
+            "jcodemunch_mcp.cli.hooks._build_session_snapshot",
+            lambda: ("## Session Snapshot (jCodemunch)\n- src/auth.py (9 reads)", False),
+        )
+
+    def _start(self, source: str) -> tuple[int, str, str]:
+        return _run(run_sessionstart, json.dumps({
+            "hook_event_name": "SessionStart", "source": source,
+        }))
+
+    @pytest.mark.parametrize("source,label", [
+        ("compact", "restored after compaction"),
+        ("resume", "restored on resume"),
+        ("fork", "carried into this fork"),
+    ])
+    def test_injects_on_continuing_sources(self, source, label, _snapshot):
+        """A journal from a continuing session still describes this session."""
+        rc, out, err = self._start(source)
+        assert rc == 0
+        assert err == ""
+        hso = json.loads(out)["hookSpecificOutput"]
+        assert hso["hookEventName"] == "SessionStart"
+        assert label in hso["additionalContext"]
+        assert "src/auth.py" in hso["additionalContext"]
+
+    @pytest.mark.parametrize("source", ["startup", "clear", "", "unknown"])
+    def test_silent_on_fresh_sessions(self, source, _snapshot):
+        """Restoring an unrelated session's state would misdirect the model."""
+        assert self._start(source) == (0, "", "")
+
+    def test_silent_when_no_journal(self, monkeypatch):
+        """The no-journal fallback is user-facing text; the model gains nothing
+        from being told no session data was found."""
+        monkeypatch.setattr(
+            "jcodemunch_mcp.cli.hooks._build_session_snapshot",
+            lambda: ("No live session journal was found.", True),
+        )
+        assert self._start("compact") == (0, "", "")
+
+    def test_silent_on_blank_snapshot(self, monkeypatch):
+        monkeypatch.setattr(
+            "jcodemunch_mcp.cli.hooks._build_session_snapshot",
+            lambda: ("   \n  ", False),
+        )
+        assert self._start("compact") == (0, "", "")
+
+    def test_never_blocks_startup_on_error(self, monkeypatch):
+        """A snapshot failure must not take the session down with it."""
+        def boom():
+            raise RuntimeError("journal unreadable")
+        monkeypatch.setattr(
+            "jcodemunch_mcp.cli.hooks._build_session_snapshot", boom
+        )
+        assert self._start("compact") == (0, "", "")
+
+    def test_invalid_json_is_tolerated(self):
+        assert _run(run_sessionstart, "not json") == (0, "", "")
+
+    def test_shares_snapshot_builder_with_precompact(self, monkeypatch):
+        """Both hooks must describe the same session identically — one builder."""
+        from jcodemunch_mcp.cli.hooks import run_precompact
+
+        calls = []
+
+        def fake():
+            calls.append(1)
+            return ("## Session Snapshot (jCodemunch)\n- a.py", False)
+
+        monkeypatch.setattr(
+            "jcodemunch_mcp.cli.hooks._build_session_snapshot", fake
+        )
+        _, pre_out, _ = _run(run_precompact, '{"hook_event_name": "PreCompact"}')
+        _, ss_out, _ = _run(run_sessionstart, json.dumps(
+            {"hook_event_name": "SessionStart", "source": "compact"}
+        ))
+
+        assert len(calls) == 2
+        # PreCompact reports to the user; SessionStart steers the model. Same body.
+        body = "## Session Snapshot (jCodemunch)\n- a.py"
+        assert body in json.loads(pre_out)["systemMessage"]
+        assert body in json.loads(ss_out)["hookSpecificOutput"]["additionalContext"]
+
+
+class TestSessionStartRegistersTranscriptRoot:
+    """SessionStart is the earliest hook on a resumed session, so it is the
+    earliest point a custom-profile transcript root can be learned (#421)."""
+
+    @pytest.fixture
+    def _seen(self, monkeypatch):
+        seen: list = []
+        monkeypatch.setattr(
+            "jcodemunch_mcp.cli.hooks._note_transcript_root", seen.append
+        )
+        return seen
+
+    def _start(self, source: str) -> None:
+        _run(run_sessionstart, json.dumps({
+            "hook_event_name": "SessionStart",
+            "source": source,
+            "transcript_path": "/tmp/p/projects/repo/abc.jsonl",
+        }))
+
+    @pytest.mark.parametrize("source", ["compact", "resume", "fork"])
+    def test_registers_on_continuing_sources(self, source, _seen):
+        self._start(source)
+        assert [d["transcript_path"] for d in _seen] == [
+            "/tmp/p/projects/repo/abc.jsonl"
+        ]
+
+    @pytest.mark.parametrize("source", ["startup", "clear"])
+    def test_registers_even_when_no_snapshot_is_injected(self, source, _seen):
+        """The root is a property of the session, not of whether we inject.
+
+        A fresh session must stay silent on every output channel, but its
+        transcripts still belong to a profile `receipt` needs to know about —
+        so registration happens BEFORE the source gate.
+        """
+        self._start(source)
+        assert len(_seen) == 1
+
+    def test_invalid_json_registers_nothing(self, _seen):
+        _run(run_sessionstart, "not json")
+        assert _seen == []
+
+
+class TestSessionStartIsRegistered:
+    """A correct handler nobody invokes is still a no-op — assert `init` wires it."""
+
+    def _install(self, tmp_path, initial="{}"):
+        from jcodemunch_mcp.cli.init import install_enforcement_hooks
+
+        settings = tmp_path / "settings.json"
+        settings.write_text(initial, encoding="utf-8")
+        with mock.patch(
+            "jcodemunch_mcp.cli.init._settings_json_path", return_value=settings
+        ):
+            install_enforcement_hooks(dry_run=False, backup=False)
+        return json.loads(settings.read_text(encoding="utf-8"))["hooks"]
+
+    def test_sessionstart_hook_installed(self, tmp_path):
+        hooks = self._install(tmp_path)
+        assert "SessionStart" in hooks
+        cmd = hooks["SessionStart"][0]["hooks"][0]["command"]
+        assert cmd.endswith("hook-sessionstart")
+
+    def test_matcher_excludes_fresh_sessions(self, tmp_path):
+        """startup/clear must not match — restoring unrelated state misleads."""
+        hooks = self._install(tmp_path)
+        matcher = hooks["SessionStart"][0]["matcher"]
+        assert matcher == "compact|resume|fork"
+        assert "startup" not in matcher
+        assert "clear" not in matcher
+
+    def test_added_to_existing_install_on_rerun(self, tmp_path):
+        """Upgraders already have the other hooks; SessionStart must still land.
+
+        Duplicate detection is per-subcommand, so an existing PreToolUse entry
+        must not cause the whole merge to skip the new event.
+        """
+        existing = json.dumps({"hooks": {
+            "PreToolUse": [{
+                "matcher": "Read|Grep",
+                "hooks": [{"type": "command",
+                           "command": "jcodemunch-mcp hook-pretooluse"}],
+            }],
+        }})
+        hooks = self._install(tmp_path, existing)
+        assert "SessionStart" in hooks
+        assert len(hooks["PreToolUse"]) == 1  # not duplicated
+
+    def test_idempotent(self, tmp_path):
+        from jcodemunch_mcp.cli.init import install_enforcement_hooks
+
+        settings = tmp_path / "settings.json"
+        settings.write_text("{}", encoding="utf-8")
+        with mock.patch(
+            "jcodemunch_mcp.cli.init._settings_json_path", return_value=settings
+        ):
+            install_enforcement_hooks(dry_run=False, backup=False)
+            install_enforcement_hooks(dry_run=False, backup=False)
+        hooks = json.loads(settings.read_text(encoding="utf-8"))["hooks"]
+        assert len(hooks["SessionStart"]) == 1

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -60,6 +60,24 @@ def _run_with_stdin(func, stdin_text: str) -> tuple[int, str, str]:
     return rc, fake_out.getvalue(), fake_err.getvalue()
 
 
+def _additional_context(stdout: str, event: str = "PreToolUse") -> str:
+    """Extract the model-facing additionalContext from hook stdout.
+
+    Asserts the nudge went out on the ONE channel a hook exiting 0 can use to
+    reach the model. stderr-on-exit-0 and top-level systemMessage both surface to
+    the user instead, so a nudge on either is inert — that was the bug these
+    tests previously locked in.
+    """
+    assert stdout, "hook produced no stdout — nudge cannot reach the model"
+    payload = json.loads(stdout)
+    hso = payload.get("hookSpecificOutput", {})
+    assert hso.get("hookEventName") == event, f"wrong hookEventName: {hso!r}"
+    assert "permissionDecision" not in hso, "advisory nudge must not carry a decision"
+    ctx = hso.get("additionalContext", "")
+    assert ctx, f"no additionalContext in {payload!r}"
+    return ctx
+
+
 # ---------------------------------------------------------------------------
 # PreToolUse tests
 # ---------------------------------------------------------------------------
@@ -86,14 +104,15 @@ class TestPreToolUse:
         assert err == ""
 
     def test_warns_large_code_file(self, tmp_path):
-        """Large code files are allowed but produce a stderr warning."""
+        """Large code files are allowed, with the nudge delivered to the model."""
         f = tmp_path / "big.py"
         f.write_text("x = 1\n" * 2000)  # well above 4KB
         rc, out, err = _run_with_stdin(run_pretooluse, _make_hook_input("Read", str(f)))
         assert rc == 0
-        assert out == ""  # No deny JSON on stdout
-        assert "get_file_outline" in err
-        assert "get_symbol_source" in err
+        ctx = _additional_context(out)
+        assert "get_file_outline" in ctx
+        assert "get_symbol_source" in ctx
+        assert err == ""  # stderr would never reach the model — must stay unused
 
     def test_allows_large_code_file_with_offset(self, tmp_path):
         """Targeted reads (offset set) are allowed silently — likely pre-edit."""
@@ -157,13 +176,12 @@ class TestPreToolUse:
             assert out == ""
             assert err == ""
 
-        # With a low threshold, it should warn on stderr
+        # With a low threshold, it should nudge the model
         with mock.patch("jcodemunch_mcp.cli.hooks._MIN_SIZE_BYTES", 100):
             rc, out, err = _run_with_stdin(
                 run_pretooluse, _make_hook_input("Read", str(f))
             )
-            assert out == ""  # No deny
-            assert "jCodemunch hint" in err
+            assert "jCodemunch hint" in _additional_context(out)
 
     @pytest.mark.parametrize("ext", [".py", ".ts", ".go", ".rs", ".java", ".cpp", ".rb"])
     def test_code_extensions_covered(self, ext, tmp_path):
@@ -171,13 +189,13 @@ class TestPreToolUse:
         assert ext in _CODE_EXTENSIONS
 
     def test_warning_includes_file_size(self, tmp_path):
-        """The stderr warning includes the file size for context."""
+        """The nudge includes the file size for context."""
         f = tmp_path / "large.go"
         content = "package main\n" * 1000
         f.write_text(content)
         size = f.stat().st_size
         rc, out, err = _run_with_stdin(run_pretooluse, _make_hook_input("Read", str(f)))
-        assert f"{size:,}" in err
+        assert f"{size:,}" in _additional_context(out)
 
 
 # ---------------------------------------------------------------------------
@@ -212,11 +230,12 @@ class TestGrepNudge:
             run_pretooluse, _make_grep_input("ViewBag.Username", cwd=str(tmp_path))
         )
         assert rc == 0
-        assert out == ""  # never blocks
-        assert "search_text" in err
-        assert "search_symbols" in err
-        assert "find_references" in err
-        assert "ViewBag.Username" in err  # echoes the pattern
+        ctx = _additional_context(out)  # never blocks; reaches the model
+        assert "search_text" in ctx
+        assert "search_symbols" in ctx
+        assert "find_references" in ctx
+        assert "ViewBag.Username" in ctx  # echoes the pattern
+        assert err == ""  # stderr would never reach the model
 
     def test_nudges_grep_with_subpath_inside_repo(self, tmp_path, monkeypatch):
         """A relative `path` resolved under the indexed cwd still nudges."""
@@ -228,7 +247,7 @@ class TestGrepNudge:
             run_pretooluse, _make_grep_input("foo", path="src", cwd=str(tmp_path))
         )
         assert rc == 0
-        assert "search_text" in err
+        assert "search_text" in _additional_context(out)
 
     def test_silent_outside_indexed_repo(self, tmp_path, monkeypatch):
         """A Grep outside every indexed repo is allowed silently."""
@@ -275,7 +294,7 @@ class TestGrepNudge:
         assert rc == 0  # never crashes the agent's Grep
 
     def test_grep_never_blocks(self, tmp_path, monkeypatch):
-        """The nudge must never emit a deny/stdout payload."""
+        """The nudge informs without denying: context, but no permissionDecision."""
         monkeypatch.setattr(
             "jcodemunch_mcp.cli.hooks._indexed_source_roots",
             lambda: [os.path.normcase(os.path.abspath(str(tmp_path)))],
@@ -284,7 +303,9 @@ class TestGrepNudge:
             run_pretooluse, _make_grep_input("foo", cwd=str(tmp_path))
         )
         assert rc == 0
-        assert out == ""
+        # _additional_context asserts no permissionDecision is present, which is
+        # what "never blocks" means now that the nudge does use stdout.
+        assert _additional_context(out)
 
 
 # ---------------------------------------------------------------------------
@@ -393,8 +414,7 @@ class TestStrictEnforce:
             run_pretooluse, _make_grep_input("foo", cwd=str(tmp_path))
         )
         assert rc == 0
-        assert out == ""  # advisory never denies
-        assert "search_text" in err
+        assert "search_text" in _additional_context(out)  # advisory never denies
 
     def test_unknown_value_falls_back_to_advisory(self, tmp_path, monkeypatch):
         """A typo'd mode must never hard-block — it degrades to advisory."""
@@ -404,8 +424,7 @@ class TestStrictEnforce:
             run_pretooluse, _make_grep_input("foo", cwd=str(tmp_path))
         )
         assert rc == 0
-        assert out == ""  # not a deny
-        assert "search_text" in err
+        assert "search_text" in _additional_context(out)  # not a deny
 
 
 # ---------------------------------------------------------------------------
@@ -763,9 +782,9 @@ class TestSubagentStart:
         rc, out, _ = _run_with_stdin(run_subagentstart, '{"hook_event_name": "SubagentStart"}')
         assert rc == 0
         if out:
-            result = json.loads(out)
-            assert "systemMessage" in result
-            msg = result["systemMessage"]
+            # The briefing must reach the subagent, so it rides additionalContext
+            # rather than systemMessage (which only the user would see).
+            msg = _additional_context(out, event="SubagentStart")
             assert "test/repo" in msg
             assert "search_symbols" in msg  # Tool catalog
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -61,13 +61,7 @@ def _run_with_stdin(func, stdin_text: str) -> tuple[int, str, str]:
 
 
 def _additional_context(stdout: str, event: str = "PreToolUse") -> str:
-    """Extract the model-facing additionalContext from hook stdout.
-
-    Asserts the nudge went out on the ONE channel a hook exiting 0 can use to
-    reach the model. stderr-on-exit-0 and top-level systemMessage both surface to
-    the user instead, so a nudge on either is inert — that was the bug these
-    tests previously locked in.
-    """
+    """Extract and validate model-facing additionalContext from hook stdout."""
     assert stdout, "hook produced no stdout — nudge cannot reach the model"
     payload = json.loads(stdout)
     hso = payload.get("hookSpecificOutput", {})
@@ -303,8 +297,6 @@ class TestGrepNudge:
             run_pretooluse, _make_grep_input("foo", cwd=str(tmp_path))
         )
         assert rc == 0
-        # _additional_context asserts no permissionDecision is present, which is
-        # what "never blocks" means now that the nudge does use stdout.
         assert _additional_context(out)
 
 
@@ -782,8 +774,6 @@ class TestSubagentStart:
         rc, out, _ = _run_with_stdin(run_subagentstart, '{"hook_event_name": "SubagentStart"}')
         assert rc == 0
         if out:
-            # The briefing must reach the subagent, so it rides additionalContext
-            # rather than systemMessage (which only the user would see).
             msg = _additional_context(out, event="SubagentStart")
             assert "test/repo" in msg
             assert "search_symbols" in msg  # Tool catalog


### PR DESCRIPTION
## Summary

Several hook messages meant to steer the model were emitted on channels only the user can see. For a non-blocking hook that exits 0:

| Output | Recipient |
|---|---|
| stderr | transcript / debug log — not model context |
| top-level `systemMessage` | user |
| `hookSpecificOutput.additionalContext` | model |

(Exit 2 does feed stderr to the model, but it also blocks the call — not what an advisory nudge wants. `permissionDecisionReason` likewise reaches the model, which is why strict mode was never affected. See the [hooks reference](https://code.claude.com/docs/en/hooks).)

So the advisory Read/Grep nudges and the SubagentStart briefing were inert: the hooks fired, gated correctly, computed the right text, and none of it landed. The Read nudge has been in this state since v1.22.5 (4516640), which correctly replaced a hard `Read` deny with an exit-0 stderr warning to unbreak Read-before-Edit (#241) — and in moving off the deny channel, moved off the only channel that reached the model. The comment there read:

```python
# Stderr text is surfaced to the agent as guidance.
```

## Changes

- Route the advisory Read and Grep nudges through `additionalContext`.
- Route the SubagentStart repo briefing through `additionalContext` — it exists to orient the subagent, so the user-facing channel defeated its purpose.
- Keep TaskCompleted diagnostics on `systemMessage`: that event has no non-blocking model channel, and its only alternative — exit 2 — would refuse task completion over advisory findings.
- Add a SessionStart hook for `compact|resume|fork`. PreCompact can report its snapshot to the user but cannot inject it into model context, so the snapshot was computed at the moment state was about to be lost and then discarded. SessionStart restores it afterwards; both hooks share snapshot construction.
- Stay silent on `startup|clear`, empty snapshots, and missing journals — an unrelated session's journal would present stale files as current focus.
- Register SessionStart idempotently, including on existing installs. Duplicate detection is per-subcommand, so the legacy `"hook-p"` marker does not block the new event.

## Behavior preserved

Advisory output carries no `permissionDecision`, so calls proceed and Read-before-Edit keeps working; a regression test asserts this. Unchanged: the 4KB threshold, extension allowlist, indexed-repo checks, the `offset`/`limit` escape hatch, `JCODEMUNCH_HOOK_MIN_SIZE`, `JCODEMUNCH_HOOK_GREP_NUDGE`, `JCODEMUNCH_ENFORCE`, and the strict-mode deny.

## Tests

New `tests/test_hook_output_channels.py` pins delivery channels rather than message content, covering Read, Grep, SubagentStart, and SessionStart: silent paths silent on every channel, source scoping, error containment, shared snapshot construction, and install idempotency. Nine tests in `test_hooks.py` asserted `"search_text" in err` — they passed *because* the message went nowhere — and now assert the model-facing channel.

Full suite: 7,023 passed. Eight failures in `test_count_cap_end_to_end.py`, `test_install_pack.py`, `test_suggest_corrections.py`, and `test_v1_108_163.py` reproduce identically on unmodified `main` (network/env-dependent).

Manually verified in a live Claude Code session: the Read nudge now arrives as a system reminder, targeted reads stay silent, and `hook-sessionstart` injects only for continuing-session sources.
