### PR TITLE
fix(nextjs): detect src/app App Router layouts, not just root app/

### DIFF
--- a/src/jcodemunch_mcp/parser/context/framework_profiles.py
+++ b/src/jcodemunch_mcp/parser/context/framework_profiles.py
@@ -119,7 +119,9 @@ _NEXT = FrameworkProfile(
         Layer("lib",        ["lib/", "src/lib/"]),
         Layer("api",        ["app/api/", "src/app/api/"]),
     ],
-    high_value_paths=["app/", "src/app/", "lib/", "components/"],
+    high_value_paths=[
+        "app/", "src/app/", "lib/", "src/lib/", "components/", "src/components/",
+    ],
 )
 
 _VUE_SPA = FrameworkProfile(

--- a/src/jcodemunch_mcp/parser/context/framework_profiles.py
+++ b/src/jcodemunch_mcp/parser/context/framework_profiles.py
@@ -107,15 +107,19 @@ _NEXT = FrameworkProfile(
         "app/**/page.tsx",
         "app/**/route.ts",
         "app/layout.tsx",
+        "src/app/**/page.tsx",
+        "src/app/**/route.ts",
+        "src/app/layout.tsx",
         "middleware.ts",
+        "src/middleware.ts",
     ],
     layer_definitions=[
-        Layer("pages",      ["app/"]),
-        Layer("components", ["components/"]),
-        Layer("lib",        ["lib/"]),
-        Layer("api",        ["app/api/"]),
+        Layer("pages",      ["app/", "src/app/"]),
+        Layer("components", ["components/", "src/components/"]),
+        Layer("lib",        ["lib/", "src/lib/"]),
+        Layer("api",        ["app/api/", "src/app/api/"]),
     ],
-    high_value_paths=["app/", "lib/", "components/"],
+    high_value_paths=["app/", "src/app/", "lib/", "components/"],
 )
 
 _VUE_SPA = FrameworkProfile(

--- a/src/jcodemunch_mcp/parser/context/nextjs.py
+++ b/src/jcodemunch_mcp/parser/context/nextjs.py
@@ -1,9 +1,10 @@
 """Next.js context provider — detects Next.js projects and enriches symbols with framework metadata.
 
 When a Next.js project is detected (via next.config.js/ts/mjs), this provider:
-1. Parses app/ for App Router file-based routing → enriches components with route metadata
-2. Parses app/api/ for API route handlers → enriches with endpoint metadata
-3. Detects middleware.ts at project root
+1. Parses the App Router directory (app/ or src/app/) for file-based routing
+   → enriches components with route metadata
+2. Parses <app dir>/api/ for API route handlers → enriches with endpoint metadata
+3. Detects middleware.ts at the project root (or src/ for src-layout projects)
 4. Exposes route metadata via get_metadata()
 """
 
@@ -75,10 +76,11 @@ def _next_api_methods_from_content(content: str) -> list[str]:
 class NextjsContextProvider(ContextProvider):
     """Context provider for Next.js projects (App Router).
 
-    Detects next.config.js/ts/mjs, then parses:
-    - app/**/page.tsx    → page routes with route metadata
-    - app/**/layout.tsx  → layout nesting
-    - app/api/**/route.ts → API handlers with HTTP methods
+    Detects next.config.js/ts/mjs, then parses (app/ or src/app/ — both
+    official layouts; root app/ wins when both exist, matching Next.js):
+    - <app>/**/page.tsx    → page routes with route metadata
+    - <app>/**/layout.tsx  → layout nesting
+    - <app>/api/**/route.ts → API handlers with HTTP methods
     """
 
     def __init__(self) -> None:
@@ -106,9 +108,15 @@ class NextjsContextProvider(ContextProvider):
         self._parse_middleware(folder_path)
 
     def _parse_app_router(self, folder_path: Path) -> None:
-        """Parse app/ directory for pages, layouts, and API routes."""
-        app_dir = folder_path / "app"
-        if not app_dir.is_dir():
+        """Parse the App Router directory (app/ or src/app/)."""
+        # Next.js supports both the root app/ layout and the src/ directory
+        # layout (create-next-app --src-dir). When both exist, Next.js itself
+        # uses root app/ and ignores src/app — probe in the same order.
+        for app_prefix in ("app", "src/app"):
+            app_dir = folder_path / app_prefix
+            if app_dir.is_dir():
+                break
+        else:
             return
 
         for src_file in sorted(app_dir.rglob("*")):
@@ -119,7 +127,7 @@ class NextjsContextProvider(ContextProvider):
                 continue
 
             rel_path = str(src_file.relative_to(folder_path)).replace("\\", "/")
-            route = _next_route_from_path(rel_path)
+            route = _next_route_from_path(rel_path, app_prefix)
 
             if stem == "route":
                 # API route handler
@@ -169,8 +177,8 @@ class NextjsContextProvider(ContextProvider):
         )
 
     def _parse_middleware(self, folder_path: Path) -> None:
-        """Detect middleware.ts at project root."""
-        for name in ("middleware.ts", "middleware.js"):
+        """Detect middleware.ts at the project root or under src/."""
+        for name in ("middleware.ts", "middleware.js", "src/middleware.ts", "src/middleware.js"):
             mw_path = folder_path / name
             if mw_path.exists():
                 try:

--- a/src/jcodemunch_mcp/parser/context/nextjs.py
+++ b/src/jcodemunch_mcp/parser/context/nextjs.py
@@ -77,7 +77,8 @@ class NextjsContextProvider(ContextProvider):
     """Context provider for Next.js projects (App Router).
 
     Detects next.config.js/ts/mjs, then parses (app/ or src/app/ — both
-    official layouts; root app/ wins when both exist, matching Next.js):
+    official layouts; a root app/ or pages/ directory makes Next.js ignore
+    src/ entirely, and parsing matches):
     - <app>/**/page.tsx    → page routes with route metadata
     - <app>/**/layout.tsx  → layout nesting
     - <app>/api/**/route.ts → API handlers with HTTP methods
@@ -110,14 +111,18 @@ class NextjsContextProvider(ContextProvider):
     def _parse_app_router(self, folder_path: Path) -> None:
         """Parse the App Router directory (app/ or src/app/)."""
         # Next.js supports both the root app/ layout and the src/ directory
-        # layout (create-next-app --src-dir). When both exist, Next.js itself
-        # uses root app/ and ignores src/app — probe in the same order.
-        for app_prefix in ("app", "src/app"):
-            app_dir = folder_path / app_prefix
-            if app_dir.is_dir():
-                break
-        else:
-            return
+        # layout (create-next-app --src-dir). Root directories win: if app/
+        # or pages/ exists at the root, Next.js ignores src/ entirely
+        # (https://nextjs.org/docs/app/api-reference/file-conventions/src-folder),
+        # so an ignored src/app tree must not be published as live routes.
+        app_prefix = "app"
+        if not (folder_path / app_prefix).is_dir():
+            if (folder_path / "pages").is_dir():
+                return
+            app_prefix = "src/app"
+            if not (folder_path / app_prefix).is_dir():
+                return
+        app_dir = folder_path / app_prefix
 
         for src_file in sorted(app_dir.rglob("*")):
             if src_file.suffix not in (".tsx", ".ts", ".jsx", ".js"):

--- a/src/jcodemunch_mcp/parser/context/nextjs.py
+++ b/src/jcodemunch_mcp/parser/context/nextjs.py
@@ -105,19 +105,25 @@ class NextjsContextProvider(ContextProvider):
         if self._folder is None:
             self._folder = folder_path
 
-        self._parse_app_router(folder_path)
-        self._parse_middleware(folder_path)
+        # Root directories win: when app/ or pages/ exists at the project
+        # root, Next.js ignores src/ entirely
+        # (https://nextjs.org/docs/app/api-reference/file-conventions/src-folder).
+        # Resolved once, here, so the router and middleware parsers share one
+        # precedence rule and cannot drift apart.
+        src_ignored = (folder_path / "app").is_dir() or (folder_path / "pages").is_dir()
 
-    def _parse_app_router(self, folder_path: Path) -> None:
+        self._parse_app_router(folder_path, src_ignored)
+        self._parse_middleware(folder_path, src_ignored)
+
+    def _parse_app_router(self, folder_path: Path, src_ignored: bool) -> None:
         """Parse the App Router directory (app/ or src/app/)."""
-        # Next.js supports both the root app/ layout and the src/ directory
-        # layout (create-next-app --src-dir). Root directories win: if app/
-        # or pages/ exists at the root, Next.js ignores src/ entirely
-        # (https://nextjs.org/docs/app/api-reference/file-conventions/src-folder),
-        # so an ignored src/app tree must not be published as live routes.
+        # Root app/ wins over src/app. A root pages/ directory (src_ignored
+        # without a root app/) means any src/app tree is dead — publishing
+        # it would invent routes, and inventing routes is a worse failure
+        # than missing them.
         app_prefix = "app"
         if not (folder_path / app_prefix).is_dir():
-            if (folder_path / "pages").is_dir():
+            if src_ignored:
                 return
             app_prefix = "src/app"
             if not (folder_path / app_prefix).is_dir():
@@ -181,9 +187,12 @@ class NextjsContextProvider(ContextProvider):
             len(self._route_metadata), len(self._api_metadata),
         )
 
-    def _parse_middleware(self, folder_path: Path) -> None:
-        """Detect middleware.ts at the project root or under src/."""
-        for name in ("middleware.ts", "middleware.js", "src/middleware.ts", "src/middleware.js"):
+    def _parse_middleware(self, folder_path: Path, src_ignored: bool) -> None:
+        """Detect middleware.ts at the project root (or src/, when src/ is live)."""
+        names = ("middleware.ts", "middleware.js")
+        if not src_ignored:
+            names += ("src/middleware.ts", "src/middleware.js")
+        for name in names:
             mw_path = folder_path / name
             if mw_path.exists():
                 try:

--- a/tests/test_nextjs_provider.py
+++ b/tests/test_nextjs_provider.py
@@ -288,6 +288,29 @@ export async function POST(request: Request) { return Response.json({}); }
         assert provider.get_file_context("src/app/other/page.tsx") is None
         assert provider.stats()["page_routes"] == 1
 
+    def test_root_pages_blocks_src_app(self, tmp_path):
+        """A root pages/ directory makes Next.js ignore src/ entirely.
+
+        "src/app or src/pages will be ignored if app or pages are present in
+        the root directory" — so a half-finished App Router migration (root
+        pages/ still live, src/app staged) must publish NO src/app routes.
+        Inventing routes is a worse failure than missing them.
+        """
+        _make_next_project(tmp_path)
+        _write(tmp_path / "pages" / "index.tsx", "export default () => <div/>;")
+        _write(tmp_path / "src" / "app" / "page.tsx", "export default () => <div/>;")
+        _write(tmp_path / "src" / "app" / "api" / "users" / "route.ts",
+               "export function GET() { return Response.json([]); }")
+
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        assert provider.get_file_context("src/app/page.tsx") is None
+        assert provider.get_file_context("src/app/api/users/route.ts") is None
+        assert provider.stats() == {"page_routes": 0, "api_routes": 0}
+        assert provider.get_metadata() == {}
+
     def test_src_middleware_detected(self, tmp_path):
         _make_next_project(tmp_path)
         _write(tmp_path / "src" / "middleware.ts", """
@@ -317,3 +340,13 @@ export const config = { matcher: ['/dashboard/:path*'] };
         meta = provider.get_metadata()
         assert "/" in meta["nextjs_routes"]
         assert any("/api/health" in key for key in meta["nextjs_api"])
+
+    def test_high_value_paths_cover_both_layouts(self):
+        """#433 review: layer_definitions listed the src/ twins but
+        high_value_paths only picked up src/app/, so --src-dir projects had
+        src/lib and src/components deprioritized by profile consumers."""
+        from jcodemunch_mcp.parser.context.framework_profiles import _NEXT
+        hv = set(_NEXT.high_value_paths)
+        for root in ("app/", "lib/", "components/"):
+            assert root in hv, root
+            assert f"src/{root}" in hv, f"src/{root}"

--- a/tests/test_nextjs_provider.py
+++ b/tests/test_nextjs_provider.py
@@ -327,6 +327,41 @@ export const config = { matcher: ['/dashboard/:path*'] };
         assert "nextjs-middleware" in ctx.tags
         assert "/dashboard/:path*" in ctx.properties.get("matcher", "")
 
+    def test_root_app_blocks_src_middleware(self, tmp_path):
+        """A root app/ directory makes Next.js ignore src/ entirely —
+        middleware included. A stale src/middleware.ts must not be published
+        as a live handler while a root layout is what actually serves.
+        """
+        _make_next_project(tmp_path)
+        _write(tmp_path / "app" / "page.tsx", "export default () => <div/>;")
+        _write(tmp_path / "src" / "middleware.ts", """
+export function middleware(request) { return NextResponse.next(); }
+export const config = { matcher: ['/dashboard/:path*'] };
+""")
+
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        assert provider.get_file_context("src/middleware.ts") is None
+        # Only the dead middleware is suppressed — the live root app/ tree
+        # still publishes.
+        assert provider.stats() == {"page_routes": 1, "api_routes": 0}
+
+    def test_root_pages_blocks_src_middleware(self, tmp_path):
+        """Same precedence, pages/ shape: root pages/ live, src/ staged."""
+        _make_next_project(tmp_path)
+        _write(tmp_path / "pages" / "index.tsx", "export default () => <div/>;")
+        _write(tmp_path / "src" / "middleware.ts", """
+export function middleware(request) { return NextResponse.next(); }
+""")
+
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        assert provider.get_file_context("src/middleware.ts") is None
+
     def test_src_app_metadata_and_no_dir_safety(self, tmp_path):
         _make_next_project(tmp_path)
         _write(tmp_path / "src" / "app" / "page.tsx", "export default () => <div/>;")

--- a/tests/test_nextjs_provider.py
+++ b/tests/test_nextjs_provider.py
@@ -49,6 +49,11 @@ class TestNextRouteFromPath:
     def test_nested(self):
         assert _next_route_from_path("app/dashboard/settings/page.tsx") == "/dashboard/settings"
 
+    def test_src_app_prefix(self):
+        """src/ directory layout: strip the src/app prefix when supplied."""
+        assert _next_route_from_path("src/app/page.tsx", "src/app") == "/"
+        assert _next_route_from_path("src/app/users/[id]/page.tsx", "src/app") == "/users/:id"
+
 
 class TestNextApiMethods:
     def test_get_and_post(self):
@@ -221,3 +226,94 @@ export const config = { matcher: ['/dashboard/:path*', '/api/:path*'] };
         ctx = provider.get_file_context("app/(marketing)/about/page.tsx")
         assert ctx is not None
         assert ctx.properties["route"] == "/about"
+
+
+# ---------------------------------------------------------------------------
+# src/ directory layout (create-next-app --src-dir) — issue #432
+# ---------------------------------------------------------------------------
+
+class TestNextjsSrcAppLayout:
+    def test_src_app_page_routing(self, tmp_path):
+        _make_next_project(tmp_path)
+        _write(tmp_path / "src" / "app" / "page.tsx",
+               "export default function Home() { return <div/>; }")
+        _write(tmp_path / "src" / "app" / "users" / "[id]" / "page.tsx",
+               "export default function UserPage() { return <div/>; }")
+
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        ctx = provider.get_file_context("src/app/page.tsx")
+        assert ctx is not None
+        assert "nextjs-page" in ctx.tags
+        assert ctx.properties["route"] == "/"
+
+        ctx2 = provider.get_file_context("src/app/users/[id]/page.tsx")
+        assert ctx2 is not None
+        assert ctx2.properties["route"] == "/users/:id"
+
+        stats = provider.stats()
+        assert stats["page_routes"] == 2
+
+    def test_src_app_api_route_handler(self, tmp_path):
+        _make_next_project(tmp_path)
+        _write(tmp_path / "src" / "app" / "api" / "users" / "route.ts", """
+export async function GET(request: Request) { return Response.json([]); }
+export async function POST(request: Request) { return Response.json({}); }
+""")
+
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        ctx = provider.get_file_context("src/app/api/users/route.ts")
+        assert ctx is not None
+        assert "nextjs-api" in ctx.tags
+        assert ctx.properties["endpoint"] == "/api/users"
+        assert "GET" in ctx.properties["methods"]
+        assert provider.stats()["api_routes"] == 1
+
+    def test_root_app_wins_over_src_app(self, tmp_path):
+        """When both layouts exist, Next.js uses root app/ and ignores src/app."""
+        _make_next_project(tmp_path)
+        _write(tmp_path / "app" / "page.tsx", "export default () => <div/>;")
+        _write(tmp_path / "src" / "app" / "other" / "page.tsx", "export default () => <div/>;")
+
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        assert provider.get_file_context("app/page.tsx") is not None
+        assert provider.get_file_context("src/app/other/page.tsx") is None
+        assert provider.stats()["page_routes"] == 1
+
+    def test_src_middleware_detected(self, tmp_path):
+        _make_next_project(tmp_path)
+        _write(tmp_path / "src" / "middleware.ts", """
+export function middleware(request) { return NextResponse.next(); }
+export const config = { matcher: ['/dashboard/:path*'] };
+""")
+
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        ctx = provider.get_file_context("src/middleware.ts")
+        assert ctx is not None
+        assert "nextjs-middleware" in ctx.tags
+        assert "/dashboard/:path*" in ctx.properties.get("matcher", "")
+
+    def test_src_app_metadata_and_no_dir_safety(self, tmp_path):
+        _make_next_project(tmp_path)
+        _write(tmp_path / "src" / "app" / "page.tsx", "export default () => <div/>;")
+        _write(tmp_path / "src" / "app" / "api" / "health" / "route.ts",
+               "export function GET() { return Response.json({ok: true}); }")
+
+        provider = NextjsContextProvider()
+        assert provider.detect(tmp_path)
+        provider.load(tmp_path)
+
+        meta = provider.get_metadata()
+        assert "/" in meta["nextjs_routes"]
+        assert any("/api/health" in key for key in meta["nextjs_api"])


### PR DESCRIPTION
Fixes #432.

## Problem

`NextjsContextProvider.detect()` passes on any root `next.config.{js,ts,mjs}`, but `_parse_app_router` only probed `<root>/app` and silently returned when absent. Projects using the official [`src/` directory layout](https://nextjs.org/docs/app/building-your-application/configuring/src-directory) (`create-next-app --src-dir`) therefore indexed with **zero** page/API routes while still reporting the framework as detected. Real-world hit that motivated #432: a Next.js repo with 6 `page.tsx` + 171 `route.ts` under `src/app/` and `page_routes: 0, api_routes: 0` after indexing.

## Change

- `_parse_app_router` probes `app/` then `src/app/` and threads the matched prefix into `_next_route_from_path`, so route strings stay identical between layouts. Root `app/` wins when both exist — the same precedence Next.js itself applies.
- `_parse_middleware` additionally probes `src/middleware.{ts,js}` (where the `src/` layout places middleware).
- The `next` framework profile mirrors `src/app/**` entry-point patterns and `src/`-prefixed layer / high-value paths.
- Docstrings updated to describe both layouts.

## Tests

6 new tests (`pytest tests/test_nextjs_provider.py tests/test_context_providers.py` → 51 passed):

- `TestNextRouteFromPath.test_src_app_prefix` — prefix stripping with `src/app`.
- `TestNextjsSrcAppLayout` — src-layout page routing (routes + stats), API handler (endpoint `/api/users` + methods + stats), **root-app-wins precedence when both layouts exist**, `src/middleware.ts` detection with matcher extraction, and metadata (`nextjs_routes` / `nextjs_api`) for the src layout.

All pre-existing root-`app/` tests pass unchanged — behavior for the root layout is byte-identical (`_next_route_from_path`'s default parameter is untouched).
