### PR TITLE
fix: allow shallow Windows Git roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@ The Windows regression coverage keeps the positive repository case beside both
 negative cases and mocks the filesystem probes, so the runner's drive layout
 cannot decide the result.
 
+⚠⚠ **Review note, recorded because the wrong version of this nearly shipped on
+maintainer advice.** The first review asked for the UNC scope predicate to be
+dropped as redundant with the shared depth helper. It is not, and the two are
+not the same kind of rule: `_path_safety_part_count` measures DEPTH, while
+`not drive.startswith("\\")` bounds SCOPE. A UNC share root has one real part
+and the depth helper adds one for the `\\server\share` anchor, so it computes to
+**exactly two -- the same depth as `C:\repo`**. With the predicate gone, a share
+root holding a `.git` would have been admitted, handing a whole file server to
+the indexer through the guard that exists to prevent it (#321/#322).
+
+⚠ **The regression test for it was ALSO wrong on its first run, in a way that
+passed.** It patched `os.path.exists` to a blanket `True`, which answers
+`_is_container()`'s `/.dockerenv` probe as well -- that drops `_MIN_PATH_PARTS`
+from three to two, so `2 < 2` skips the guard and the assertion never reaches
+the code under test. The probe is narrowed to the `.git` path and the reason is
+recorded at the patch site. **A mock broad enough to satisfy the assertion can
+be broad enough to bypass what the assertion is about.**
+
 ## [1.108.275] - 2026-08-12 - A pattern that matches nothing now says so
 
 ### `entry_point_patterns` failed silently ([#446](https://github.com/jgravelle/jcodemunch-mcp/issues/446))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased] - A Windows drive-root child can prove it is a repository
+
+### Exact Git working trees no longer trip the broad-root guard ([#438](https://github.com/jgravelle/jcodemunch-mcp/issues/438))
+
+On Windows, an explicit repository at `X:\repo` has only two logical path
+components, so `index_folder` rejected it alongside genuinely broad paths. The
+guard now accepts that narrow case only when `.git` exists at the selected root.
+Drive roots, shallow non-Git directories, POSIX paths, and UNC depth handling are
+unchanged.
+
+The Windows regression coverage keeps the positive repository case beside both
+negative cases and mocks the filesystem probes, so the runner's drive layout
+cannot decide the result.
+
 ## [1.108.275] - 2026-08-12 - A pattern that matches nothing now says so
 
 ### `entry_point_patterns` failed silently ([#446](https://github.com/jgravelle/jcodemunch-mcp/issues/446))
@@ -136,7 +150,6 @@ Item 1 of the QA pass — the `install-pack` archive guard missing drive-absolut
 member names — is [#447](https://github.com/jgravelle/jcodemunch-mcp/issues/447),
 with @elfrost's [PR #443](https://github.com/jgravelle/jcodemunch-mcp/pull/443)
 open against it.
-
 ## [1.108.273] - 2026-08-12 - A pattern that names two extensions and matches neither
 
 ### v1.108.271's #435 fix matched nothing ([#445](https://github.com/jgravelle/jcodemunch-mcp/issues/445))

--- a/src/jcodemunch_mcp/tools/index_folder.py
+++ b/src/jcodemunch_mcp/tools/index_folder.py
@@ -329,12 +329,21 @@ def _is_shallow_windows_git_root(path: Path) -> bool:
     selected a working-tree root rather than the drive itself or a broad parent.
     The corresponding POSIX case was considered and intentionally left unchanged
     so this exception remains scoped to the reported Windows drive-root behavior.
+
+    ⚠ The depth check and the UNC check answer different questions and neither
+    is redundant with the other. ``_path_safety_part_count`` is a DEPTH rule;
+    ``not drive.startswith("\\\\")`` is a SCOPE rule. A UNC share root has one
+    real part and the depth helper adds one for the ``\\server\share`` anchor,
+    so it computes to exactly two -- the same value as ``C:\repo``. Dropping the
+    UNC test would therefore admit ``\\server\share`` itself, which #321/#322
+    classify as too broad whatever it happens to contain.
     """
     drive = str(path.drive)
     return (
         os.name == "nt"
         and _path_safety_part_count(path) == 2
         and bool(drive)
+        and not drive.startswith("\\\\")
         and os.path.exists(path / ".git")
     )
 

--- a/src/jcodemunch_mcp/tools/index_folder.py
+++ b/src/jcodemunch_mcp/tools/index_folder.py
@@ -321,6 +321,24 @@ def _path_safety_part_count(path: Path) -> int:
     return count
 
 
+def _is_shallow_windows_git_root(path: Path) -> bool:
+    r"""Return whether ``path`` is a Git root directly below a local drive.
+
+    ``C:\repo`` has a safety depth of two and normally trips the broad-root
+    guard. A ``.git`` directory or file at that exact path proves the caller
+    selected a working-tree root rather than the drive itself or a broad parent.
+    The corresponding POSIX case was considered and intentionally left unchanged
+    so this exception remains scoped to the reported Windows drive-root behavior.
+    """
+    drive = str(path.drive)
+    return (
+        os.name == "nt"
+        and _path_safety_part_count(path) == 2
+        and bool(drive)
+        and os.path.exists(path / ".git")
+    )
+
+
 @lru_cache(maxsize=512)
 def _is_trusted(
     folder_path: Path, trusted_folders: tuple, whitelist_mode: bool = True
@@ -1445,7 +1463,8 @@ def index_folder(
     _MIN_PATH_PARTS = 2 if container else 3
     path_part_count = _path_safety_part_count(folder_path)
     if path_part_count < _MIN_PATH_PARTS:
-        if not is_trusted:
+        shallow_windows_git_root = _is_shallow_windows_git_root(folder_path)
+        if not is_trusted and not shallow_windows_git_root:
             error_msg = (
                 f"Resolved path '{folder_path}' is too broad to index safely "
                 f"(fewer than {_MIN_PATH_PARTS} path components). "
@@ -1456,10 +1475,16 @@ def index_folder(
             logger.error(error_msg)
             return {"success": False, "error": error_msg}
 
-        warning_msg = (
-            f"Resolved path '{folder_path}' would normally be rejected as too broad, "
-            "but it matched trusted_folders and was allowed."
-        )
+        if is_trusted:
+            warning_msg = (
+                f"Resolved path '{folder_path}' would normally be rejected as too broad, "
+                "but it matched trusted_folders and was allowed."
+            )
+        else:
+            warning_msg = (
+                f"Resolved path '{folder_path}' is a Git working-tree root directly "
+                "below a Windows drive root and was allowed."
+            )
         logger.warning(warning_msg)
         warnings.append(warning_msg)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1276,6 +1276,77 @@ class TestWindowsDriveRootPathSafety:
         assert result["success"] is False
         assert "too broad to index safely" in result["error"]
 
+    def test_unc_share_root_with_git_remains_too_broad(self, tmp_path):
+        r"""A UNC share root is out of scope even when it holds a ``.git``.
+
+        ⚠ This is NOT covered by the depth check. ``_path_safety_part_count``
+        adds one for the ``\\server\share`` anchor, so a share root computes to
+        exactly two — the same depth as ``C:\repo``. Only the explicit UNC scope
+        predicate keeps it out, so removing that predicate makes this admit a
+        whole file server. See #321/#322.
+        """
+        from jcodemunch_mcp.tools import index_folder as index_folder_module
+
+        share_root = Path(r"\\server\share")
+        assert index_folder_module._path_safety_part_count(share_root) == 2, (
+            "premise: a UNC share root is depth-equivalent to C:\\repo, so the "
+            "depth check alone cannot exclude it"
+        )
+
+        with (
+            patch.object(
+                index_folder_module._config, "load_project_config", return_value=None
+            ),
+            patch.object(
+                index_folder_module._config,
+                "get",
+                side_effect=lambda key, default=None, repo=None: (
+                    [] if key == "trusted_folders" else default
+                ),
+            ),
+            patch(
+                "jcodemunch_mcp.tools.index_folder.Path.resolve",
+                return_value=share_root,
+            ),
+            patch("jcodemunch_mcp.tools.index_folder.Path.exists", return_value=True),
+            patch("jcodemunch_mcp.tools.index_folder.Path.is_dir", return_value=True),
+            patch(
+                "jcodemunch_mcp.tools.index_folder.os.path.exists",
+                # ⚠ Narrow, NOT return_value=True. A blanket True also answers
+                # _is_container()'s /.dockerenv probe, which drops
+                # _MIN_PATH_PARTS to 2 so `2 < 2` skips the guard entirely and
+                # the test passes without ever reaching the code under test.
+                side_effect=lambda candidate: Path(candidate) == share_root / ".git",
+            ),
+            patch.object(
+                index_folder_module, "discover_local_files", return_value=([], [], {})
+            ),
+        ):
+            result = index_folder_module.index_folder(
+                str(tmp_path / "share"),
+                use_ai_summaries=False,
+                storage_path=str(tmp_path / "store"),
+            )
+
+        assert result["success"] is False
+        assert "too broad to index safely" in result["error"]
+
+    def test_unc_repository_below_share_root_is_unaffected(self, tmp_path):
+        r"""``\\server\share\repo`` never reaches the exception at all.
+
+        Its safety depth is three, so it clears the guard on depth alone. Pinned
+        so a future widening of the exception cannot be justified by "UNC repos
+        need it" — they do not.
+        """
+        from jcodemunch_mcp.tools import index_folder as index_folder_module
+
+        unc_repo = Path(r"\\server\share\repo")
+        assert index_folder_module._path_safety_part_count(unc_repo) == 3
+        with patch(
+            "jcodemunch_mcp.tools.index_folder.os.path.exists", return_value=True
+        ):
+            assert index_folder_module._is_shallow_windows_git_root(unc_repo) is False
+
 
 class TestIndexFolderGitignoreWarning:
     """index_folder should warn when no root .gitignore exists and file count is large."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1161,6 +1161,122 @@ class TestWindowsUNCPathSafety:
         assert "too broad to index safely" in result["error"]
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows drive path semantics only")
+class TestWindowsDriveRootPathSafety:
+    """Exact Git roots directly below a Windows drive root are project-scoped."""
+
+    def test_drive_root_child_git_repo_is_not_too_broad(self, tmp_path):
+        from jcodemunch_mcp.tools import index_folder as index_folder_module
+
+        drive_root_repo = Path(r"F:\repo")
+
+        with (
+            patch.object(
+                index_folder_module._config, "load_project_config", return_value=None
+            ),
+            patch.object(
+                index_folder_module._config,
+                "get",
+                side_effect=lambda key, default=None, repo=None: (
+                    [] if key == "trusted_folders" else default
+                ),
+            ),
+            patch(
+                "jcodemunch_mcp.tools.index_folder.Path.resolve",
+                return_value=drive_root_repo,
+            ),
+            patch("jcodemunch_mcp.tools.index_folder.Path.exists", return_value=True),
+            patch("jcodemunch_mcp.tools.index_folder.Path.is_dir", return_value=True),
+            patch(
+                "jcodemunch_mcp.tools.index_folder.os.path.exists",
+                side_effect=lambda candidate: Path(candidate) == drive_root_repo / ".git",
+            ),
+            patch.object(
+                index_folder_module, "discover_local_files", return_value=([], [], {})
+            ),
+        ):
+            result = index_folder_module.index_folder(
+                str(tmp_path / "repo"),
+                use_ai_summaries=False,
+                storage_path=str(tmp_path / "store"),
+            )
+
+        assert "too broad" not in result.get("error", "")
+        assert result["error"] == "No source files found"
+
+    def test_drive_root_remains_too_broad(self, tmp_path):
+        from jcodemunch_mcp.tools import index_folder as index_folder_module
+
+        drive_root = Path("F:/")
+
+        with (
+            patch.object(
+                index_folder_module._config, "load_project_config", return_value=None
+            ),
+            patch.object(
+                index_folder_module._config,
+                "get",
+                side_effect=lambda key, default=None, repo=None: (
+                    [] if key == "trusted_folders" else default
+                ),
+            ),
+            patch(
+                "jcodemunch_mcp.tools.index_folder.Path.resolve",
+                return_value=drive_root,
+            ),
+            patch("jcodemunch_mcp.tools.index_folder.Path.exists", return_value=True),
+            patch("jcodemunch_mcp.tools.index_folder.Path.is_dir", return_value=True),
+        ):
+            result = index_folder_module.index_folder(
+                str(tmp_path / "drive"),
+                use_ai_summaries=False,
+                storage_path=str(tmp_path / "store"),
+            )
+
+        assert result["success"] is False
+        assert "too broad to index safely" in result["error"]
+
+    def test_shallow_non_git_directory_remains_too_broad(self, tmp_path):
+        from jcodemunch_mcp.tools import index_folder as index_folder_module
+
+        shallow_directory = Path(r"F:\Users")
+
+        with (
+            patch.object(
+                index_folder_module._config, "load_project_config", return_value=None
+            ),
+            patch.object(
+                index_folder_module._config,
+                "get",
+                side_effect=lambda key, default=None, repo=None: (
+                    [] if key == "trusted_folders" else default
+                ),
+            ),
+            patch(
+                "jcodemunch_mcp.tools.index_folder.Path.resolve",
+                return_value=shallow_directory,
+            ),
+            patch(
+                "jcodemunch_mcp.tools.index_folder.Path.exists",
+                autospec=True,
+                side_effect=lambda candidate: candidate == shallow_directory,
+            ),
+            patch("jcodemunch_mcp.tools.index_folder.Path.is_dir", return_value=True),
+            patch(
+                "jcodemunch_mcp.tools.index_folder.os.path.exists",
+                return_value=False,
+            ),
+        ):
+            result = index_folder_module.index_folder(
+                str(tmp_path / "users"),
+                use_ai_summaries=False,
+                storage_path=str(tmp_path / "store"),
+            )
+
+        assert result["success"] is False
+        assert "too broad to index safely" in result["error"]
+
+
 class TestIndexFolderGitignoreWarning:
     """index_folder should warn when no root .gitignore exists and file count is large."""
 


### PR DESCRIPTION
## Summary

Fixes #438.

- allow an exact Git working-tree root directly below a local Windows drive root (for example, `F:\repo`)
- keep drive roots and shallow non-Git directories blocked by the broad-root guard
- add Windows-specific regression coverage for all three cases
- document the behavior change in the changelog

## Root cause

On Windows, `Path.parts` represents `F:\repo` with only two components: the drive anchor and the repository directory. The broad-root guard therefore rejects a valid repository located directly under a drive, even though the selected directory is an exact Git working-tree root.

## Safety

This does not lower the global minimum-depth threshold. The exception is limited to Windows local-drive paths with a safety depth of two whose selected directory contains a `.git` directory or file. The drive root itself, shallow non-Git directories, POSIX paths, and UNC handling remain unchanged. Existing `trusted_folders` behavior is also preserved.

## Testing

- red/green regression: the child-drive Git-root case failed before the production change and passes afterward
- review regression: the non-Git test was shown to fail when the mocked runner exposed `.git`, then isolated with an explicit negative filesystem probe
- `uv run pytest tests/test_tools.py -q -k WindowsDriveRootPathSafety` — 3 passed
- `uv run pytest tests/ -q` — 7618 passed, 17 skipped, 1 pre-existing warning
- `uv run ruff check src/` — passed
- real Windows smoke test indexed a separate repository directly below `F:\` without a project `.jcodemunch.jsonc`: 35 files and 984 symbols; the new narrow Git-root exception was reported

## Related work checked

- #125 introduced the broad-root guard
- #175 added explicit `trusted_folders`
- #321 / #322 cover UNC logical depth and intentionally left local-drive behavior unchanged
