### PR TITLE
feat(parser): register markdown and html; markdown sections become container symbols

### DIFF
--- a/src/jcodemunch_mcp/parser/extractor.py
+++ b/src/jcodemunch_mcp/parser/extractor.py
@@ -928,6 +928,18 @@ def _extract_name(node, spec: LanguageSpec, source_bytes: bytes) -> Optional[str
                             return source_bytes[name_node.start_byte:name_node.end_byte].decode("utf-8")
         return None
 
+    # Markdown sections: the heading text lives in atx_heading > inline,
+    # which tree-sitter exposes as plain children, not named fields.
+    if spec.ts_language == "markdown" and node.type == "section":
+        for child in node.children:
+            if child.type == "atx_heading":
+                for sub in child.children:
+                    if sub.type == "inline":
+                        text = source_bytes[sub.start_byte:sub.end_byte].decode("utf-8").strip()
+                        return text or None
+                break
+        return None  # heading-less section (e.g. preamble) -> not a symbol
+
     if node.type not in spec.name_fields:
         return None
     

--- a/src/jcodemunch_mcp/parser/languages.py
+++ b/src/jcodemunch_mcp/parser/languages.py
@@ -247,6 +247,10 @@ LANGUAGE_EXTENSIONS = {
     ".swagger.yaml": "openapi",
     ".swagger.yml": "openapi",
     ".swagger.json": "openapi",
+    ".md": "markdown",
+    ".markdown": "markdown",
+    ".html": "html",
+    ".htm": "html",
 }
 
 
@@ -1946,6 +1950,35 @@ DLANG_SPEC = LanguageSpec(
     type_patterns=[],
 )
 
+MARKDOWN_SPEC = LanguageSpec(
+    ts_language="markdown",
+    # Nested `section` nodes span a heading through its content (verified
+    # against tree-sitter-language-pack's block grammar 2026-08-12). Each
+    # becomes a container symbol so get_symbol_source returns one section.
+    symbol_node_types={"section": "class"},
+    name_fields={},  # heading text has no ts field; see _extract_name special case
+    param_fields={},
+    return_type_fields={},
+    docstring_strategy="preceding_comment",
+    decorator_node_type=None,
+    container_node_types=["section"],
+    constant_patterns=[],
+    type_patterns=[],
+)
+
+HTML_SPEC = LanguageSpec(
+    ts_language="html",   # same bundled grammar RAZOR_SPEC already rides
+    symbol_node_types={},
+    name_fields={},
+    param_fields={},
+    return_type_fields={},
+    docstring_strategy="preceding_comment",
+    decorator_node_type=None,
+    container_node_types=[],
+    constant_patterns=[],
+    type_patterns=[],
+)
+
 
 # Language registry
 LANGUAGE_REGISTRY = {
@@ -2024,6 +2057,8 @@ LANGUAGE_REGISTRY = {
     "nim": NIM_SPEC,
     "tcl": TCL_SPEC,
     "dlang": DLANG_SPEC,
+    "markdown": MARKDOWN_SPEC,
+    "html": HTML_SPEC,
 }
 
 # Template-engine languages (jinja/twig) all route through the

--- a/tests/fixtures/markdown/sample.md
+++ b/tests/fixtures/markdown/sample.md
@@ -1,0 +1,16 @@
+# Alpha Top
+
+intro text under alpha
+
+## Beta Sub
+
+beta body line one
+beta body line two
+
+## Gamma Sub
+
+gamma body
+
+# Delta Top
+
+delta body

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,25 @@
+"""Markdown + HTML language registration and section-symbol extraction."""
+from pathlib import Path
+
+from jcodemunch_mcp.parser import parse_file, Symbol
+from jcodemunch_mcp.parser.languages import (
+    LANGUAGE_REGISTRY, get_language_extensions, get_language_for_path,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_markdown_extension_in_registry():
+    ext = get_language_extensions()
+    assert ext[".md"] == "markdown"
+    assert ext[".markdown"] == "markdown"
+    assert "markdown" in LANGUAGE_REGISTRY
+    assert get_language_for_path("docs/AGENT_STATE.md") == "markdown"
+
+
+def test_html_extension_in_registry():
+    ext = get_language_extensions()
+    assert ext[".html"] == "html"
+    assert ext[".htm"] == "html"
+    assert "html" in LANGUAGE_REGISTRY
+    assert get_language_for_path("templates/index.html") == "html"

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,7 +1,7 @@
 """Markdown + HTML language registration and section-symbol extraction."""
 from pathlib import Path
 
-from jcodemunch_mcp.parser import parse_file, Symbol
+from jcodemunch_mcp.parser import parse_file
 from jcodemunch_mcp.parser.languages import (
     LANGUAGE_REGISTRY, get_language_extensions, get_language_for_path,
 )
@@ -23,3 +23,31 @@ def test_html_extension_in_registry():
     assert ext[".htm"] == "html"
     assert "html" in LANGUAGE_REGISTRY
     assert get_language_for_path("templates/index.html") == "html"
+
+
+def _md_symbols():
+    content = (FIXTURES / "markdown" / "sample.md").read_text(encoding="utf-8")
+    return parse_file(content, "sample.md", "markdown")
+
+
+def test_markdown_sections_extracted():
+    symbols = _md_symbols()
+    names = {s.name for s in symbols}
+    assert {"Alpha Top", "Beta Sub", "Gamma Sub", "Delta Top"} <= names
+    assert all(s.kind == "class" for s in symbols if s.name in names)
+
+
+def test_markdown_section_spans_nest():
+    symbols = {s.name: s for s in _md_symbols()}
+    alpha, beta, gamma, delta = (symbols[n] for n in
+        ("Alpha Top", "Beta Sub", "Gamma Sub", "Delta Top"))
+    # section span covers its body, and subsections nest inside the parent span
+    assert alpha.line < beta.line and beta.end_line <= alpha.end_line
+    assert alpha.line < gamma.line and gamma.end_line <= alpha.end_line
+    assert delta.line > alpha.end_line - 1  # Delta is a sibling, not nested
+    assert beta.end_line >= beta.line + 2   # span includes the body lines
+
+
+def test_markdown_headingless_file_no_crash():
+    symbols = parse_file("just prose\nno headings here\n", "plain.md", "markdown")
+    assert all(s.name for s in symbols)  # nothing unnamed; empty list acceptable

--- a/tests/test_plan_refactoring.py
+++ b/tests/test_plan_refactoring.py
@@ -1718,10 +1718,11 @@ class TestLanguageCoverage:
         registry_langs = set(LANGUAGE_REGISTRY.keys())
         import_langs = set(_IMPORT_PATTERNS.keys())
 
-        # Data formats and templating engines are exempt — they have no import
-        # syntax of their own (a template refactor uses the underlying language).
+        # Data formats, document languages, and templating engines are exempt —
+        # they have no import syntax of their own (a template refactor uses the
+        # underlying language; markdown/html carry section structure only).
         from jcodemunch_mcp.parser.template_shared import TEMPLATE_ENGINE_LANGUAGES
-        exempt = {"toml", "xml", "json", "yaml", "ansible", "openapi"} | set(TEMPLATE_ENGINE_LANGUAGES)
+        exempt = {"toml", "xml", "json", "yaml", "ansible", "openapi", "markdown", "html"} | set(TEMPLATE_ENGINE_LANGUAGES)
         expected = registry_langs - exempt
         missing = expected - import_langs
 
@@ -1736,10 +1737,12 @@ class TestLanguageCoverage:
         registry_langs = set(LANGUAGE_REGISTRY.keys())
         def_langs = set(_DEF_PATTERNS.keys())
 
-        # Data formats and templating engines are exempt — they have no symbol
-        # definitions of their own (a template refactor uses the underlying language).
+        # Data formats, document languages, and templating engines are exempt —
+        # they have no refactorable symbol definitions of their own (a template
+        # refactor uses the underlying language; markdown sections/html are
+        # document structure, not definitions).
         from jcodemunch_mcp.parser.template_shared import TEMPLATE_ENGINE_LANGUAGES
-        exempt = {"toml", "xml", "json", "yaml", "ansible", "openapi"} | set(TEMPLATE_ENGINE_LANGUAGES)
+        exempt = {"toml", "xml", "json", "yaml", "ansible", "openapi", "markdown", "html"} | set(TEMPLATE_ENGINE_LANGUAGES)
         expected = registry_langs - exempt
         missing = expected - def_langs
 

--- a/tests/test_suggest_queries.py
+++ b/tests/test_suggest_queries.py
@@ -21,8 +21,10 @@ class TestSuggestQueriesErrors:
         store = tmp_path / "store"
         src.mkdir()
         store.mkdir()
-        # Write a file type the parser ignores (no symbols extracted)
-        (src / "README.md").write_text("# Hello\n")
+        # Write a parseable file that yields no symbols. (README.md no longer
+        # qualifies — markdown headings ARE symbols now, so a comment-only .py
+        # keeps this test on the empty-index path.)
+        (src / "empty.py").write_text("# nothing defined here\n")
         r_idx = index_folder(str(src), use_ai_summaries=False, storage_path=str(store))
         # If no symbols were extracted the tool returns an empty-index error
         if r_idx["success"] and r_idx.get("symbols_indexed", 0) == 0:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -105,7 +105,9 @@ def test_discover_source_files():
     assert "src/engine.cpp" in files
     assert "include/engine.hpp" in files
     assert "node_modules/foo.js" not in files
-    assert "README.md" not in files  # Not a source file
+    # Markdown is an indexed source language (sections become symbols), so
+    # README.md IS discovered now.
+    assert "README.md" in files
     assert truncated is False
 
 

--- a/tests/test_v1_108_56.py
+++ b/tests/test_v1_108_56.py
@@ -104,8 +104,10 @@ class TestNoChangeRefreshesGitHead:
             incremental=True, identity_mode="local")["repo"]}, store_path)
         assert idx.git_head == head_a
 
-        # Commit a change to a NON-indexed file only.
-        (repo / "README.md").write_text("# hello world\n")
+        # Commit a change to a NON-indexed file only. (Was README.md, but
+        # markdown is indexed now; an extensionless LICENSE stays outside
+        # every language mapping.)
+        (repo / "LICENSE").write_text("hello world\n")
         _git(repo, "add", "-A")
         _git(repo, "commit", "-m", "docs only")
         head_b = _head(repo)


### PR DESCRIPTION
Closes #452.

## What

Three commits:

1. **feat(languages): register markdown (section symbols) and html** — adds `.md`/`.markdown`/`.html`/`.htm` to `LANGUAGE_EXTENSIONS`, plus `MARKDOWN_SPEC` (nested `section` nodes → container symbols, verified against tree-sitter-language-pack's block grammar) and `HTML_SPEC` (same bundled grammar `RAZOR_SPEC` already rides).
2. **feat(extractor): markdown section names from atx heading inline text** — the heading text lives in `atx_heading > inline` as plain children, not named ts fields, so `_extract_name` gets a small markdown special case. Heading-less preamble sections produce no symbol by design.
3. **test: update expectations for markdown/html as indexed languages** — markdown/html join the data-format exemption in the refactor-pattern coverage tests (document structure, no import/def syntax), and three fixtures that used README.md as "a file the parser ignores" switch to files that still are ignored (comment-only `.py`, extensionless `LICENSE`).

## Why

Docs are the biggest files agents touch and today they're invisible to the index. With sections as symbols, `get_file_outline` on a 274 KB operating doc lists its sections, and `get_symbol_source` returns one section for ~400 tokens instead of a whole-file read. Enabling this across one production repo: 5,153 → 7,563 symbols. Same token economics as TOKEN_SAVINGS.md, applied to documentation.

## Tests

`tests/test_markdown.py` (5 tests: extension routing, registry specs, section symbols from a fixture, heading-name extraction, preamble exclusion) + `tests/fixtures/markdown/sample.md`. Full suite run with `PYTHONPATH=src` on Windows 11 against v1.108.274: **13 failed, 7688 passed, 30 skipped**. The 13 failures are environment-dependent and **pre-exist on pristine `upstream/main` in this environment** (verified A/B on the same machine — identical set with the feature commits absent; e.g. a temp-path case-sensitivity assertion `pytest-of-user` vs `pytest-of-User`). Happy to file those separately per one-issue-one-verdict.

## Notes

- No new dependencies; both grammars ship in tree-sitter-language-pack already.
- Deployed in production on our side since 2026-08-12 (watcher reindex included) — the numbers above are measured, not projected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)