### PR TITLE
test: stop the UNC path-safety tests letting the network decide their verdict (#453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,56 @@ the code under test. The probe is narrowed to the `.git` path and the reason is
 recorded at the patch site. **A mock broad enough to satisfy the assertion can
 be broad enough to bypass what the assertion is about.**
 
+### A path-safety test that let the network decide its verdict ([#453](https://github.com/jgravelle/jcodemunch-mcp/issues/453))
+
+Test-only, no behaviour change. `TestWindowsUNCPathSafety` names a UNC path that
+does not exist, and **it was not fully isolated from the real filesystem**, so its
+result depended on the runner's network rather than on the code under test. It
+failed two releases in one day (.272 on `windows-latest/3.10`, .275 on 3.11),
+both times passing on re-run of the identical SHA.
+
+⚠⚠ **The cause is one unpatched probe, and the mechanism explains why it was
+intermittent rather than simply broken.** `resolve_index_identity` calls
+`folder_path.is_file()` (`storage/git_root.py:160`); the test patched `Path.exists`
+and `Path.is_dir` but never `Path.is_file`, so `os.stat` went to the network.
+`Path.is_file()` **swallows ENOENT-class errors** -- what a box with no such share
+returns, which is why it passes everywhere locally -- but **propagates
+`WinError 64` (`ERROR_NETNAME_DELETED`)**, which is what a runner with
+live-but-failing networking returns. Same code, same test, opposite outcomes,
+decided by whose network answered.
+
+⚠ **The false-green half is the same test class and the more expensive one.**
+`test_unc_share_root_remains_too_broad` let the runner's lack of a
+`\\server\share\.git` decide the #438 probe. So the boundary it defends could move
+without the test noticing -- and it did, in #439, where a UNC share root would have
+been admitted as narrow. It now answers that probe TRUE, which proves the UNC scope
+predicate excludes a share root **on its own** rather than by accident of the
+runner's drive layout.
+
+⚠ **Fixed by isolation, deliberately not by a retry or a flaky marker.** A retry
+would have hidden the false red while leaving the false green fully intact -- and
+the false green is what let a real regression through.
+
+**The durable half is `_no_real_access_under()`**, a tripwire wrapping `Path.stat`
+/ `read_text` / `open` that fails loudly if a test touches the fake root at all.
+Two details are load-bearing and were both found by measurement rather than
+design:
+
+- ⚠⚠ **It raises a `BaseException` subclass, not `AssertionError`.** Every read
+  site it covers is wrapped in a bare `except Exception` in production
+  (`_composer_requires` and friends). The first version derived from `Exception`,
+  was silently swallowed, and **a deliberately re-broadened mock passed cleanly
+  with the guard in place** -- a tripwire that cannot fire is worse than none,
+  because it reads as coverage.
+- An audit hook showed the blanket `Path.exists=True` also convinced
+  `detect_framework` that seven manifests existed, so a unit test did seven
+  network round trips reading `composer.json`, `package.json`, `pyproject.toml`,
+  `pom.xml`, `build.gradle`, `Gemfile` and `requirements.txt`. Those never failed
+  anything, because production swallows them. Narrowed anyway.
+
+Proven non-vacuous by removing the `is_file` patch: the guard fires and names the
+call, rather than the run going red somewhere else an hour later.
+
 ## [1.108.275] - 2026-08-12 - A pattern that matches nothing now says so
 
 ### `entry_point_patterns` failed silently ([#446](https://github.com/jgravelle/jcodemunch-mcp/issues/446))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,61 @@ not measure is what that costs in practice.
 a RESUMED conversation counts accumulated context on every step, so the total is
 dominated by how much the agent read early on, which compounds.
 
+**Merged 2026-08-13: #439 (@JayceeB1) Windows drive-root child Git repos, closing
+#438** — plus **#453 fixed on top, test-only.** Both ride the next release; no
+version bump. ⚠⚠ **The reusable lesson is one sentence and it cost most of a day:
+a mock broad enough to satisfy an assertion can be broad enough to bypass what the
+assertion is about.** It fired three times in three different costumes.
+
+⚠⚠ **My own review advice on #439 was WRONG and nearly shipped a hole.** I told
+them `_path_safety_part_count(path) == 2` subsumed `not drive.startswith("\\\\")`.
+It does not: the helper is a **DEPTH** rule and the UNC clause is a **SCOPE** rule.
+A UNC share root has ONE real part and the helper adds one for the
+`\\server\share` anchor, so it computes to **exactly 2 — the same as `C:\repo`**.
+With the clause gone, `\\server\share` holding a `.git` is admitted, handing the
+indexer a whole file server through the guard that exists to stop that (#321/#322).
+⚠ **`len(path.parts)` genuinely WAS a redundant depth notion — that half was
+right.** The error was concluding that a second condition mentioning the same
+variable must therefore be redundant too. **Check what a predicate is FOR, not what
+it reads.** Restored with both clauses, the reason recorded in the docstring, and
+the bad advice corrected in the CHANGELOG rather than deleted
+([[feedback_a_fix_comment_is_not_evidence_about_its_siblings]] — same reason).
+
+⚠⚠ **The regression test for it was ALSO wrong, in a way that PASSED.** It patched
+`os.path.exists` to a blanket `True`, which also answers `_is_container()`'s
+`/.dockerenv` probe — that drops `_MIN_PATH_PARTS` from three to two, so `2 < 2`
+skips the guard entirely and `_is_shallow_windows_git_root` **was never called**
+(proven by spying on it: zero invocations). ⚠ **The tell was that it failed
+IDENTICALLY with and without the fix.** A test failing on both sides is as
+uninformative as one passing on both sides, and it is the cheaper tell to notice
+because you are already looking at a red. **Run the non-vacuity pass even when the
+test is currently failing.**
+
+⚠⚠ **#453's tripwire had the same disease a third time: it could not fire.**
+`_no_real_access_under` raised `AssertionError`, and every read site it guards is
+wrapped in a bare `except Exception` in production, so a deliberately re-broadened
+mock **passed cleanly with the guard installed**. Now derives from
+`BaseException`. **A guard that cannot fire is worse than no guard, because it
+reads as coverage.** Always prove a new guard fires by breaking the thing it
+watches.
+
+⚠ **#453's actual root cause was NOT the one I inferred**, and the difference
+mattered. I traced seven network `read_text` calls (`detect_framework` probing
+manifests under a blanket `Path.exists=True`) and took them for the culprit; they
+are real network I/O in a unit test but are **swallowed by production's
+`except Exception` and never failed anything**. The failure was
+`resolve_index_identity` → `folder_path.is_file()` (`storage/git_root.py:160`),
+never patched. **Only pulling the real CI traceback settled it** — attempt 1 of a
+rerun run, via `gh api .../runs/<id>/attempts/1/jobs`, because **a rerun flips the
+run's conclusion to success and hides the failure from `gh run list`**.
+`Path.is_file()` swallows ENOENT-class errors (a box with no such share) but
+propagates `WinError 64` (a runner with live-but-failing networking) — same test,
+opposite outcomes, decided by whose network answered.
+
+⚠ **Process note: `git checkout -- <file>` destroyed uncommitted work TWICE**
+during the non-vacuity passes, because the falsification edit and the fix lived in
+the same file. Copy the fixed file to the scratchpad first and restore from that.
+
 **Merged 2026-07-25: #379 (@oderwat) Gleam import extraction** — Gleam was already
 in `LANGUAGE_REGISTRY`, so symbols extracted but the import graph stayed EMPTY,
 leaving `find_importers`/`get_blast_radius`/`get_dependency_graph` silently blind

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,5 +1,6 @@
 """Tests for tools module."""
 
+import contextlib
 import json
 import os
 from pathlib import Path
@@ -1089,6 +1090,65 @@ class TestContainerDetection:
         assert "too broad to index safely" in result["error"]
 
 
+class _RealFilesystemReached(BaseException):
+    r"""Raised when a path-safety test touches the real filesystem (#453).
+
+    ⚠⚠ Derives from ``BaseException``, NOT ``Exception``, and that is the whole
+    point. Every read site this guard covers is wrapped in a bare
+    ``except Exception`` in production (``_composer_requires`` and friends in
+    ``parser/context/framework_profiles.py``), so an ``AssertionError`` tripwire
+    is swallowed and reports nothing. Measured: a deliberately re-broadened mock
+    passed cleanly with an ``Exception``-derived guard in place.
+    """
+
+
+@contextlib.contextmanager
+def _no_real_access_under(fake_root: Path):
+    r"""Fail loudly if anything stats or reads a path under ``fake_root``.
+
+    These tests name a UNC path that does not exist. Any unpatched probe of it
+    goes to the NETWORK, and the verdict then depends on the runner rather than
+    on the code under test. That produced both halves of #453, in opposite
+    directions:
+
+    * **False red.** ``resolve_index_identity`` calls ``folder_path.is_file()``
+      (``storage/git_root.py:160``), which was never patched. ``Path.is_file``
+      swallows ENOENT-class errors -- what a box with no such share returns --
+      but PROPAGATES ``WinError 64`` (``ERROR_NETNAME_DELETED``), which is what a
+      runner with live-but-failing networking returns. Same code, same test,
+      opposite outcomes, decided by the network. Two releases lost to it.
+    * **False green.** ``test_unc_share_root_remains_too_broad`` let the runner's
+      lack of a ``\\server\share\.git`` decide the ``#438`` probe, so the guard
+      it defends could move without the test noticing. It did move, in #439.
+
+    This is a tripwire, not a mock: narrowing the patches is what makes the tests
+    pass. This exists so that re-broadening one fails with a message naming the
+    cause, instead of intermittently and somewhere else.
+    """
+    needle = str(fake_root).lower()
+    originals = {name: getattr(Path, name) for name in ("stat", "read_text", "open")}
+
+    def _guard(name):
+        real = originals[name]
+
+        def wrapper(self, *args, **kwargs):
+            if needle in str(self).lower():
+                raise _RealFilesystemReached(
+                    f"Path.{name}() reached the real filesystem at {str(self)!r}. "
+                    f"A patch is broad enough to make this fake path look real, "
+                    f"or a probe of it is unpatched -- narrow or add one rather "
+                    f"than letting the runner decide the result (see #453)."
+                )
+            return real(self, *args, **kwargs)
+
+        return wrapper
+
+    with contextlib.ExitStack() as stack:
+        for name in originals:
+            stack.enter_context(patch.object(Path, name, _guard(name)))
+        yield
+
+
 @pytest.mark.skipif(os.name != "nt", reason="Windows UNC path semantics only")
 class TestWindowsUNCPathSafety:
     """Windows UNC roots should be treated as server/share plus descendants."""
@@ -1113,11 +1173,31 @@ class TestWindowsUNCPathSafety:
                 "jcodemunch_mcp.tools.index_folder.Path.resolve",
                 return_value=unc_repo,
             ),
-            patch("jcodemunch_mcp.tools.index_folder.Path.exists", return_value=True),
+            # ⚠ Narrow, NOT return_value=True. A blanket True convinces
+            # detect_framework that composer.json / package.json / pyproject.toml
+            # / pom.xml / build.gradle / Gemfile / requirements.txt all exist
+            # here, and it read_text()s all seven over the network. Those are
+            # swallowed by production's `except Exception`, so they never failed
+            # the test -- they just made a unit test do seven network round
+            # trips. Measured with an audit hook.
+            patch(
+                "jcodemunch_mcp.tools.index_folder.Path.exists",
+                autospec=True,
+                side_effect=lambda candidate: candidate == unc_repo,
+            ),
+            patch(
+                "jcodemunch_mcp.tools.index_folder.os.path.exists",
+                return_value=False,
+            ),
             patch("jcodemunch_mcp.tools.index_folder.Path.is_dir", return_value=True),
+            # ⚠⚠ THIS is the one that lost two releases. resolve_index_identity
+            # calls folder_path.is_file() (storage/git_root.py:160) and nothing
+            # patched it, so os.stat went to the network and raised WinError 64.
+            patch("jcodemunch_mcp.tools.index_folder.Path.is_file", return_value=False),
             patch.object(
                 index_folder_module, "discover_local_files", return_value=([], [], {})
             ),
+            _no_real_access_under(unc_repo),
         ):
             result = index_folder_module.index_folder(
                 str(tmp_path / "repo"),
@@ -1148,8 +1228,24 @@ class TestWindowsUNCPathSafety:
                 "jcodemunch_mcp.tools.index_folder.Path.resolve",
                 return_value=unc_share_root,
             ),
-            patch("jcodemunch_mcp.tools.index_folder.Path.exists", return_value=True),
+            patch(
+                "jcodemunch_mcp.tools.index_folder.Path.exists",
+                autospec=True,
+                side_effect=lambda candidate: candidate == unc_share_root,
+            ),
+            # ⚠⚠ Answering the .git probe TRUE is the point. It proves the UNC
+            # scope predicate (#439) excludes a share root on its own, rather
+            # than because the runner happens to have no such share. Before this,
+            # the guard could move and the test could not tell -- and it did.
+            patch(
+                "jcodemunch_mcp.tools.index_folder.os.path.exists",
+                side_effect=lambda candidate: (
+                    Path(candidate) == unc_share_root / ".git"
+                ),
+            ),
             patch("jcodemunch_mcp.tools.index_folder.Path.is_dir", return_value=True),
+            patch("jcodemunch_mcp.tools.index_folder.Path.is_file", return_value=False),
+            _no_real_access_under(unc_share_root),
         ):
             result = index_folder_module.index_folder(
                 str(tmp_path / "share"),


### PR DESCRIPTION
Fixes #453. Test-only, no behaviour change, no version bump.

## The false red

`resolve_index_identity` calls `folder_path.is_file()` (`storage/git_root.py:160`). The test patched `Path.exists` and `Path.is_dir` but **never `Path.is_file`**, so `os.stat` went to the network for a UNC path that does not exist.

Why it was intermittent rather than simply broken: `Path.is_file()` **swallows ENOENT-class errors** — what a box with no such share returns, which is why it passes everywhere locally — but **propagates `WinError 64` (`ERROR_NETNAME_DELETED`)**, which is what a runner with live-but-failing networking returns. Same code, same test, opposite outcomes, decided by whose network answered. It failed .272 on `windows-latest/3.10` and .275 on 3.11, both passing on re-run of the identical SHA.

⚠ **The cause I first inferred was wrong.** An audit hook showed seven `read_text` calls going to the network — `detect_framework` probing `composer.json`, `package.json`, `pyproject.toml`, `pom.xml`, `build.gradle`, `Gemfile`, `requirements.txt` under a blanket `Path.exists=True`. Those are real network round trips in a unit test, but production wraps them in `except Exception`, so they never failed anything. Only pulling the real CI traceback settled it — and that needed `attempts/1`, because **a rerun flips the run conclusion to `success` and hides the failure from `gh run list`**.

## The false green, which is the more expensive half

`test_unc_share_root_remains_too_broad` let the runners lack of a `\server\share\.git` decide the #438 probe. The boundary it defends could move without the test noticing — and it did, in #439, where a UNC share root would have been admitted as narrow. It now answers that probe **TRUE**, proving the UNC scope predicate excludes a share root on its own rather than by accident of the runners drive layout.

⚠ Fixed by isolation, **deliberately not by a retry or a flaky marker**. A retry would hide the false red while leaving the false green fully intact, and the false green is what let a real regression through.

## The durable half

`_no_real_access_under()` wraps `Path.stat` / `read_text` / `open` and fails loudly if a test touches the fake root at all.

⚠⚠ **It raises a `BaseException` subclass, not `AssertionError`.** Every read site it guards is wrapped in a bare `except Exception` in production. The first version derived from `Exception`, was silently swallowed, and **a deliberately re-broadened mock passed cleanly with the guard installed**. A guard that cannot fire is worse than none, because it reads as coverage.

## Verification

- Both Windows classes: 7 passed. Whole `test_tools.py`: 55 passed. Sync + rotation gates: 37 passed.
- Non-vacuity proven by removing the `is_file` patch — the tripwire fires and names the call:
  ```
  E  tests.test_tools._RealFilesystemReached: Path.stat() reached the real
     filesystem at '\\server\share\repo'. A patch is broad enough to make this
     fake path look real, or a probe of it is unpatched (see #453).
  ```
- ⚠ The two `F401`s ruff reports on this file **pre-exist at HEAD** and are in imports this PR does not touch; CI lints `src/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)