### PR TITLE
feat(languages): html as a text-searchable file class (zero symbols) - the accepted half of #452

### DIFF
--- a/src/jcodemunch_mcp/parser/languages.py
+++ b/src/jcodemunch_mcp/parser/languages.py
@@ -247,6 +247,8 @@ LANGUAGE_EXTENSIONS = {
     ".swagger.yaml": "openapi",
     ".swagger.yml": "openapi",
     ".swagger.json": "openapi",
+    ".html": "html",
+    ".htm": "html",
 }
 
 
@@ -1947,6 +1949,30 @@ DLANG_SPEC = LanguageSpec(
 )
 
 
+# HTML: a text-searchable FILE class, deliberately emitting no symbols
+# (jcm#452 triage). Empty symbol_node_types means an indexed .html contributes
+# zero entries to index.symbols, so symbol-driven consumers (find_dead_code's
+# per-symbol sweep, health-radar axes, importance/Gini maths) are unaffected;
+# what changes is that the file itself enters index.source_files, which is what
+# flow_edges._resolve_template needs to resolve render("page.html") edges.
+# Rides the same bundled html grammar RAZOR_SPEC already uses.
+# Known interaction, stated rather than discovered from a grade change: an
+# indexed .html with no importers is still a dead FILE under the current rule;
+# teaching find_dead_code to honour render edges is a separate issue.
+HTML_SPEC = LanguageSpec(
+    ts_language="html",
+    symbol_node_types={},
+    name_fields={},
+    param_fields={},
+    return_type_fields={},
+    docstring_strategy="preceding_comment",
+    decorator_node_type=None,
+    container_node_types=[],
+    constant_patterns=[],
+    type_patterns=[],
+)
+
+
 # Language registry
 LANGUAGE_REGISTRY = {
     "python": PYTHON_SPEC,
@@ -2024,6 +2050,7 @@ LANGUAGE_REGISTRY = {
     "nim": NIM_SPEC,
     "tcl": TCL_SPEC,
     "dlang": DLANG_SPEC,
+    "html": HTML_SPEC,
 }
 
 # Template-engine languages (jinja/twig) all route through the

--- a/tests/test_html_file_class.py
+++ b/tests/test_html_file_class.py
@@ -1,0 +1,92 @@
+"""HTML as a text-searchable file class (jcm#452, HTML half).
+
+`.html`/`.htm` register on the bundled html grammar with EMPTY
+symbol_node_types: an indexed template contributes zero symbols (so
+symbol-driven consumers — find_dead_code's per-symbol sweep, the health-radar
+axes, importance maths — are unaffected) but the FILE enters
+``index.source_files``, which is what ``flow_edges._resolve_template`` needs.
+
+The test that makes this change worth having is
+``test_resolve_template_resolves_indexed_html``: before this feature,
+``_resolve_template(index, "page.html")`` returns ``None`` on every Django/
+Flask/Express/Rails repo because the template file never enters the index —
+the ``views`` annotation on ``get_signal_chains`` and the render edges in
+``get_endpoint_impact`` degrade silently. Registry-coverage assertions alone
+would pass just as happily against a version that resolves nothing.
+"""
+from pathlib import Path
+
+from jcodemunch_mcp.parser.extractor import parse_file
+from jcodemunch_mcp.parser.languages import (
+    LANGUAGE_REGISTRY,
+    get_language_for_path,
+    get_language_extensions,
+)
+from jcodemunch_mcp.storage import IndexStore
+from jcodemunch_mcp.tools.flow_edges import _resolve_template
+from jcodemunch_mcp.tools.index_folder import index_folder
+
+
+_HTML_DOC = """<!doctype html>
+<html>
+  <head><title>Probe</title></head>
+  <body>
+    <h1>Rendered template</h1>
+    <p>A needle for text search: osprey-template-probe.</p>
+  </body>
+</html>
+"""
+
+
+def test_html_extensions_in_registry():
+    ext = get_language_extensions()
+    assert ext[".html"] == "html"
+    assert ext[".htm"] == "html"
+    assert "html" in LANGUAGE_REGISTRY
+    assert get_language_for_path("templates/index.html") == "html"
+
+
+def test_html_emits_no_symbols():
+    """Empty symbol_node_types: a parsed .html contributes nothing to
+    index.symbols — the file class is text-searchable, not a symbol source."""
+    assert parse_file(_HTML_DOC, "page.html", "html") == []
+
+
+def _indexed(tmp_path: Path):
+    src = tmp_path / "src"
+    (src / "templates").mkdir(parents=True)
+    (src / "app.py").write_text(
+        "def home(request):\n"
+        "    return render(request, \"page.html\")\n",
+        encoding="utf-8",
+    )
+    (src / "templates" / "page.html").write_text(_HTML_DOC, encoding="utf-8")
+    store = tmp_path / "store"
+    store.mkdir()
+    result = index_folder(str(src), use_ai_summaries=False, storage_path=str(store))
+    assert result["success"], result
+    owner, name = result["repo"].split("/", 1)
+    return IndexStore(base_path=str(store)).load_index(owner, name), result
+
+
+def test_resolve_template_resolves_indexed_html(tmp_path):
+    """THE proof: _resolve_template resolves a template it returns None for
+    without this feature (the .html never entered index.source_files)."""
+    index, _ = _indexed(tmp_path)
+    assert "templates/page.html" in index.source_files
+    assert _resolve_template(index, "page.html") == "templates/page.html"
+    # Suffix-path form used by Django/Flask render calls resolves too.
+    assert _resolve_template(index, "templates/page.html") == "templates/page.html"
+
+
+def test_indexed_html_adds_file_but_no_symbols(tmp_path):
+    """The dead-file interaction, stated as an assertion: the html file is
+    indexed (file-level counts move by one file class) while symbol counts
+    stay untouched — no .html-derived entries appear in index.symbols."""
+    index, result = _indexed(tmp_path)
+    html_symbols = [
+        s for s in index.symbols
+        if str(s.get("file") or s.get("filename") or "").endswith(".html")
+    ]
+    assert html_symbols == []
+    assert "templates/page.html" in result.get("no_symbols_files", [])

--- a/tests/test_plan_refactoring.py
+++ b/tests/test_plan_refactoring.py
@@ -1720,8 +1720,10 @@ class TestLanguageCoverage:
 
         # Data formats and templating engines are exempt — they have no import
         # syntax of their own (a template refactor uses the underlying language).
+        # html is a text-searchable file class emitting no symbols (jcm#452),
+        # so there is nothing for refactor patterns to find.
         from jcodemunch_mcp.parser.template_shared import TEMPLATE_ENGINE_LANGUAGES
-        exempt = {"toml", "xml", "json", "yaml", "ansible", "openapi"} | set(TEMPLATE_ENGINE_LANGUAGES)
+        exempt = {"toml", "xml", "json", "yaml", "ansible", "openapi", "html"} | set(TEMPLATE_ENGINE_LANGUAGES)
         expected = registry_langs - exempt
         missing = expected - import_langs
 
@@ -1738,8 +1740,9 @@ class TestLanguageCoverage:
 
         # Data formats and templating engines are exempt — they have no symbol
         # definitions of their own (a template refactor uses the underlying language).
+        # html is a text-searchable file class emitting no symbols (jcm#452).
         from jcodemunch_mcp.parser.template_shared import TEMPLATE_ENGINE_LANGUAGES
-        exempt = {"toml", "xml", "json", "yaml", "ansible", "openapi"} | set(TEMPLATE_ENGINE_LANGUAGES)
+        exempt = {"toml", "xml", "json", "yaml", "ansible", "openapi", "html"} | set(TEMPLATE_ENGINE_LANGUAGES)
         expected = registry_langs - exempt
         missing = expected - def_langs
 


### PR DESCRIPTION
Closes #452 (the accepted HTML half, scoped per your triage). Supersedes #454, which I'll close pointing here.

## What

`.html` / `.htm` register on the bundled html grammar — the one `RAZOR_SPEC` already rides, so no new dependency — with **empty `symbol_node_types`**: an indexed template contributes zero entries to `index.symbols`. Symbol-driven consumers (`find_dead_code`'s per-symbol sweep, the health-radar axes, the importance/Gini maths) see nothing new. What changes is that the file enters `index.source_files`.

## The test that makes it worth having

`test_resolve_template_resolves_indexed_html` proves the claim from the triage directly: on current `main`, `flow_edges._resolve_template(index, "page.html")` returns `None` because the template never enters the index — verified red/green by stashing the `languages.py` hunk and re-running (fails on pristine main, passes with the change). Registry-coverage assertions are there too, but as you said, they'd pass just as happily against a version that resolves nothing.

Also asserted rather than implied: a parsed `.html` yields `[]` symbols, and an indexed repo's `index.symbols` contains no `.html`-derived entries while `no_symbols_files` carries the template.

## Dead-file interaction (stated, not discovered)

An indexed `.html` with no importers is still a dead **file** under the current rule — one file class, zero symbols, but the file-level count moves. The `HTML_SPEC` comment in `languages.py` states this in place; teaching `find_dead_code` to honour render edges is a separate issue, as you proposed.

## Collateral edit

`html` joins the data-format exemption set in `test_plan_refactoring`'s LanguageCoverage tests (no import syntax, no symbols for refactor patterns to find) — one edit, commented with the reason.

## Tests

Rebased on `main` @ v1.108.275 (`e35e4ae`). Full suite with `PYTHONPATH=src` on Windows 11: **7737 passed, 0 failed, 31 skipped**. Worth noting: the 13 environment-dependent failures I reported on #454 no longer reproduce on current `main` on the same machine — whatever landed between v1.108.274 and now fixed that family, so I'm not filing those issues unless you want a record of the old set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
