### PR TITLE
fix(dead-code): treat a render edge as a reachability edge (#461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog
 
+## [Unreleased] - Two subsystems reading one index disagreed, and the wrong one had no hedge
+
+### `find_dead_code` reported a rendered template as dead at confidence 1.0 ([#461](https://github.com/jgravelle/jcodemunch-mcp/issues/461))
+
+A template is never *imported*. It is reached by a render edge — a string
+argument (`render(request, "page.html")`) that `flow_edges` resolves to a file.
+`find_dead_code` classified purely from the import graph, so an actively
+rendered template came back `zero_importers` while
+`flow_edges._resolve_template` resolved that same file from the same index in
+the same process.
+
+Resolved render edges now contribute live roots, surfaced separately as
+`render_reachable_count` and an analysis note: a file kept alive by an inbound
+render edge is reachable for a *different reason* than one that looks like an
+entry point, and a caller auditing the verdict could not otherwise tell them
+apart from a single count.
+
+⚠⚠ **The confidence value is the sharp part, not the misclassification.** `1.0`
+is reserved for "no importers and not a test file" — a test file gets `0.9`, a
+cascading case `0.7`. So the one file class indexed *because* another subsystem
+can prove it reachable was reported dead with no hedge attached, above the
+default `min_confidence` of `0.8`, meaning it could not be filtered out without
+discarding genuine findings too. **A wrong answer delivered at maximum certainty
+is worse than the same wrong answer delivered tentatively**, because the
+confidence is exactly what a caller uses to decide whether to look.
+
+⚠ **Deliberately NOT an extension exemption**, and two tests exist to fail
+against one. A template that nothing renders **is** dead and is still reported;
+`.html` is not special, having an inbound render edge is. An exemption would
+trade a false positive for a false negative — the worse direction, because
+silence reads as "nothing found" — and would not generalise to the other edge
+families `resolve_flow_edges` already emits.
+
+⚠ **This is not a regression from [#459](https://github.com/jgravelle/jcodemunch-mcp/pull/459) and that PR is not the cause.** Before the HTML
+file class, `.html` was not indexed, so it could not be reported dead — it also
+could not be resolved, which is the silent degradation
+[#452](https://github.com/jgravelle/jcodemunch-mcp/issues/452) was accepted to
+fix. The trade was made knowingly and stated in a comment at `HTML_SPEC`.
+
+⚠ **Two corrections to the issue's own text, made rather than quietly
+contradicted.** It claimed this would newly introduce content scanning to a tool
+that "reads only the import graph"; `find_dead_code` already reads file content
+at two sites (`_package_json_entries`, the `__main__` guard), so the fix is
+always-on and the design question the issue raised does not arise. It also
+flagged the observatory-grade question as unmeasured; measured, templates emit no
+symbols and `dead_symbol_count` is 0, so the symbol-driven `dead_code` radar axis
+does not move.
+
+⚠ Scope checked rather than assumed: **`get_dead_code_v2` does not share this
+defect.** It returns symbols only and templates emit none — 0 template-derived
+entries on the reproduction. Worth stating because
+[#446](https://github.com/jgravelle/jcodemunch-mcp/issues/446) went the other
+way, where both dead-code tools needed the same fix and doing one would have been
+half a job.
+
+The resolver call degrades to the previous behaviour and logs at debug on
+failure: a flow-edge resolution problem must never fail this tool.
+
 ## [1.108.276] - 2026-08-13 - A Windows drive-root child can prove it is a repository
 
 ### Exact Git working trees no longer trip the broad-root guard ([#438](https://github.com/jgravelle/jcodemunch-mcp/issues/438))

--- a/src/jcodemunch_mcp/tools/find_dead_code.py
+++ b/src/jcodemunch_mcp/tools/find_dead_code.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import fnmatch
 import json
+import logging
 import re
 import time
 from typing import Optional
@@ -12,6 +13,8 @@ from ..storage import IndexStore
 from ..parser.imports import resolve_specifier
 from ._utils import index_status_to_tool_error, resolve_repo
 from ..parser.context._route_utils import ENTRY_POINT_DECORATOR_RE
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -250,6 +253,42 @@ def find_dead_code(
     live_roots.update(pkg_entries)
 
     # -----------------------------------------------------------------------
+    # Phase 1b: render-edge reachability (#461)
+    # -----------------------------------------------------------------------
+    # A template is never IMPORTED. It is reached by a render edge — a string
+    # argument (`render(request, "page.html")`) that `flow_edges` resolves to a
+    # file. Classifying from the import graph alone therefore reports an
+    # actively-rendered template as `zero_importers` at confidence 1.0, the
+    # value reserved for "no importers and not a test file", while
+    # `_resolve_template` resolves that same file from the same index in the
+    # same process. Two subsystems disagreeing is bad; the one that was wrong
+    # being the one with no hedge is worse.
+    #
+    # ⚠ This is deliberately NOT an extension exemption. A template that
+    # nothing renders IS dead and must still be reported — `.html` is not
+    # special, having an inbound render edge is. An exemption would suppress
+    # the true positives with the false ones and would not generalise to the
+    # other edge families `resolve_flow_edges` already emits.
+    #
+    # ⚠ Always-on rather than behind a parameter: this tool ALREADY reads file
+    # content in two places (package.json entries above, the `__main__` guard
+    # in Phase 2), so consulting a content-scanning resolver introduces no new
+    # class of work. The issue text originally claimed otherwise and was wrong.
+    render_reachable: set[str] = set()
+    try:
+        from .flow_edges import resolve_flow_edges
+
+        for edge in resolve_flow_edges(index, store, owner, name, kinds=("render",)):
+            if edge.get("resolution") != "resolved":
+                continue
+            dst = edge.get("dst_file")
+            if dst and dst in source_files:
+                render_reachable.add(dst)
+    except Exception:  # pragma: no cover - resolver must never fail the tool
+        logger.debug("render-edge reachability pass failed", exc_info=True)
+    live_roots.update(render_reachable)
+
+    # -----------------------------------------------------------------------
     # Phase 2: content check for `if __name__ == "__main__"` (Python only,
     # only for files not yet classified as live and with zero importers)
     # -----------------------------------------------------------------------
@@ -350,6 +389,14 @@ def find_dead_code(
     ]
     if sample_roots:
         analysis_notes.append(f"Sample entry points: {', '.join(sample_roots)}")
+    # Surfaced separately from the entry-point total (#461): a file kept alive by
+    # an inbound render edge is reachable for a different reason than a file that
+    # looks like an entry point, and a caller auditing this tool's verdict cannot
+    # tell them apart from a single count.
+    if render_reachable:
+        analysis_notes.append(
+            f"Reachable via render edges (not imports): {len(render_reachable)}"
+        )
 
     result: dict = {
         "repo": f"{owner}/{name}",
@@ -360,6 +407,7 @@ def find_dead_code(
         "dead_file_count": len(dead_files),
         "dead_symbol_count": len(dead_symbols),
         "live_root_count": len(live_roots),
+        "render_reachable_count": len(render_reachable),
         "analysis_notes": analysis_notes,
         "_meta": {"timing_ms": round(elapsed, 1)},
     }

--- a/tests/test_v1_108_277.py
+++ b/tests/test_v1_108_277.py
@@ -1,0 +1,139 @@
+"""Render-edge reachability in ``find_dead_code`` (jcm#461).
+
+A template is never IMPORTED. It is reached by a render edge — a string argument
+(``render(request, "page.html")``) that ``flow_edges`` resolves to a file. Before
+this change, ``find_dead_code`` classified purely from the import graph, so an
+actively-rendered template came back ``zero_importers`` at **confidence 1.0** —
+the value reserved for "no importers and not a test file" — while
+``flow_edges._resolve_template`` resolved that same file from the same index in
+the same process.
+
+⚠ The load-bearing test here is ``test_unrendered_template_is_still_dead``. It is
+what distinguishes this fix from a blanket ``.html`` exemption, which would pass
+every other test in this file while suppressing true positives. `.html` is not
+special; having an inbound render edge is.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from jcodemunch_mcp.storage import IndexStore
+from jcodemunch_mcp.tools.find_dead_code import find_dead_code
+from jcodemunch_mcp.tools.flow_edges import _resolve_template
+from jcodemunch_mcp.tools.index_folder import index_folder
+
+
+_TEMPLATE = """<!doctype html>
+<html><body><h1>A template</h1></body></html>
+"""
+
+
+def _build(tmp_path: Path, *, render: bool, extra_template: bool = False):
+    """Index a Django-shaped repo. ``render`` controls whether the view
+    actually renders the template, which is the only thing under test."""
+    src = tmp_path / "src"
+    (src / "templates").mkdir(parents=True)
+    body = (
+        '    return render(request, "page.html")\n'
+        if render
+        else "    return None\n"
+    )
+    (src / "app.py").write_text(
+        "from django.shortcuts import render\n\n"
+        "def home(request):\n" + body,
+        encoding="utf-8",
+    )
+    (src / "templates" / "page.html").write_text(_TEMPLATE, encoding="utf-8")
+    if extra_template:
+        # Never referenced by any render call anywhere in the repo.
+        (src / "templates" / "orphan.html").write_text(_TEMPLATE, encoding="utf-8")
+
+    store_dir = tmp_path / "store"
+    store_dir.mkdir()
+    result = index_folder(str(src), use_ai_summaries=False, storage_path=str(store_dir))
+    assert result["success"], result
+    return result["repo"], str(store_dir)
+
+
+def _dead_files(repo: str, storage: str) -> dict[str, dict]:
+    out = find_dead_code(repo, granularity="file", storage_path=storage)
+    assert "error" not in out, out
+    return {d["file"]: d for d in out.get("dead_files", [])}, out
+
+
+def test_rendered_template_is_not_dead(tmp_path):
+    """THE regression: a template an indexed view renders is reachable."""
+    repo, storage = _build(tmp_path, render=True)
+    dead, out = _dead_files(repo, storage)
+    assert "templates/page.html" not in dead, (
+        "an actively-rendered template was reported dead; dead_files=%r" % list(dead)
+    )
+    assert out["render_reachable_count"] == 1
+
+
+def test_unrendered_template_is_still_dead(tmp_path):
+    """The guard against an extension exemption.
+
+    ⚠ A ``.html``-is-exempt implementation passes every other test in this file
+    and fails this one. A template nothing renders IS dead and must still be
+    reported — otherwise the fix trades a false positive for a false negative,
+    which is the worse direction because silence reads as 'nothing found'.
+    """
+    repo, storage = _build(tmp_path, render=False)
+    dead, out = _dead_files(repo, storage)
+    assert "templates/page.html" in dead
+    assert dead["templates/page.html"]["reason"] == "zero_importers"
+    assert out["render_reachable_count"] == 0
+
+
+def test_only_the_rendered_template_is_rescued(tmp_path):
+    """Two templates, one rendered: the rescue is edge-driven, not per-extension."""
+    repo, storage = _build(tmp_path, render=True, extra_template=True)
+    dead, out = _dead_files(repo, storage)
+    assert "templates/page.html" not in dead
+    assert "templates/orphan.html" in dead, (
+        "an unrendered sibling was rescued, which means the rule keyed on the "
+        "file class rather than on the render edge"
+    )
+    assert out["render_reachable_count"] == 1
+
+
+def test_render_edge_resolves_for_the_same_index(tmp_path):
+    """Pins the premise the whole fix rests on: flow_edges CAN resolve this.
+
+    If this fails, the disagreement #461 describes no longer exists and the
+    reachability pass above is answering a question nobody is asking.
+    """
+    repo, storage = _build(tmp_path, render=True)
+    owner, name = repo.split("/", 1)
+    index = IndexStore(base_path=storage).load_index(owner, name)
+    assert _resolve_template(index, "page.html") == "templates/page.html"
+
+
+def test_analysis_note_names_render_reachability(tmp_path):
+    """The two reachability kinds must stay tellable apart in output.
+
+    ⚠ Asserts the COUNT and the fact a note exists, not its exact wording —
+    binding a test to prose makes editing the message expensive and pins
+    spelling rather than effect.
+    """
+    repo, storage = _build(tmp_path, render=True)
+    out = find_dead_code(repo, granularity="file", storage_path=storage)
+    assert out["render_reachable_count"] == 1
+    assert any("render" in note.lower() for note in out["analysis_notes"])
+
+
+def test_repo_without_templates_is_unaffected(tmp_path):
+    """Control: the pass must not perturb a repo it has nothing to say about."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "app.py").write_text("def home():\n    return 1\n", encoding="utf-8")
+    (src / "orphan.py").write_text("def unused():\n    return 2\n", encoding="utf-8")
+    store_dir = tmp_path / "store"
+    store_dir.mkdir()
+    r = index_folder(str(src), use_ai_summaries=False, storage_path=str(store_dir))
+    assert r["success"], r
+    out = find_dead_code(r["repo"], granularity="file", storage_path=str(store_dir))
+    assert out["render_reachable_count"] == 0
+    # orphan.py is genuinely dead and must still be reported.
+    assert any(d["file"] == "orphan.py" for d in out["dead_files"])


### PR DESCRIPTION
Closes #461.

## What was wrong

`find_dead_code` classified purely from the import graph. A template is never *imported* — it is reached by a render edge, a string argument that `flow_edges` resolves to a file. So an actively-rendered template came back:

```
templates/page.html | zero_importers | confidence: 1.0
```

while `_resolve_template(index, "page.html")` resolved that same file from the same index in the same process.

⚠ **The confidence is the sharp part.** `1.0` is reserved for "no importers and not a test file" — a test file gets `0.9`, a cascading case `0.7`. So the one file class we index *because* another subsystem can prove it reachable was reported dead with no hedge, above the default `0.8` threshold, meaning it could not be filtered out without discarding genuine findings too.

## The fix

Resolved render edges contribute live roots, in a new Phase 1b beside the existing entry-point and `package.json` passes.

`render_reachable_count` and an analysis note surface it separately from the entry-point total: a file kept alive by an inbound render edge is reachable for a *different reason* than one that looks like an entry point, and a caller auditing the verdict could not otherwise tell the two apart from a single number.

## What this is not

⚠⚠ **Not an extension exemption**, and two tests exist specifically to fail against one. A template that nothing renders **is** dead and is still reported — `.html` is not special, having an inbound render edge is. An exemption would trade a false positive for a false negative, which is the worse direction because silence reads as "nothing found", and it would not generalise to the other edge families `resolve_flow_edges` already emits.

- `test_unrendered_template_is_still_dead` — same repo, view does not render; template must still come back `zero_importers`.
- `test_only_the_rendered_template_is_rescued` — two templates, one rendered; the sibling must stay dead.

## Two corrections to my own issue text

⚠ **The cost objection I raised was wrong.** #461 said this would make a tool that "currently reads only the import graph" depend on a content-scanning resolver. `find_dead_code` already reads file content at two sites — `_package_json_entries` (`:115`) and the `__main__` guard (`:261`). No new class of work is introduced, so this is always-on rather than behind a parameter. Corrected on the issue rather than left standing.

⚠ **The observatory-grade question is now measured rather than expected.** The issue said the `dead_code` radar axis is symbol-driven so this "probably" does not move a published grade, and flagged that as reasoning rather than measurement. Confirmed: templates emit no symbols, `dead_symbol_count` is 0 on the reproduction.

## Scope, checked rather than assumed

`get_dead_code_v2` **does not share this defect.** It returns `dead_symbols` only — functions and methods — and templates emit none. Measured on the reproduction: 0 template-derived entries, 0 total. Worth stating explicitly because #446 went the other way, where both dead-code tools needed the same message and fixing one would have been half a fix.

## Verification

- **Falsification pass run before trusting the tests.** Reverting `find_dead_code.py` to `main` makes `test_rendered_template_is_not_dead` fail with an **AssertionError** — the real defect — not a missing-key error. `test_render_edge_resolves_for_the_same_index` passes on both sides by design: it pins the premise the whole fix rests on, so if it ever fails the disagreement no longer exists and this pass is answering a question nobody is asking.
- **Suite: 7773 passed, 9 skipped, 0 failed.** `uv run ruff check src/` clean.
- Reconciled by same-tree collect rather than arithmetic: **7782 total, 7776 without `test_v1_108_277.py`** (= its 6), and 7776 is exactly the post-#459 total. Nothing else moved.
- Tests go end-to-end through `find_dead_code`, not the helper. ⚠ Both #446 gaps were found because an end-to-end test landed on a fallback by accident while every helper-level test passed.

⚠ The resolver call is wrapped and logs at debug on failure: a flow-edge resolution problem must degrade this tool to its previous behaviour, never fail the call.
