### PR TITLE
test(changelog): fail on a version heading that is not line-anchored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15816,7 +15816,7 @@ Thanks to **@MariusAdrian88** for this contribution (#244).
 - **`cross_repo_default` config key** — boolean default for the `cross_repo` parameter across all import graph tools. Env var: `JCODEMUNCH_CROSS_REPO_DEFAULT`. Default: `false`.
 - **53 new tests** (1431 total, 9 skipped).
 
-## [1.12.9] — docs patch 2026-03-30
+## Docs patch — 2026-03-30 (no version bump)
 
 ### Changed
 - **QUICKSTART.md Step 3** — upgraded AGENT_HOOKS.md footnote to an `[!IMPORTANT]` callout naming the "pressure bypass" failure mode (agent sees CLAUDE.md rule, ignores it under load) and explaining why hooks are needed for hard enforcement.

--- a/tests/test_claude_md_rotation.py
+++ b/tests/test_claude_md_rotation.py
@@ -42,6 +42,63 @@ def _changelog_versions() -> list[str]:
     return re.findall(r"^## \[(\d+\.\d+\.\d+)\]", text, re.MULTILINE)
 
 
+# ---------------------------------------------------------------------------
+# Heading well-formedness (2026-08-13)
+# ---------------------------------------------------------------------------
+#
+# ⚠⚠ Every check above matches `^## \[...\]` -- LINE-ANCHORED. A heading fused
+# to the end of a preceding paragraph is invisible to all of them, so the file
+# can be visibly corrupt while the whole gate passes.
+#
+# Demonstrated, not hypothetical. On 2026-08-13 a rebase on PR #451 dropped the
+# `1.108.273` section; the restore then re-inserted it TWICE -- once correctly,
+# and once fused to the `.274` section's closing sentence:
+#
+#     open against it.## [1.108.273] - 2026-08-12 - A pattern that names two ...
+#
+# The rotation gate found exactly one well-formed `.273`, agreed with CLAUDE.md's
+# boundary, and passed on all nine CI jobs over a changelog that rendered `.274`
+# ending mid-sentence followed by a duplicate release section.
+#
+# ⚠ The maintainer review missed it for the SAME reason: the fix was verified
+# with a line-anchored regex, i.e. the same instrument as the gate, carrying the
+# same blind spot. It reported "byte-identical, nothing lost, 517 versions both
+# sides" -- all true, and all blind to duplication. **A check that shares an
+# assumption with the thing it checks is not independent evidence.** These two
+# functions exist to break that shared assumption: `_glued_headings` deliberately
+# does NOT anchor, and `_duplicate_versions` counts rather than compares.
+
+_ANY_VERSION_HEADING = re.compile(r"## \[(\d+\.\d+\.\d+)\]")
+
+
+def _glued_headings(text: str) -> list[str]:
+    """Version headings that are not at the start of a line.
+
+    Deliberately UNANCHORED -- that is the entire point. Returns the offending
+    line's text (trimmed) for each, so a failure names what to look for rather
+    than only a count.
+    """
+    out: list[str] = []
+    for m in _ANY_VERSION_HEADING.finditer(text):
+        if m.start() == 0 or text[m.start() - 1] == "\n":
+            continue
+        line_start = text.rfind("\n", 0, m.start()) + 1
+        line_end = text.find("\n", m.start())
+        out.append(text[line_start: line_end if line_end != -1 else len(text)].strip()[:120])
+    return out
+
+
+def _duplicate_versions(versions: list[str]) -> list[str]:
+    """Versions whose heading appears more than once, in first-seen order."""
+    seen: set[str] = set()
+    dupes: list[str] = []
+    for v in versions:
+        if v in seen and v not in dupes:
+            dupes.append(v)
+        seen.add(v)
+    return dupes
+
+
 def _claude_md() -> str:
     return (ROOT / "CLAUDE.md").read_text(encoding="utf-8")
 
@@ -108,3 +165,91 @@ def test_older_releases_boundary_starts_below_the_rotation():
         assert boundary == expected, (
             f"boundary says {boundary}; the release below the rotation is {expected}."
         )
+
+
+# ---------------------------------------------------------------------------
+# Heading well-formedness gate (2026-08-13, from PR #451)
+# ---------------------------------------------------------------------------
+
+def test_no_version_heading_is_fused_to_a_paragraph():
+    """A `## [X.Y.Z]` heading must start its own line.
+
+    ⚠ This is the one check in this file that does NOT anchor its pattern.
+    Every other check here would pass over the exact corruption it catches.
+    """
+    text = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    glued = _glued_headings(text)
+    assert not glued, (
+        "CHANGELOG.md has version heading(s) fused to the preceding text, so "
+        "they render as body copy and are invisible to every line-anchored "
+        f"check in this file: {glued}"
+    )
+
+
+def test_no_release_section_appears_twice():
+    """A released version may head exactly one section.
+
+    A duplicate is what a re-inserted section looks like when the first attempt
+    was not fully removed. Counting catches it; comparing against `main` does
+    not, because both copies are byte-identical to the original.
+    """
+    versions = _changelog_versions()
+    dupes = _duplicate_versions(versions)
+    assert not dupes, f"CHANGELOG.md heads these versions more than once: {dupes}"
+
+
+# --- non-vacuity: prove both predicates fire on the real 2026-08-13 shape ----
+
+_CORRUPT_FIXTURE = """# Changelog
+
+## [1.108.276] - 2026-08-13 - A title
+
+Body text of the newest release.
+
+## [1.108.274] - 2026-08-12 - Another title
+
+with @elfrost's [PR #443](https://example.invalid/pull/443)
+open against it.## [1.108.273] - 2026-08-12 - A pattern that names two extensions
+
+Duplicated body.
+
+## [1.108.273] - 2026-08-12 - A pattern that names two extensions
+
+Duplicated body.
+"""
+
+
+def test_glued_heading_predicate_fires_on_the_known_bad_shape():
+    """⚠ Guards against the gate being written so it cannot fail.
+
+    The fixture is the real shape from PR #451, not an invented one.
+    """
+    glued = _glued_headings(_CORRUPT_FIXTURE)
+    assert len(glued) == 1
+    assert glued[0].startswith("open against it.## [1.108.273]")
+
+
+def test_duplicate_predicate_fires_on_the_known_bad_shape():
+    """The line-anchored extractor sees ONE `.273` in the fixture, which is
+    exactly why the duplicate check alone would not have caught this and the
+    glued check is the load-bearing half."""
+    anchored = re.findall(r"^## \[(\d+\.\d+\.\d+)\]", _CORRUPT_FIXTURE, re.MULTILINE)
+    assert anchored.count("1.108.273") == 1, (
+        "if this ever counts 2, the fixture no longer reproduces the failure "
+        "mode -- the whole point is that the fused copy is invisible to an "
+        "anchored pattern"
+    )
+    assert _duplicate_versions(anchored) == []
+
+
+def test_both_predicates_pass_on_a_clean_changelog():
+    """Control: neither predicate fires on well-formed input, so a green result
+    on the real file means something."""
+    clean = _CORRUPT_FIXTURE.replace(
+        "open against it.## [1.108.273] - 2026-08-12 - A pattern that names two extensions\n\nDuplicated body.\n\n",
+        "open against it.\n\n",
+    )
+    assert _glued_headings(clean) == []
+    assert _duplicate_versions(
+        re.findall(r"^## \[(\d+\.\d+\.\d+)\]", clean, re.MULTILINE)
+    ) == []


### PR DESCRIPTION
Closes the gap found while reviewing [#451](https://github.com/jgravelle/jcodemunch-mcp/pull/451). Test-only plus a one-line `CHANGELOG.md` correction; no behaviour change.

## The gap

Every check in `test_claude_md_rotation.py` matched `^## \[...\]` — **line-anchored**. A version heading fused to the end of a preceding paragraph is invisible to all of them.

On 2026-08-13 a rebase on #451 dropped the `1.108.273` section. The restore re-inserted it **twice** — once correctly, and once fused to the `.274` section's closing sentence:

```
with @elfrost's [PR #443](...)
open against it.## [1.108.273] - 2026-08-12 - A pattern that names two extensions and matches neither
```

The gate found exactly one well-formed `.273`, agreed with `CLAUDE.md`'s boundary, and **passed on all nine CI jobs** over a changelog that rendered `.274` ending mid-sentence followed by a duplicate release section.

⚠⚠ **The maintainer review missed it for the same reason, and that is the part worth recording.** The fix was verified with a line-anchored regex — the same instrument as the gate, carrying the same blind spot — and reported as "byte-identical to main, nothing lost, 517 versions both sides". Every one of those statements was true, and every one was blind to duplication. **A check that shares an assumption with the thing it checks is not independent evidence.** It surfaced only because `gh pr diff` rendered the fused line and contradicted the grep; had both tools agreed, a corrupt file merges on a green build.

## What is added

Two predicates, each built to break that shared assumption:

- **`_glued_headings`** — deliberately **unanchored**, the only such pattern in the file. Returns the offending line text, so a failure names what to look for rather than emitting a count.
- **`_duplicate_versions`** — **counts** rather than compares against a reference, because both copies were byte-identical to the original and a comparison cannot see that.

## Non-vacuity

The fixture is #451's real shape, not an invented one, and three tests guard the guard:

- `test_glued_heading_predicate_fires_on_the_known_bad_shape` — the predicate fires.
- `test_duplicate_predicate_fires_on_the_known_bad_shape` — asserts the **anchored** extractor still sees only **one** `.273` in that fixture. ⚠ If a later "simplification" makes the fixture catchable by an anchored pattern, this fails loudly instead of silently retiring the reproduction — which is how a guard quietly stops guarding.
- `test_both_predicates_pass_on_a_clean_changelog` — control, so a green result on the real file means something.

## It found a real defect on its first run

`1.12.9` headed **two** sections: the actual release (2026-03-29) and a docs patch (2026-03-30). That patch was never a shipped version — `1.12.9` went out the day before and `1.13.0` the same day — so the heading claimed a version it did not own, and `_changelog_versions()` has been double-counting it for five months.

Retitled to `## Docs patch — 2026-03-30 (no version bump)`. **No content moved, no history rewritten**, only the false version claim dropped. Every word of the patch notes is preserved in place.

⚠ This is the second gate in a week to fire on our own tree on first run (`test_security_disclosure.py` did it in 1.108.274). Worth reading as a pattern rather than a coincidence: hand-maintained conventions drift, and a gate written for a contributor's mistake tends to find one of ours.

## Verification

- Suite **7778 passed, 9 skipped, 0 failed**; `uv run ruff check src/` clean.
- Delta reconciles exactly: this file went 4 tests → 9, and post-#462 `main` was 7773. Nothing else moved.
- 39 passed across all changelog / whatsnew / provenance tests, confirming nothing else parses the retitled heading.
