### PR TITLE
fix(search): identity_type must not report exact for a normalised match (#458)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## [Unreleased]
+
+### `identity_type: "exact"` graded a normalised match ([#458](https://github.com/jgravelle/jcodemunch-mcp/issues/458))
+
+`_tokenize` folds case, strips leading underscores and drops punctuation, and the
+identity channel's tokenized comparison ran against that folded form. So for the
+query `_State`, a pytest fixture named `state` and the class literally named
+`_State` both scored `identity: 50.0, identity_type: "exact"`. The identity
+channel could not separate them, the tie fell through to BM25, and the shorter
+name with a docstring won by **0.355 points out of ~58** — a test fixture
+outranking the source symbol it tests, on the single highest-confidence query a
+caller can send.
+
+A match that needed normalisation now scores **40.0** and reports
+`identity_type: "normalized"`. Literal stays 50.0, prefix 30.0 and segment 20.0
+are untouched, so the tiering mechanism this uses already existed.
+
+⚠ **Case folding alone is still `exact`, and that boundary was the decision.**
+`raw_lower` has been case-folded since the channel arrived, so making case
+load-bearing would change the answer for every caller who types `getuser` for
+`getUser` — a behaviour change with no defect behind it. What drops a tier is a
+match that needed *more* than case. A caller passing only tokenized terms and no
+raw query keeps `exact`: with no raw spelling there is nothing to be literal
+about, and grading it down would report a distinction that was never measured —
+which is the defect, not the fix.
+
+⚠⚠ **The first version of the end-to-end test passed against the broken code**,
+and the reason generalises past this fix. BM25 normalises by document length, and
+on the real repo `_State` is a large class that scored *below* the two-line
+fixture on every lexical field (name 6.996 vs 8.012, signature 6.153 vs 7.389,
+summary 0.0 vs 5.992). A small synthetic class wins on lexical signals alone, so
+the ordering assertion held with or without the identity tier. The corpus in
+`tests/test_identity_normalized_tier.py` gives the class a long docstring of
+words unrelated to the query — length without a match — which is what the real
+class's own prose does. **4 of the 10 tests fail against `8cc01a0`**, including
+the ordering one; the 6 that pass both sides are the unchanged tiers and the
+term-only control.
+
+⚠ This was found by the `Retrieval-quality gate` failing on
+[PR #457](https://github.com/jgravelle/jcodemunch-mcp/pull/457), a telemetry-only
+change that cannot affect ranking: the replay harness indexes this repo, so a new
+test file changed the corpus and displaced the expected top-1. The gate's
+self-indexing sensitivity will keep producing false reds on ordinary test-adding
+PRs. **It also caught a defect nobody was looking for**, and neither half of that
+is addressed here.
+
 ## [1.108.277] - 2026-08-13 - Reachability is not only the import graph, and liveness is not only the PID
 
 ### `.html` / `.htm` are indexable as a text-searchable file class ([#452](https://github.com/jgravelle/jcodemunch-mcp/issues/452), [PR #459](https://github.com/jgravelle/jcodemunch-mcp/pull/459) by [@phantom-man](https://github.com/phantom-man))

--- a/src/jcodemunch_mcp/tools/search_symbols.py
+++ b/src/jcodemunch_mcp/tools/search_symbols.py
@@ -365,17 +365,35 @@ def _compute_centrality(
 
 
 def _identity_score(sym: dict, query_joined: str, raw_query: str = "") -> float:
-    """Identity channel: exact or prefix match on symbol name/ID.
+    """Identity channel: exact, normalised, or prefix match on symbol name/ID.
 
-    Returns a high score for exact matches and a decreasing score for
-    prefix matches by specificity.  Replaces the old ``50.0`` exact-name hack.
+    Returns a high score for exact matches and a decreasing score for weaker
+    identity matches by specificity.  Replaces the old ``50.0`` exact-name hack.
 
     Scoring:
       - Exact name match          → 50.0
       - Exact ID match            → 50.0
+      - Normalised name/ID match  → 40.0
       - Name starts with query    → 30.0
       - ID contains query segment → 20.0
       - No match                  →  0.0
+
+    ⚠ **The 40.0 tier is the whole point of #458 and it is easy to delete by
+    "simplification".** ``_tokenize`` folds case *and* strips leading
+    underscores and punctuation, so a pytest fixture named ``state`` and the
+    class literally named ``_State`` both reach the tokenized comparison for
+    the query ``_State``. Grading them alike put them at 50.0 apiece, and the
+    tie fell through to BM25, where the shorter name with a docstring won —
+    a test fixture outranking the source symbol it tests, by 0.355 points out
+    of ~58. A literal match must outrank a normalised one, and ``identity_type``
+    must not report ``exact`` for a grade it did not measure (#440's shape).
+
+    ⚠ **Case folding alone still counts as exact, deliberately.** ``raw_lower``
+    is already case-folded and has graded exact since the channel arrived, so
+    making case load-bearing would change the answer for every caller who types
+    ``getuser`` for ``getUser`` — a behaviour change with no defect behind it.
+    What drops to 40.0 is a match that needed *more* than case: an underscore,
+    a separator, anything ``_tokenize`` removed.
     """
     raw_lower = raw_query.lower() if raw_query else ""
     if not raw_lower and not query_joined:
@@ -389,7 +407,9 @@ def _identity_score(sym: dict, query_joined: str, raw_query: str = "") -> float:
 
     # Tokenized fallback preserves previous semantics for callers that only have terms.
     if query_joined == name_lower or query_joined == sym_id_lower:
-        return 50.0
+        # With no raw spelling there is nothing to be literal about, so the
+        # tokenized match is the best evidence available and stays exact.
+        return 50.0 if not raw_lower else 40.0
 
     # Prefix match on name (e.g. query "get_sym" matches "get_symbol_source")
     if query_joined and name_lower.startswith(query_joined):
@@ -511,6 +531,10 @@ def _bm25_breakdown(sym: dict, query_terms: list[str], idf: dict[str, float], av
     out["identity"] = identity
     if identity >= 50.0:
         out["identity_type"] = "exact"
+    elif identity >= 40.0:
+        # #458: the query matched only after tokenization folded case,
+        # underscores and punctuation away. Still a match, not an exact one.
+        out["identity_type"] = "normalized"
     elif identity >= 30.0:
         out["identity_type"] = "prefix"
     elif identity >= 20.0:

--- a/tests/test_identity_normalized_tier.py
+++ b/tests/test_identity_normalized_tier.py
@@ -1,0 +1,159 @@
+"""#458: `identity_type` reported "exact" for a match only tokenization made.
+
+The reproduction is a pytest fixture named `state` outranking the class literally
+named `_State` for the query `_State`. Both scored `identity: 50.0,
+identity_type: "exact"`, the identity channel could not separate them, and the
+tie fell through to BM25 — where the shorter name with a docstring wins. The
+margin was 0.355 points out of ~58, so the two were tied by construction and an
+unrelated text signal decided it.
+
+⚠ The end-to-end tests here go through `search_symbols`, not through
+`_identity_score`. The helper-level tests below are cheap and specific, and they
+would ALL have passed against a version where the tool still returned the fixture
+first — the ordering is the defect a caller experiences.
+"""
+
+from jcodemunch_mcp.tools.index_folder import index_folder
+from jcodemunch_mcp.tools.search_symbols import (
+    _bm25_breakdown,
+    _identity_score,
+    _tokenize,
+    search_symbols,
+)
+
+_FIXTURE = {"name": "state", "id": "tests/test_thing.py::state#function"}
+_CLASS = {"name": "_State", "id": "src/storage/token_tracker.py::_State#class"}
+
+
+def _tokenized(query: str) -> str:
+    return " ".join(_tokenize(query))
+
+
+class TestIdentityScoreTiers:
+    def test_literal_match_outscores_normalized_match(self):
+        query = "_State"
+        joined = _tokenized(query)
+
+        literal = _identity_score(_CLASS, joined, query)
+        normalized = _identity_score(_FIXTURE, joined, query)
+
+        assert literal == 50.0
+        assert normalized == 40.0
+        assert literal > normalized
+
+    def test_case_only_difference_is_still_exact(self):
+        """Case folding alone stays exact — no defect motivates changing it."""
+        sym = {"name": "getUser", "id": "src/api.py::getUser#function"}
+
+        assert _identity_score(sym, _tokenized("getuser"), "getuser") == 50.0
+
+    def test_term_only_caller_keeps_the_exact_grade(self):
+        """With no raw spelling there is nothing to be literal about."""
+        assert _identity_score(_FIXTURE, "state", raw_query="") == 50.0
+
+    def test_normalized_match_still_outscores_a_prefix(self):
+        prefix_sym = {"name": "state_machine", "id": "src/a.py::state_machine#function"}
+        query = "_State"
+        joined = _tokenized(query)
+
+        assert _identity_score(_FIXTURE, joined, query) > _identity_score(
+            prefix_sym, joined, query
+        )
+
+    def test_no_match_is_still_zero(self):
+        unrelated = {"name": "parse_file", "id": "src/p.py::parse_file#function"}
+
+        assert _identity_score(unrelated, _tokenized("_State"), "_State") == 0.0
+
+
+class TestIdentityTypeLabel:
+    def test_normalized_match_is_not_labelled_exact(self):
+        breakdown = _bm25_breakdown(_FIXTURE, _tokenize("_State"), {}, 1.0, raw_query="_State")
+
+        assert breakdown["identity"] == 40.0
+        assert breakdown["identity_type"] == "normalized"
+
+    def test_literal_match_is_labelled_exact(self):
+        breakdown = _bm25_breakdown(_CLASS, _tokenize("_State"), {}, 1.0, raw_query="_State")
+
+        assert breakdown["identity_type"] == "exact"
+
+    def test_prefix_and_none_labels_are_unchanged(self):
+        prefix_sym = {"name": "state_machine", "id": "src/a.py::state_machine#function"}
+        unrelated = {"name": "parse_file", "id": "src/p.py::parse_file#function"}
+
+        assert (
+            _bm25_breakdown(prefix_sym, _tokenize("state"), {}, 1.0, raw_query="state")[
+                "identity_type"
+            ]
+            == "prefix"
+        )
+        assert (
+            _bm25_breakdown(unrelated, _tokenize("_State"), {}, 1.0, raw_query="_State")[
+                "identity_type"
+            ]
+            == "none"
+        )
+
+
+def _seed_state_collision(tmp_path):
+    """The #458 corpus: a private class and a same-after-normalization fixture.
+
+    ⚠ **The class's long docstring is load-bearing and is not decoration.** BM25
+    normalizes by document length, so on the real repo `_State` — a large class
+    with a rich summary — scored BELOW the two-line fixture on every lexical
+    field (name 6.996 vs 8.012, signature 6.153 vs 7.389, summary 0.0 vs 5.992).
+    A short synthetic class wins on lexical signals alone, and the ordering
+    assertion then passes with or without the fix, testing nothing. The
+    docstring's words are deliberately unrelated to the query: they lengthen the
+    document without contributing a match, which is what the real class's own
+    prose does.
+    """
+    filler = " ".join(f"detail{i} note{i}" for i in range(30))
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "token_tracker.py").write_text(
+        "class _State:\n"
+        f'    """{filler}"""\n'
+        "\n"
+        "    def __init__(self):\n"
+        "        self.rows = []\n"
+    )
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_thing.py").write_text(
+        "def state():\n"
+        '    """Recorder state."""\n'
+        "    return {}\n"
+    )
+    idx = index_folder(
+        path=str(tmp_path), use_ai_summaries=False, storage_path=str(tmp_path / "idx")
+    )
+    return idx["repo"], str(tmp_path / "idx")
+
+
+class TestEndToEndOrdering:
+    def test_exact_name_query_returns_the_class_before_the_fixture(self, tmp_path):
+        repo, storage = _seed_state_collision(tmp_path)
+
+        result = search_symbols(
+            repo=repo, query="_State", max_results=5, storage_path=storage
+        )
+
+        names = [r["name"] for r in result["results"]]
+        assert "_State" in names, f"the queried symbol was not returned at all: {names}"
+        assert "state" in names, f"the collision corpus did not index: {names}"
+        assert names.index("_State") < names.index("state"), (
+            f"a test fixture outranked the class the caller named: {names}"
+        )
+
+    def test_the_served_row_reports_the_grade_it_measured(self, tmp_path):
+        repo, storage = _seed_state_collision(tmp_path)
+
+        result = search_symbols(
+            repo=repo, query="_State", max_results=5, debug=True, storage_path=storage
+        )
+
+        by_name = {r["name"]: r for r in result["results"]}
+        assert by_name["_State"]["score_breakdown"]["identity_type"] == "exact"
+        assert by_name["state"]["score_breakdown"]["identity_type"] == "normalized"


### PR DESCRIPTION
Closes #458.

`_tokenize` folds case, strips leading underscores and drops punctuation, and the identity channel's tokenized comparison ran against that folded form. For the query `_State`, a pytest fixture named `state` and the class literally named `_State` both scored `identity: 50.0, identity_type: "exact"`. The channel could not separate them, the tie fell through to BM25, and the shorter name with a docstring won by **0.355 points out of ~58**.

A match that needed normalisation now scores **40.0** and reports `identity_type: "normalized"`. Literal stays 50.0; `prefix` (30.0) and `segment` (20.0) are untouched, so this uses the tiering mechanism the issue pointed at rather than adding one.

### The boundary, which the issue deliberately left open

**Case folding alone is still `exact`.** `raw_lower` has been case-folded since the channel arrived, so making case load-bearing would change the answer for every caller who types `getuser` for `getUser` — a behaviour change with no defect behind it. What drops a tier is a match that needed more than case: an underscore, a separator, anything `_tokenize` removed.

**A caller passing only tokenized terms and no raw query keeps `exact`.** With no raw spelling there is nothing to be literal about, and grading it down would report a distinction that was never measured — which is the defect this fixes, not the fix.

### The first end-to-end test passed against the broken code

BM25 normalises by document length, and on the real repo `_State` is a large class that scored *below* the two-line fixture on every lexical field (name 6.996 vs 8.012, signature 6.153 vs 7.389, summary 0.0 vs 5.992). A small synthetic class wins on lexical signals alone, so the ordering assertion held with and without the identity tier — green, asserting the right thing, and testing nothing.

The corpus now gives the class a long docstring of words unrelated to the query: length without a match, which is what the real class's own prose does. **4 of the 10 tests fail against `8cc01a0`**, including the ordering one. The 6 that pass both sides are the unchanged tiers and the term-only control.

### Verification

- `tests/test_identity_normalized_tier.py` — 10 pass here, 4 fail against `8cc01a0`.
- Suite: **7799 passed, 9 skipped, 1 failed**. The failure is `test_v1_108_183.py::test_the_core_compact_schema_budget_is_unchanged` (3885 vs a pinned 3996), caused by an unrelated schema-baseline re-measurement sitting uncommitted in the same working tree. It is not on this branch.
- `ruff check src/` clean.
- Retrieval-quality gate re-run locally against this branch: `mrr 1.0, ndcg 1.0, recall 1.0`.

`identity_type` is debug-only surface (`score_breakdown`), so `"normalized"` is a new value on a field no non-debug caller reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
