### PR TITLE
fix(watch-status): schtasks output is not UTF-8 and its state is not English (#468, #469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## [Unreleased]
+
+### `watch-status` on a non-English Windows ([#468](https://github.com/jgravelle/jcodemunch-mcp/issues/468), [#469](https://github.com/jgravelle/jcodemunch-mcp/issues/469))
+
+Both reported by [@lsg1103275794](https://github.com/lsg1103275794), split per
+one-issue-one-verdict, and independent: fixing either one alone leaves the other
+exactly as broken.
+
+**#468 — the output was decoded as UTF-8.** `schtasks.exe` writes in the
+machine's code page, so on a Simplified-Chinese install `watch-status.detail`
+came back as 40 U+FFFD characters. ⚠⚠ **`errors="replace"` is what made it
+silent.** Strict UTF-8 *raises* on those bytes; replacement turned a loud failure
+into a plausible string, and a plausible string is what nobody investigates.
+
+Native output now decodes through the code page Windows reports, asking for the
+**console output** page before the ANSI one — they are not always the same
+(measured on the dev box: 437 and 1252; on the reporter's, both 936). ⚠ The
+ORDER is the answer, not the strict-decode loop under it: a multi-byte page like
+cp936 rejects a wrong guess, while cp437 and cp1252 map nearly every byte and
+cannot fail. That is stated at the function so a successful decode is never read
+as confirmation.
+
+⚠ **`locale.getpreferredencoding()` is deliberately not used** — under
+`PYTHONUTF8=1` it reports utf-8 while the child still writes CP936, which is the
+case the reporter warned about. It would have looked principled and been wrong
+for exactly the users this is for.
+
+**#469 — liveness was decided by English display text.** `"Running" in stdout or
+"Ready" in stdout` reports `active: false` on every non-English Windows, while
+the watcher runs and reindexes normally. `正在运行` does not contain `Running`,
+and `/FO CSV` does not help because its headers *and* values are localized too.
+The verdict now reads `Get-ScheduledTask`'s `State`, an enum whose string form is
+invariant, and `Ready` still counts as active so the meaning of the field is
+unchanged.
+
+⚠ The fallback to the old predicate remains for a box where the enum cannot be
+read, and **it says so**: `state_source` is `scheduled_task_state` or
+`display_text`, and `state` is `null` rather than a guess. A wrong answer that
+names its own source is recoverable; a confident one is not.
+
+⚠ **Three call sites shared the decoding hazard and only one was reported.**
+`_install_windows` raises `InstallerError` carrying `schtasks` stderr and
+`_uninstall_windows` reads its output too, so a localized "access denied" reached
+the user as mojibake — on the path taken when something is already going wrong.
+All three go through one decoder, with a ratchet test that fails if a fourth
+arrives.
+
+⚠⚠ **The reporter's own note is why both survived a green suite:** searching
+`tests/` for `_status_windows`, `schtasks` and the `Running`/`Ready` predicate
+returned no hits. There was no coverage to fail. `tests/test_schtasks_locale.py`
+(20) runs on every platform because it drives the decode and the verdict
+directly; **17 fail against `35eeb2d`**, and the 3 that pass both sides are
+controls asserting the defect itself.
+
 ## [1.108.278] - 2026-08-14 - `exact` must mean exact, and a guardrail must not be its own baseline
 
 ### `identity_type: "exact"` graded a normalised match ([#458](https://github.com/jgravelle/jcodemunch-mcp/issues/458))

--- a/src/jcodemunch_mcp/service_installer.py
+++ b/src/jcodemunch_mcp/service_installer.py
@@ -18,6 +18,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -197,6 +198,114 @@ def _status_launchd() -> dict:
 # ── Task Scheduler (Windows) ────────────────────────────────────────────────
 
 
+def _windows_console_code_pages() -> list[str]:
+    """Codecs to try for native Windows console output, best first.
+
+    `schtasks.exe` writes in the machine's code page, not UTF-8. Which one
+    depends on the process: a redirected child writes in the CONSOLE OUTPUT
+    code page, which is not always the ANSI code page — on a Simplified-Chinese
+    install both are 936, but on a Western European one they are 850 and 1252.
+    Both are asked of Windows and tried in that order.
+
+    ⚠ `locale.getpreferredencoding()` is deliberately NOT used. Under
+    `PYTHONUTF8=1` it reports utf-8 while the child still writes CP936, which is
+    exactly the case #468 warned about — the answer would look principled and be
+    wrong only for the users this exists for.
+    """
+    pages: list[str] = []
+    try:
+        import ctypes  # noqa: PLC0415 — Windows-only, not imported on other platforms
+
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        for fn in (kernel32.GetConsoleOutputCP, kernel32.GetACP):
+            try:
+                cp = int(fn())
+            except Exception:  # pragma: no cover - defensive
+                logger.debug("code page probe failed", exc_info=True)
+                continue
+            # 0 means "no console attached"; 65001 is UTF-8 and is tried anyway.
+            if cp and f"cp{cp}" not in pages:
+                pages.append(f"cp{cp}")
+    except Exception:
+        logger.debug("ctypes unavailable for code page probe", exc_info=True)
+    pages.append("utf-8")
+    return pages
+
+
+def _decode_windows_output(raw: bytes) -> str:
+    """Decode native Windows tool output without inventing characters.
+
+    ⚠⚠ Every call site here used `encoding="utf-8", errors="replace"`, which does
+    not raise — so CP936 bytes became 40 U+FFFD characters and the corruption was
+    SILENT (#468). `errors="replace"` on a wrong codec is worse than a crash: it
+    produces a plausible string.
+
+    The ORDER is the answer: the first candidate is what Windows says the child
+    writes. Strict decoding is a net under it, and only a partial one — a
+    multi-byte page like cp936 rejects a wrong guess, while cp437 and cp1252 map
+    nearly every byte and cannot fail. Do not read a successful decode as
+    confirmation that the codec was right.
+    """
+    if not raw:
+        return ""
+    candidates = _windows_console_code_pages()
+    for codec in candidates:
+        try:
+            return raw.decode(codec)
+        except (UnicodeDecodeError, LookupError):
+            continue
+    return raw.decode(candidates[0], errors="replace")
+
+
+def _run_schtasks(args: list[str]) -> tuple[int, str, str]:
+    """Run a `schtasks` command and decode its output in the machine's code page."""
+    result = subprocess.run(args, capture_output=True, check=False)
+    return (
+        result.returncode,
+        _decode_windows_output(result.stdout or b""),
+        _decode_windows_output(result.stderr or b""),
+    )
+
+
+# Task Scheduler's own state enum, which is stable across display languages.
+# Matches the pre-#469 semantics exactly: a task that exists and is enabled is
+# "active" whether or not an instance is executing right now, because the
+# installed task is ONLOGON and sits in Ready between logons.
+_ACTIVE_TASK_STATES = frozenset({"Running", "Ready"})
+
+
+def _scheduled_task_state() -> Optional[str]:
+    """The task's `State` enum from Windows, or None if it could not be read.
+
+    ⚠⚠ The display text cannot answer this. `schtasks` prints the state in the
+    installed display language (`正在运行` for Running), so the pre-#469 test
+    `"Running" in stdout or "Ready" in stdout` reported `active: false` on every
+    non-English Windows while the watcher was running normally. `/FO CSV` does
+    not help — its headers AND values are localized too.
+
+    `Get-ScheduledTask` returns a `ScheduledTaskState` enum whose `ToString()` is
+    invariant, which is the same source Windows' own tooling reads.
+    """
+    script = (
+        "$ErrorActionPreference='Stop';"
+        f"(Get-ScheduledTask -TaskName '{SERVICE_NAME}').State.ToString()"
+    )
+    try:
+        result = subprocess.run(
+            ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
+            capture_output=True, check=False, timeout=30,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+    except (OSError, subprocess.SubprocessError):
+        logger.debug("Get-ScheduledTask probe failed", exc_info=True)
+        return None
+    if result.returncode != 0:
+        logger.debug("Get-ScheduledTask returned %s", result.returncode)
+        return None
+    state = _decode_windows_output(result.stdout or b"").strip()
+    return state or None
+
+
 def _install_windows() -> dict:
     _log_dir().mkdir(parents=True, exist_ok=True)
     cmd_str = " ".join(_cmd_quote(x) for x in _exec_cmd())
@@ -209,28 +318,44 @@ def _install_windows() -> dict:
         "/RL", "LIMITED",
         "/TR", cmd_str,
     ]
-    result = subprocess.run(args, capture_output=True, text=True, encoding="utf-8", errors="replace", check=False)
-    if result.returncode != 0:
-        raise InstallerError(f"schtasks /Create failed: {result.stderr.strip() or result.stdout.strip()}")
+    # ⚠ The failure message is USER-FACING, so it needs the same decoding as the
+    # status path — a localized "access denied" rendered as mojibake is a support
+    # ticket, not a diagnosis.
+    returncode, stdout, stderr = _run_schtasks(args)
+    if returncode != 0:
+        raise InstallerError(f"schtasks /Create failed: {stderr.strip() or stdout.strip()}")
     subprocess.run(["schtasks", "/Run", "/TN", SERVICE_NAME], check=False, capture_output=True)
     return {"platform": "schtasks", "task": SERVICE_NAME, "status": "registered"}
 
 
 def _uninstall_windows() -> dict:
-    result = subprocess.run(
-        ["schtasks", "/Delete", "/F", "/TN", SERVICE_NAME],
-        capture_output=True, text=True, encoding="utf-8", errors="replace", check=False,
+    returncode, _stdout, _stderr = _run_schtasks(
+        ["schtasks", "/Delete", "/F", "/TN", SERVICE_NAME]
     )
-    return {"platform": "schtasks", "task": SERVICE_NAME, "removed": result.returncode == 0}
+    return {"platform": "schtasks", "task": SERVICE_NAME, "removed": returncode == 0}
 
 
 def _status_windows() -> dict:
-    result = subprocess.run(
-        ["schtasks", "/Query", "/TN", SERVICE_NAME, "/FO", "LIST"],
-        capture_output=True, text=True, encoding="utf-8", errors="replace", check=False,
+    _rc, stdout, _stderr = _run_schtasks(
+        ["schtasks", "/Query", "/TN", SERVICE_NAME, "/FO", "LIST"]
     )
-    active = "Running" in result.stdout or "Ready" in result.stdout
-    return {"platform": "schtasks", "active": active, "detail": result.stdout.strip()[:400]}
+    state = _scheduled_task_state()
+    if state is not None:
+        active = state in _ACTIVE_TASK_STATES
+        source = "scheduled_task_state"
+    else:
+        # Fallback only. ⚠ This is the pre-#469 predicate and it is WRONG on any
+        # non-English Windows; `state_source` says so rather than letting a
+        # confident `false` pass for a measurement.
+        active = "Running" in stdout or "Ready" in stdout
+        source = "display_text"
+    return {
+        "platform": "schtasks",
+        "active": active,
+        "state": state,
+        "state_source": source,
+        "detail": stdout.strip()[:400],
+    }
 
 
 # ── Public dispatch ─────────────────────────────────────────────────────────

--- a/tests/test_schtasks_locale.py
+++ b/tests/test_schtasks_locale.py
@@ -1,0 +1,210 @@
+"""#468 / #469: `watch-status` on a non-English Windows.
+
+Two independent defects in one function, reported and split by
+[@lsg1103275794](https://github.com/lsg1103275794):
+
+- **#468** `schtasks` output was decoded as UTF-8 while the process writes in the
+  machine's code page, so `detail` was mojibake. `errors="replace"` meant it did
+  not raise — the corruption was silent.
+- **#469** liveness was decided by `"Running" in stdout or "Ready" in stdout`, so
+  a running task reported `active: false` on every non-English Windows.
+
+⚠⚠ **The reporter's own note is the reason both survived a green suite: searching
+`tests/` for `_status_windows`, `schtasks` and the `Running`/`Ready` predicate
+returned no hits.** There was no coverage to fail. These tests run on every
+platform because they drive the decode and the verdict directly rather than
+shelling out to Windows.
+
+The CP936 fixture is the reporter's measured bytes, verbatim from #468.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from jcodemunch_mcp import service_installer as si
+
+# The first 32 bytes of `schtasks /Query /TN \jcodemunch-watch /FO LIST` on a
+# Simplified-Chinese Windows 11, active code page CP936, as measured in #468.
+_CP936_SCHTASKS = bytes.fromhex(
+    "0d0acec4bcfebcd03a205c0d0ad6f7bbfac3fb3a2020202020202047474259"
+)
+_CP936_EXPECTED = "\r\n文件夹: \\\r\n主机名:       GGBY"
+
+
+class TestDecodingNativeOutput:
+    def test_the_reported_bytes_decode_without_replacement_characters(self):
+        with patch.object(si, "_windows_console_code_pages", lambda: ["cp936", "utf-8"]):
+            decoded = si._decode_windows_output(_CP936_SCHTASKS)
+
+        assert decoded == _CP936_EXPECTED
+        assert "�" not in decoded
+
+    def test_the_old_utf8_path_is_what_produced_the_mojibake(self):
+        """Non-vacuity, and it pins the defect rather than the fix.
+
+        ⚠ This is the shape that made #468 silent: strict UTF-8 RAISES on these
+        bytes, so `errors="replace"` was doing real work — turning a loud failure
+        into a plausible string.
+        """
+        with pytest.raises(UnicodeDecodeError):
+            _CP936_SCHTASKS.decode("utf-8")
+
+        assert _CP936_SCHTASKS.decode("utf-8", errors="replace").count("�") == 10
+
+    def test_ascii_output_is_unchanged_by_the_new_path(self):
+        with patch.object(si, "_windows_console_code_pages", lambda: ["cp437", "utf-8"]):
+            assert si._decode_windows_output(b"TaskName: \\jcodemunch-watch") == (
+                "TaskName: \\jcodemunch-watch"
+            )
+
+    def test_empty_output_is_empty_not_an_error(self):
+        assert si._decode_windows_output(b"") == ""
+
+    def test_a_codec_that_cannot_decode_falls_back_rather_than_raising(self):
+        """The last resort must return something. A status probe that raises
+        turns a cosmetic problem into an outage."""
+        with patch.object(si, "_windows_console_code_pages", lambda: ["utf-8"]):
+            decoded = si._decode_windows_output(_CP936_SCHTASKS)
+
+        assert "�" in decoded  # degraded, but present
+
+    def test_utf8_is_always_a_candidate(self):
+        """A UTF-8 console (code page 65001) must still work if the probe fails."""
+        with patch.object(si, "logger"):
+            assert "utf-8" in si._windows_console_code_pages()
+
+
+class TestLivenessIsNotDecidedByDisplayText:
+    """#469. `正在运行` does not contain `Running`, and never will."""
+
+    def _status(self, *, state, stdout: bytes):
+        with patch.object(si, "_run_schtasks", lambda args: (0, si._decode_windows_output(stdout), "")), \
+             patch.object(si, "_scheduled_task_state", lambda: state), \
+             patch.object(si, "_windows_console_code_pages", lambda: ["cp936", "utf-8"]):
+            return si._status_windows()
+
+    def test_a_running_task_on_chinese_windows_reports_active(self):
+        result = self._status(state="Running", stdout="模式:         正在运行".encode("cp936"))
+
+        assert result["active"] is True
+        assert result["state"] == "Running"
+        assert result["state_source"] == "scheduled_task_state"
+
+    def test_the_display_text_alone_would_have_said_false(self):
+        """Non-vacuity: the pre-fix predicate against the same output.
+
+        ⚠ This asserts the DEFECT, so it fails if someone 'simplifies' the fix
+        back to a string match — the fallback below is the only path allowed to
+        use it, and only when the enum is unreadable.
+        """
+        localized = "模式:         正在运行"
+
+        assert "Running" not in localized
+        assert "Ready" not in localized
+
+    def test_a_ready_task_is_active_preserving_the_original_semantics(self):
+        """An ONLOGON task sits in Ready between logons, and the pre-#469 code
+        counted Ready as active. Fixing the locale bug must not quietly change
+        what `active` MEANS."""
+        assert self._status(state="Ready", stdout=b"")["active"] is True
+
+    def test_a_disabled_task_is_not_active(self):
+        assert self._status(state="Disabled", stdout=b"")["active"] is False
+
+    def test_the_detail_carries_readable_localized_text(self):
+        result = self._status(state="Running", stdout="模式:         正在运行".encode("cp936"))
+
+        assert "正在运行" in result["detail"]
+        assert "�" not in result["detail"]
+
+    def test_an_unreadable_state_falls_back_and_says_so(self):
+        """⚠ The fallback is the pre-#469 predicate and is wrong off English
+        Windows. It must never present as a measurement: `state_source` names it
+        and `state` is None rather than a guess."""
+        result = self._status(state=None, stdout=b"Status: Running")
+
+        assert result["state_source"] == "display_text"
+        assert result["state"] is None
+        assert result["active"] is True
+
+
+class TestStateProbeFailsClosed:
+    def test_a_nonzero_return_code_reads_as_unknown_not_as_stopped(self):
+        completed = subprocess.CompletedProcess(args=[], returncode=1, stdout=b"", stderr=b"nope")
+        with patch.object(si.subprocess, "run", return_value=completed):
+            assert si._scheduled_task_state() is None
+
+    def test_a_missing_powershell_reads_as_unknown(self):
+        with patch.object(si.subprocess, "run", side_effect=FileNotFoundError):
+            assert si._scheduled_task_state() is None
+
+    def test_a_timeout_reads_as_unknown(self):
+        with patch.object(si.subprocess, "run", side_effect=subprocess.TimeoutExpired("powershell", 30)):
+            assert si._scheduled_task_state() is None
+
+    def test_empty_output_reads_as_unknown_rather_than_an_empty_state(self):
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"  \r\n", stderr=b"")
+        with patch.object(si.subprocess, "run", return_value=completed):
+            assert si._scheduled_task_state() is None
+
+    def test_the_state_is_read_from_the_enum_not_from_display_text(self):
+        """Pins the source. `Get-ScheduledTask ... .State.ToString()` is the
+        invariant enum; a change to localized parsing fails here."""
+        captured: dict = {}
+
+        def _capture(args, **kwargs):
+            captured["args"] = args
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=b"Running\r\n", stderr=b"")
+
+        with patch.object(si.subprocess, "run", side_effect=_capture):
+            assert si._scheduled_task_state() == "Running"
+
+        script = captured["args"][-1]
+        assert "Get-ScheduledTask" in script
+        assert "State.ToString()" in script
+        assert si.SERVICE_NAME in script
+
+
+class TestEveryWindowsCallSiteSharesTheDecoder:
+    """⚠ `_status_windows` was the reported site; it was not the only one.
+
+    `_install_windows` raises `InstallerError` carrying `schtasks` stderr, and
+    `_uninstall_windows` reads a return code. Both decoded UTF-8 the same way, so
+    a localized failure message reached the user as mojibake. Guarding only the
+    reported path leaves the same hazard on the path a user hits when something
+    is already going wrong.
+    """
+
+    def test_install_failure_message_is_decoded_in_the_machine_code_page(self):
+        localized = "错误: 拒绝访问。"
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout=b"", stderr=localized.encode("cp936")
+        )
+        with patch.object(si.subprocess, "run", return_value=completed), \
+             patch.object(si, "_windows_console_code_pages", lambda: ["cp936", "utf-8"]), \
+             patch.object(si, "_log_dir") as log_dir, \
+             patch.object(si, "_exec_cmd", lambda: ["python", "-m", "jcodemunch_mcp"]):
+            log_dir.return_value.mkdir.return_value = None
+            with pytest.raises(si.InstallerError) as excinfo:
+                si._install_windows()
+
+        assert localized in str(excinfo.value)
+        assert "�" not in str(excinfo.value)
+
+    def test_uninstall_still_reports_removal_by_return_code(self):
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        with patch.object(si.subprocess, "run", return_value=completed):
+            assert si._uninstall_windows()["removed"] is True
+
+    def test_no_windows_call_site_hardcodes_utf8_any_more(self):
+        """A ratchet. The defect was one keyword argument repeated at three
+        sites; this fails if a fourth arrives or an old one comes back."""
+        import inspect
+
+        for fn in (si._install_windows, si._uninstall_windows, si._status_windows):
+            source = inspect.getsource(fn)
+            assert 'encoding="utf-8"' not in source, fn.__name__


### PR DESCRIPTION
Closes #468. Closes #469.

Both reported by @lsg1103275794, split per one-issue-one-verdict, and genuinely independent — fixing either alone leaves the other exactly as broken, which the reporter established before filing.

## #468 — the output was decoded as UTF-8

`schtasks.exe` writes in the machine's code page. On a Simplified-Chinese install `watch-status.detail` came back as 40 U+FFFD characters.

⚠⚠ **`errors="replace"` is what made it silent.** Strict UTF-8 *raises* on those bytes; replacement turned a loud failure into a plausible string, and a plausible string is what nobody investigates.

Native output now decodes through the code page Windows reports, asking for the **console output** page before the ANSI one. Those are not always the same — measured on the dev box while writing this, `GetConsoleOutputCP()` is 437 and `GetACP()` is 1252; on the reporter's machine both are 936, which is why their evidence could not discriminate between them.

⚠ **The order is the answer, not the strict-decode loop under it.** A multi-byte page like cp936 rejects a wrong guess; cp437 and cp1252 map nearly every byte and cannot fail. That is stated at the function so a successful decode is never read as confirmation the codec was right.

⚠ **`locale.getpreferredencoding()` is deliberately not used.** Under `PYTHONUTF8=1` it reports utf-8 while the child still writes CP936 — the exact case the reporter warned about. It would have looked principled and been wrong for precisely the users this exists for.

Verified against the reporter's measured bytes from the issue: they decode to `文件夹: \` / `主机名: GGBY` with zero replacement characters, against 10 before.

## #469 — liveness was decided by English display text

`"Running" in stdout or "Ready" in stdout` reports `active: false` on every non-English Windows while the watcher runs and reindexes normally. `正在运行` does not contain `Running`, and `/FO CSV` does not help because its headers *and* values are localized too.

The verdict now reads `Get-ScheduledTask`'s `State`, an enum whose string form is invariant. **`Ready` still counts as active**, so the meaning of the field is unchanged — the installed task is `ONLOGON` and sits in `Ready` between logons, and fixing a locale bug must not quietly redefine what `active` claims.

⚠ The fallback to the old predicate remains for a box where the enum cannot be read, and **it says so**: `state_source` is `scheduled_task_state` or `display_text`, and `state` is `null` rather than a guess. A wrong answer that names its own source is recoverable.

## Three call sites shared the hazard; one was reported

`_install_windows` raises `InstallerError` carrying `schtasks` stderr, and `_uninstall_windows` reads its output too. A localized "access denied" reached the user as mojibake — on the path taken when something is already going wrong. All three route through one decoder now, with a ratchet test that fails if a fourth site appears or an old one returns.

## Verification

- `tests/test_schtasks_locale.py` — 20 tests, **17 fail against `35eeb2d`**. The 3 that pass both sides are controls asserting the defect itself (strict UTF-8 raises; `正在运行` contains neither English token).
- They run on **every platform**, because they drive the decode and the verdict directly rather than shelling out to Windows.
- Suite: **7819 passed, 9 skipped, 0 failed** — +20 over 1.108.278's 7808, exactly the new file. `ruff check src/` clean.

⚠⚠ **The reporter's own note is why both survived a green suite:** searching `tests/` for `_status_windows`, `schtasks` and the `Running`/`Ready` predicate returned no hits. There was no coverage to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
