### PR TITLE
docs: no timebox we offer runs longer than 24 hours

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -624,11 +624,12 @@ which is backwards.
 **3. A contributor's PR is never the only path.** Timebox it and keep our own
 path warm (#388 taught this the expensive way).
 
-**3a. An unsigned CLA gets TWENTY-FOUR HOURS, not two weeks** (set 2026-08-14
-after #443 was given until 08-20). CLA Assistant prompts automatically the moment
-a PR opens and signing takes about 30 seconds, so the window is sized to the
-task. A longer one does not buy a contributor anything — it parks a finished,
-green, reviewed fix behind a form.
+**3a. NO TIMEBOX WE OFFER RUNS LONGER THAN 24 HOURS** (jjg, 2026-08-14, widened
+the same day from the CLA-only version). It covers **every** shape: signing the
+CLA, opening a PR already written, and taking an issue to implement. The CLA case
+is the easiest to justify — CLA Assistant prompts the moment a PR opens and
+signing takes about 30 seconds, so a longer window parks a finished, green,
+reviewed fix behind a form — but the rule is not limited to it.
 
 ⚠⚠ **The window is only fair BECAUSE the default action preserves credit.** At
 expiry we implement the fix ourselves and credit them in the CHANGELOG, the
@@ -637,9 +638,23 @@ never whether they are credited and never whether the fix ships. Quote the
 default in the same comment as the deadline — a 24-hour clock with an unstated
 consequence reads as a threat, and it is not one.
 
+⚠ **An extension the contributor ASKS FOR is not the same as a default we hand
+out**, and CONTRIBUTING.md invites the ask by name. Hold it when they ask; the
+clock exists to stop work going quiet, not to catch anyone out.
+
+⚠ **Stated consequence, not hidden**: on an IMPLEMENTATION handoff, 24 hours
+means in practice that we implement it and they are credited, because nobody
+lands an additive-schema-plus-dispatcher change around a job in a day. That is a
+change in what a handoff IS, not only in how long it lasts. It is the intended
+trade — our throughput over their commit — and it should be made in the open
+rather than discovered at expiry.
+
 ⚠ **Do not shorten a timebox already posted.** State the new window on new PRs.
 A public promise to a contributor outlives the policy that produced it, and
-retracting one to save six days costs more than the six days.
+retracting one to save six days costs more than the six days. ⚠⚠ **Reaffirmed by
+jjg when this rule widened: #447 (2026-08-20), #465 (2026-08-21) and #456
+(2026-08-27) stand AS POSTED.** The new ceiling applies to timeboxes offered
+after that date, and to nothing already promised.
 
 ⚠⚠ **Do NOT answer "an issue is stuck" with aggregate stats.** Measured
 2026-07-28: jcm median 0 days to close (80 issues, 70 within a day, 2 ever past

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,22 @@ full and we announce it retroactively. Nothing expires.
 Every timebox we set names its default action, because a date with no stated
 consequence is a wish. "Verification by X, or Y ships with disclosure Z."
 
+**No timebox we offer runs longer than 24 hours.** That applies to all of them,
+not only the CLA window above: signing a form, opening a PR you have already
+written, or taking an issue you want to implement. At expiry the default action
+fires — usually that we do the work ourselves — and you are credited in the
+CHANGELOG, the release notes and the close comment either way.
+
+The short clock is only fair because of that last sentence. It decides whose
+commit it is. It never decides whether you are credited, and it never decides
+whether the fix ships.
+
+If 24 hours does not fit — you want the weekend for it, you are away, the change
+is large — **say so and we will hold it.** An extension you ask for is not the
+same as a default we hand out, and we would rather you told us than went quiet.
+Timeboxes already posted are honoured as posted; we do not shorten a promise
+after making it.
+
 The point of this rule is that a reviewer's thoroughness should never become a
 veto. If being careful can stall a release, then careful review is expensive to
 accept, and that is the opposite of what we want. This way your findings are an


### PR DESCRIPTION
Widens this morning's CLA-only 24-hour window to **every** timebox we hand out: signing the CLA, opening a PR already written, and taking an issue to implement.

Docs only. No CHANGELOG entry — this is a policy statement, not a released behaviour, which also keeps it from conflicting with @elfrost's #443 a fourth time.

### The rule

> **No timebox we offer runs longer than 24 hours.** [...] At expiry the default action fires — usually that we do the work ourselves — and you are credited in the CHANGELOG, the release notes and the close comment either way.

The short clock is only fair because of that last clause. It decides whose commit it is; it never decides whether they are credited or whether the fix ships. CONTRIBUTING.md now invites the ask by name — **an extension a contributor requests is not the same as a default we hand out** — because a clock whose only outcome is "we take it over" makes going quiet the cheapest option.

### One consequence, recorded rather than discovered at expiry

⚠ On an **implementation** handoff, 24 hours means in practice that we implement it and they are credited, because nobody lands an additive-schema-plus-dispatcher change around a job in a day. That is a change in what a handoff *is*, not only in how long it lasts. It is the intended trade — our throughput over their commit — and CLAUDE.md says so out loud.

### Already-posted timeboxes are untouched

#447 (2026-08-20), #465 (2026-08-21) and #456 (2026-08-27) stand exactly as promised. The standing rule against shortening a posted timebox is unchanged and now names those three, so nobody re-derives it on the day.

### Suite-wide

`CONTRIBUTING.md` is deliberately identical across jcm/jdoc/jdata. The same paragraph is committed to [jdocmunch-mcp](https://github.com/jgravelle/jdocmunch-mcp) (`a3e761d`) and [jdatamunch-mcp](https://github.com/jgravelle/jdatamunch-mcp) (`4fb1791`); the three files' policy sections hash identically. Three copies disagreeing about one rule is how the broken `pip install -e ".[test]"` survived in all three repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
