### PR TITLE
docs: a mergeable contributor PR merges before our own changelog work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -649,6 +649,27 @@ change in what a handoff IS, not only in how long it lasts. It is the intended
 trade — our throughput over their commit — and it should be made in the open
 rather than discovered at expiry.
 
+**3b. A MERGEABLE contributor PR merges BEFORE any changelog-touching work of
+our own** (jjg, 2026-08-14). Not a courtesy and not a preference — a measured
+cost. Every entry we add lands in the same `[Unreleased]` block a contributor's
+entry occupies, so each of our merges puts their PR into conflict, and a
+CONFLICTING fork PR has **no `refs/pull/N/merge`** and therefore gets no CI at
+all. Their branch goes dark for a reason that has nothing to do with their
+change.
+
+⚠⚠ **Measured 2026-08-14: #443 conflicted FIVE TIMES IN ONE DAY** — twice from
+our own PR merges, twice from releases, once from the docs work — and every one
+was resolved by us pushing to their fork. **Five is not five incidents, it is
+one wrong merge order repeated.**
+
+⚠ **The boundary, or the rule fails on its first real case.** A BLOCKED
+contributor PR cannot go first: #443 was unsigned-CLA the whole time, so
+"contributor first" was never available. When it is blocked we ship anyway
+(policy 2 — a release is never blocked on an open issue) and **we own the
+resolution**: push the merge to their branch, resolve it ourselves, and say on
+the thread that the conflict was ours. **This rule is about ORDER when we have a
+choice, never about holding our work behind someone else's form.**
+
 ⚠ **Do not shorten a timebox already posted.** State the new window on new PRs.
 A public promise to a contributor outlives the policy that produced it, and
 retracting one to save six days costs more than the six days. ⚠⚠ **Reaffirmed by

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,23 @@ same as a default we hand out, and we would rather you told us than went quiet.
 Timeboxes already posted are honoured as posted; we do not shorten a promise
 after making it.
 
+### Your PR merges before our own changelog work
+
+When your PR is ready to merge, it goes in **before** anything of ours that
+touches `CHANGELOG.md`. That is a rule about our merge order, not a favour.
+
+The reason is mechanical. Our entries land in the same `[Unreleased]` block
+yours does, so every merge of ours puts your branch into conflict — and a
+conflicting fork PR has no merge ref, which means **CI stops running on it
+entirely.** Your branch goes quiet for a reason that has nothing to do with your
+change, and you get asked to rebase work that was finished days ago.
+
+⚠ **When your PR is blocked — an unsigned CLA, a red matrix, a change we asked
+you for — we cannot put it first, and we will not hold our own work behind it.**
+We ship, and then **we** resolve the conflict on your branch and say so on the
+thread. You should never be asked to rebase for a conflict we created. If you
+would rather resolve it yourself, say so and it is yours.
+
 The point of this rule is that a reviewer's thoroughness should never become a
 veto. If being careful can stall a release, then careful review is expensive to
 accept, and that is the opposite of what we want. This way your findings are an


### PR DESCRIPTION
Docs only, no CHANGELOG entry — which is also the point: it keeps this PR from doing the very thing it forbids.

### The rule

**A mergeable contributor PR merges before anything of ours that touches `CHANGELOG.md`**, including a release commit.

The reason is mechanical, not etiquette. Our `[Unreleased]` entries land in the same block a contributor's entry occupies, so every merge of ours conflicts their branch — and **a conflicting fork PR has no `refs/pull/N/merge`, so `pull_request` workflows stop running on it entirely.** Their branch goes dark for a reason that has nothing to do with their change, and they get asked to rebase work that was finished days ago.

⚠⚠ **Measured today: #443 conflicted five times** — two PR merges (#466/#467, #470), two releases (1.108.278, 1.108.279) and one docs change (#471) — every one resolved by us pushing to their fork. That is one wrong merge order repeated, not five incidents.

### The boundary, stated so the rule survives its first real case

A **blocked** PR cannot go first. #443 was unsigned-CLA the whole time, so "contributor first" was never available for any of those five. Blocked means we ship anyway — a release is never blocked on an open issue — and **we own the resolution**: push the merge to their branch, resolve it, say on the thread that the conflict was ours.

**The rule governs order when we have a choice. It never holds our work behind someone else's form.** Without that sentence the rule reads as "one unsigned CLA freezes the changelog", which is the opposite of policy 2.

### Contributor-facing half

`CONTRIBUTING.md` says plainly that they should never be asked to rebase for a conflict we created, and that they can take the resolution themselves if they would rather have it.

### Operational half

The release skill now carries a `gh pr list` one-liner to run **before every changelog-touching merge**, so this is a check with a command behind it rather than a good intention.

### Suite-wide

`CONTRIBUTING.md` is identical across the three repos: [jdocmunch-mcp](https://github.com/jgravelle/jdocmunch-mcp) `9235e22`, [jdatamunch-mcp](https://github.com/jgravelle/jdatamunch-mcp) `ecb5b99`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
