### PR TITLE
feat(telemetry): correlate perf rows by session and call (#456)

### DIFF
--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -5283,7 +5283,20 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent] | CallToolR
     Kept as the registered entry point (and the name the front door re-dispatches
     through) so every route into the dispatcher passes the cap.
     """
-    return _enforce_response_cap(name, await _call_tool_impl(name, arguments))
+    from .storage.token_tracker import begin_call_context, end_call_context
+
+    # **The dispatcher is re-entrant.** `order` and executable `route` both re-enter the
+    # registered `call_tool`, so one client request can produce two `tool_calls` rows. Giving
+    # each entry its own `call_uid` keeps a ranking event joined to exactly one latency row,
+    # which is why token-based reset matters: setting `None` in the `finally` would clear the
+    # outer entry's value and silently write `NULL` for it. The consequence to expect is that
+    # `COUNT(DISTINCT call_uid)` counts dispatcher entries rather than client requests, and
+    # the front-door row has no matching ranking event.
+    call_token = begin_call_context()
+    try:
+        return _enforce_response_cap(name, await _call_tool_impl(name, arguments))
+    finally:
+        end_call_context(call_token)
 
 
 async def _call_tool_impl(name: str, arguments: dict) -> list[TextContent] | CallToolResult:

--- a/src/jcodemunch_mcp/storage/token_tracker.py
+++ b/src/jcodemunch_mcp/storage/token_tracker.py
@@ -1385,8 +1385,8 @@ def record_tool_latency(
     _state.record_latency(tool_name, duration_ms, ok=ok, repo=repo, base_path=base_path)
 
 
-def begin_call_context(call_uid: Optional[str] = None) -> Token:
-    """Bind one dispatcher call identifier to the current execution context (#456).
+def begin_call_context() -> Token:
+    """Bind a fresh dispatcher call identifier to the current execution context (#456).
 
     ⚠ Reset with the returned token in a ``finally``. A skipped reset leaves the
     inner entry's identity visible to the outer one after it returns, so the join
@@ -1398,7 +1398,7 @@ def begin_call_context(call_uid: Optional[str] = None) -> Token:
     ``call_tool`` stays the single registered entry: the invariant is held by there
     being one door, not by this helper.
     """
-    return _CURRENT_CALL_UID.set(call_uid or uuid.uuid4().hex)
+    return _CURRENT_CALL_UID.set(uuid.uuid4().hex)
 
 
 def end_call_context(token: Token) -> None:

--- a/src/jcodemunch_mcp/storage/token_tracker.py
+++ b/src/jcodemunch_mcp/storage/token_tracker.py
@@ -36,6 +36,7 @@ import threading
 import time
 import uuid
 from collections import OrderedDict, deque
+from contextvars import ContextVar, Token
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -43,6 +44,14 @@ from typing import Optional
 from .. import config as _config
 
 logger = logging.getLogger(__name__)
+
+# One identifier per entry into the registered call_tool. Set by the dispatcher,
+# read by the telemetry sinks at write time. Default None so writes outside any
+# dispatched call record NULL rather than inventing an identity.
+_CURRENT_CALL_UID: ContextVar[Optional[str]] = ContextVar(
+    "jcodemunch_current_call_uid",
+    default=None,
+)
 
 _SAVINGS_FILE = "_savings.json"
 
@@ -1360,6 +1369,16 @@ def record_tool_latency(
 ) -> None:
     """Record a tool-call duration for the current session (and optional perf db)."""
     _state.record_latency(tool_name, duration_ms, ok=ok, repo=repo, base_path=base_path)
+
+
+def begin_call_context(call_uid: Optional[str] = None) -> Token:
+    """Bind one dispatcher call identifier to the current execution context."""
+    return _CURRENT_CALL_UID.set(call_uid or uuid.uuid4().hex)
+
+
+def end_call_context(token: Token) -> None:
+    """Restore the execution context that preceded begin_call_context."""
+    _CURRENT_CALL_UID.reset(token)
 
 
 def latency_stats() -> dict:

--- a/src/jcodemunch_mcp/storage/token_tracker.py
+++ b/src/jcodemunch_mcp/storage/token_tracker.py
@@ -757,9 +757,7 @@ class _State:
                     tool      TEXT NOT NULL,
                     duration_ms REAL NOT NULL,
                     ok        INTEGER NOT NULL,
-                    repo      TEXT,
-                    session_uid TEXT,
-                    call_uid  TEXT
+                    repo      TEXT
                 )
             """)
             conn.execute("CREATE INDEX IF NOT EXISTS ix_tool_calls_tool ON tool_calls(tool)")
@@ -791,9 +789,7 @@ class _State:
                     confidence     REAL,
                     semantic_used  INTEGER NOT NULL,
                     identity_hit   INTEGER NOT NULL,
-                    repo_is_stale  INTEGER NOT NULL,
-                    session_uid    TEXT,
-                    call_uid       TEXT
+                    repo_is_stale  INTEGER NOT NULL
                 )
             """)
             conn.execute("CREATE INDEX IF NOT EXISTS ix_ranking_events_repo ON ranking_events(repo)")
@@ -978,18 +974,10 @@ class _State:
             return
         try:
             conn.execute(
-                "INSERT INTO tool_calls "
-                "(ts, tool, duration_ms, ok, repo, session_uid, call_uid) "
+                "INSERT INTO tool_calls (ts, tool, duration_ms, ok, repo, session_uid, call_uid) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                (
-                    time.time(),
-                    tool,
-                    float(duration_ms),
-                    1 if ok else 0,
-                    repo or None,
-                    self._session_uid,
-                    _CURRENT_CALL_UID.get(),
-                ),
+                (time.time(), tool, float(duration_ms), 1 if ok else 0, repo or None,
+                 self._session_uid, _CURRENT_CALL_UID.get()),
             )
             self._perf_rows_since_trim += 1
             if self._perf_rows_since_trim >= 1000:
@@ -1398,7 +1386,18 @@ def record_tool_latency(
 
 
 def begin_call_context(call_uid: Optional[str] = None) -> Token:
-    """Bind one dispatcher call identifier to the current execution context."""
+    """Bind one dispatcher call identifier to the current execution context (#456).
+
+    ⚠ Reset with the returned token in a ``finally``. A skipped reset leaves the
+    inner entry's identity visible to the outer one after it returns, so the join
+    attributes rows to the wrong call while every write still reports success. That
+    is the failure the re-entrancy note at ``call_tool`` describes, reached by
+    forgetting the reset rather than by writing ``set(None)``.
+
+    A second entry point into the dispatcher would need this wrapper, for the reason
+    ``call_tool`` stays the single registered entry: the invariant is held by there
+    being one door, not by this helper.
+    """
     return _CURRENT_CALL_UID.set(call_uid or uuid.uuid4().hex)
 
 

--- a/src/jcodemunch_mcp/storage/token_tracker.py
+++ b/src/jcodemunch_mcp/storage/token_tracker.py
@@ -757,7 +757,9 @@ class _State:
                     tool      TEXT NOT NULL,
                     duration_ms REAL NOT NULL,
                     ok        INTEGER NOT NULL,
-                    repo      TEXT
+                    repo      TEXT,
+                    session_uid TEXT,
+                    call_uid  TEXT
                 )
             """)
             conn.execute("CREATE INDEX IF NOT EXISTS ix_tool_calls_tool ON tool_calls(tool)")
@@ -789,7 +791,9 @@ class _State:
                     confidence     REAL,
                     semantic_used  INTEGER NOT NULL,
                     identity_hit   INTEGER NOT NULL,
-                    repo_is_stale  INTEGER NOT NULL
+                    repo_is_stale  INTEGER NOT NULL,
+                    session_uid    TEXT,
+                    call_uid       TEXT
                 )
             """)
             conn.execute("CREATE INDEX IF NOT EXISTS ix_ranking_events_repo ON ranking_events(repo)")
@@ -806,6 +810,15 @@ class _State:
             self._add_column_if_missing(
                 conn, "ranking_events", "returned_count", "INTEGER"
             )
+            # #456. Correlation keys, added the same additive way returned_count was.
+            #
+            # The join is best-effort, by design. `tool_calls` is trimmed to a rolling cap while
+            # `ranking_events` is not, so older events will outlive their `tool_calls` row.
+            # Queries should use `LEFT JOIN` and expect misses. These are correlation keys, not
+            # referential integrity. Aligning retention is a separate concern.
+            for _table in ("tool_calls", "ranking_events"):
+                self._add_column_if_missing(conn, _table, "session_uid", "TEXT")
+                self._add_column_if_missing(conn, _table, "call_uid", "TEXT")
             self._perf_conns[str(path)] = conn
             return conn
         except Exception:

--- a/src/jcodemunch_mcp/storage/token_tracker.py
+++ b/src/jcodemunch_mcp/storage/token_tracker.py
@@ -935,8 +935,9 @@ class _State:
                         "INSERT INTO ranking_events "
                         "(ts, repo, tool, query_hash, query, returned_ids, "
                         " top1_score, top2_score, confidence, semantic_used, "
-                        " identity_hit, repo_is_stale, returned_count) "
-                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        " identity_hit, repo_is_stale, session_uid, call_uid, "
+                        "returned_count) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                         (
                             time.time(),
                             repo or None,
@@ -950,6 +951,8 @@ class _State:
                             1 if semantic_used else 0,
                             1 if identity_hit else 0,
                             1 if repo_is_stale else 0,
+                            self._session_uid,
+                            _CURRENT_CALL_UID.get(),
                             # #441. The TRUE size of the result set, recorded before
                             # the cap. The stored id list stays bounded; only the
                             # count is added, so a reader can tell a complete row
@@ -975,8 +978,18 @@ class _State:
             return
         try:
             conn.execute(
-                "INSERT INTO tool_calls (ts, tool, duration_ms, ok, repo) VALUES (?, ?, ?, ?, ?)",
-                (time.time(), tool, float(duration_ms), 1 if ok else 0, repo or None),
+                "INSERT INTO tool_calls "
+                "(ts, tool, duration_ms, ok, repo, session_uid, call_uid) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    time.time(),
+                    tool,
+                    float(duration_ms),
+                    1 if ok else 0,
+                    repo or None,
+                    self._session_uid,
+                    _CURRENT_CALL_UID.get(),
+                ),
             )
             self._perf_rows_since_trim += 1
             if self._perf_rows_since_trim >= 1000:

--- a/tests/test_issue_456_perf_correlation.py
+++ b/tests/test_issue_456_perf_correlation.py
@@ -279,18 +279,15 @@ def test_issue_456_writes_outside_dispatch_store_null_call_id(monkeypatch, tmp_p
     assert tool == ranking == (state._session_uid, None)
 
 
-def test_issue_456_telemetry_disabled_creates_no_database(monkeypatch, tmp_path):
-    _set_perf_enabled(monkeypatch, False)
-    state = token_tracker._State()
-    state.record_latency("disabled", 1.0, base_path=str(tmp_path))
-    state.record_ranking_event(
-        tool="disabled",
-        repo=None,
-        query="disabled",
-        returned_ids=[],
-        base_path=str(tmp_path),
-    )
-    assert not (tmp_path / "telemetry.db").exists()
+# The "behaviour with telemetry disabled is unchanged" half of the last acceptance
+# criterion has no test here on purpose. Upstream already pins it from three sides:
+# test_perf_telemetry.py::test_disabled_by_default_no_db_written for the latency sink,
+# test_ranking_ledger.py::test_disabled_no_db for the ranking sink, and
+# test_v1_108_276.py::test_telemetry_disabled_writes_nothing_and_opens_nothing for the
+# explicit base_path route and the connection cache. The new columns are only read
+# after those guards, so there is no pre-guard behaviour left to cover. The payload
+# half of the criterion does have a test below, because it guards a defect that
+# actually happened.
 
 
 def test_issue_456_outbound_payload_has_exact_legacy_keys(monkeypatch):
@@ -368,17 +365,9 @@ def test_issue_456_shipped_tool_writes_a_joinable_pair_through_module_state(
     assert ranking_session == token_tracker._state._session_uid
 
 
-def test_issue_456_context_helpers_restore_nested_values():
-    assert token_tracker._CURRENT_CALL_UID.get() is None
-    outer = token_tracker.begin_call_context("outer")
-    try:
-        assert token_tracker._CURRENT_CALL_UID.get() == "outer"
-        inner = token_tracker.begin_call_context("inner")
-        try:
-            assert token_tracker._CURRENT_CALL_UID.get() == "inner"
-        finally:
-            token_tracker.end_call_context(inner)
-        assert token_tracker._CURRENT_CALL_UID.get() == "outer"
-    finally:
-        token_tracker.end_call_context(outer)
-    assert token_tracker._CURRENT_CALL_UID.get() is None
+# There is no helper-level nesting test. The parametrized re-entrancy matrix above
+# asserts the same three properties -- inner gets its own value, outer still has its
+# original one afterwards, and the context returns to None -- through the real
+# dispatcher on order and route, under success and inner and outer failure. Testing
+# the helper in isolation only repeated that with literal values, and the literals
+# were the sole reason begin_call_context took a caller-supplied id at all.

--- a/tests/test_issue_456_perf_correlation.py
+++ b/tests/test_issue_456_perf_correlation.py
@@ -14,7 +14,6 @@ from jcodemunch_mcp import config as config_module
 from jcodemunch_mcp import server
 from jcodemunch_mcp.storage import token_tracker
 from jcodemunch_mcp.tools.index_folder import index_folder
-from jcodemunch_mcp.tools.search_symbols import search_symbols
 
 
 def _set_perf_enabled(monkeypatch: pytest.MonkeyPatch, enabled: bool) -> None:
@@ -310,17 +309,28 @@ def test_issue_456_outbound_payload_has_exact_legacy_keys(monkeypatch):
     assert not ({"session_uid", "call_uid"} & set(captured[0]))
 
 
-def test_issue_456_shipped_tool_writes_a_joinable_pair_through_module_state(
+@pytest.mark.asyncio
+async def test_issue_456_shipped_tool_writes_a_joinable_pair_through_module_state(
     monkeypatch, tmp_path
 ):
-    """The real tool, the module-level ``_state``, and a real ``LEFT JOIN``.
+    """The real dispatcher, the real tool, and the module-level ``_state``.
 
-    Every other test here drives a fresh ``_State()`` or stubs ``_call_tool_impl``.
-    The shipped tools write through the module singleton via the module-level
-    ``record_ranking_event``, so nothing above proves the ContextVar reaches the
-    object that actually does the writing. That is the seam where a later refactor
-    breaks this silently: the columns stay, those tests stay green, and ``call_uid``
-    quietly goes NULL.
+    Every other test here drives a fresh ``_State()`` or stubs ``_call_tool_impl``,
+    so nothing above runs the whole chain: the registered ``call_tool`` binds the
+    identity, the real ``_call_tool_impl`` runs the tool through
+    ``asyncio.to_thread``, the tool writes its ranking row through the module
+    singleton, and ``_call_tool_impl``'s own ``finally`` writes the latency row.
+    That is the seam where a later refactor breaks this silently: the columns stay,
+    those tests stay green, and ``call_uid`` quietly goes NULL.
+
+    ``asyncio.to_thread`` copies the context, so the boundary itself is safe by
+    construction; a raw ``threading.Thread`` is not. Driving the real path is what
+    keeps that a property of the code rather than of this test's own wiring.
+
+    ``CODE_INDEX_PATH`` is what ``_call_tool_impl`` hands the tool, while the
+    latency row is written against ``arguments["storage_path"]``. Both are set to
+    the temporary store: leaving the argument off sends the latency row to the
+    developer's real ``~/.code-index``.
     """
     _set_perf_enabled(monkeypatch, True)
     project = tmp_path / "sample"
@@ -330,25 +340,21 @@ def test_issue_456_shipped_tool_writes_a_joinable_pair_through_module_state(
     )
     store = tmp_path / "store"
     store.mkdir()
+    monkeypatch.setenv("CODE_INDEX_PATH", str(store))
 
     repo = index_folder(
         path=str(project), use_ai_summaries=False, storage_path=str(store)
     )["repo"]
 
-    token = token_tracker.begin_call_context()
-    try:
-        expected_call_uid = token_tracker._CURRENT_CALL_UID.get()
-        search_symbols(
-            repo=repo,
-            query="calculate_invoice_total",
-            storage_path=str(store),
-            max_results=5,
-        )
-        token_tracker.record_tool_latency(
-            "search_symbols", 3.0, ok=True, repo=repo, base_path=str(store)
-        )
-    finally:
-        token_tracker.end_call_context(token)
+    await server.call_tool(
+        "search_symbols",
+        {
+            "repo": repo,
+            "query": "calculate_invoice_total",
+            "storage_path": str(store),
+            "max_results": 5,
+        },
+    )
     token_tracker._state.close_perf_dbs()
 
     with _db(store / "telemetry.db") as conn:
@@ -361,7 +367,8 @@ def test_issue_456_shipped_tool_writes_a_joinable_pair_through_module_state(
     assert len(joined) == 1
     ranking_session, ranking_call, latency_call = joined[0]
     assert latency_call is not None, "the ranking row did not join a latency row"
-    assert ranking_call == latency_call == expected_call_uid
+    assert ranking_call is not None, "the dispatcher's call id did not reach the sink"
+    assert ranking_call == latency_call
     assert ranking_session == token_tracker._state._session_uid
 
 

--- a/tests/test_issue_456_perf_correlation.py
+++ b/tests/test_issue_456_perf_correlation.py
@@ -1,0 +1,308 @@
+"""Acceptance contracts for issue #456 perf-table correlation keys."""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from jcodemunch_mcp import config as config_module
+from jcodemunch_mcp import server
+from jcodemunch_mcp.storage import token_tracker
+
+
+def _set_perf_enabled(monkeypatch: pytest.MonkeyPatch, enabled: bool) -> None:
+    original_get = config_module.get
+
+    def configured_get(key: str, default=None, **kwargs):
+        if key == "perf_telemetry_enabled":
+            return enabled
+        return original_get(key, default, **kwargs)
+
+    monkeypatch.setattr(config_module, "get", configured_get)
+
+
+def _columns(db_path: Path, table: str) -> set[str]:
+    with sqlite3.connect(db_path) as conn:
+        return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def test_issue_456_fresh_database_has_both_keys_on_both_tables(monkeypatch, tmp_path):
+    _set_perf_enabled(monkeypatch, True)
+    state = token_tracker._State()
+    state.record_latency("fresh", 1.0, base_path=str(tmp_path))
+    db_path = tmp_path / "telemetry.db"
+
+    for table in ("tool_calls", "ranking_events"):
+        assert {"session_uid", "call_uid"} <= _columns(db_path, table)
+    state.close_perf_dbs()
+
+
+def test_issue_456_legacy_rows_remain_null_after_four_column_migration(
+    monkeypatch, tmp_path
+):
+    _set_perf_enabled(monkeypatch, True)
+    db_path = tmp_path / "telemetry.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE tool_calls (ts REAL NOT NULL, tool TEXT NOT NULL, "
+            "duration_ms REAL NOT NULL, ok INTEGER NOT NULL, repo TEXT)"
+        )
+        conn.execute("INSERT INTO tool_calls VALUES (1, 'legacy-tool', 2, 1, 'repo')")
+        conn.execute(
+            "CREATE TABLE ranking_events (ts REAL NOT NULL, repo TEXT, "
+            "tool TEXT NOT NULL, query_hash TEXT NOT NULL, query TEXT, "
+            "returned_ids TEXT NOT NULL, top1_score REAL, top2_score REAL, "
+            "confidence REAL, semantic_used INTEGER NOT NULL, "
+            "identity_hit INTEGER NOT NULL, repo_is_stale INTEGER NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO ranking_events VALUES "
+            "(1, 'repo', 'legacy-rank', 'hash', 'query', '[]', NULL, NULL, "
+            "NULL, 0, 0, 0)"
+        )
+
+    state = token_tracker._State()
+    state.record_latency("current-tool", 3.0, base_path=str(tmp_path))
+    state.record_ranking_event(
+        tool="current-rank",
+        repo="repo",
+        query="query",
+        returned_ids=[],
+        base_path=str(tmp_path),
+    )
+    state.close_perf_dbs()
+
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(
+            "SELECT session_uid, call_uid FROM tool_calls WHERE tool='legacy-tool'"
+        ).fetchone() == (None, None)
+        assert conn.execute(
+            "SELECT session_uid, call_uid FROM ranking_events "
+            "WHERE tool='legacy-rank'"
+        ).fetchone() == (None, None)
+
+
+def test_issue_456_schema_probe_runs_once_per_resolved_path(monkeypatch, tmp_path):
+    _set_perf_enabled(monkeypatch, True)
+    original = token_tracker._State._add_column_if_missing
+    probes: list[tuple[str, str, str]] = []
+
+    def observed_probe(conn, table, column, decl):
+        path = str(conn.execute("PRAGMA database_list").fetchone()[2])
+        if column in {"session_uid", "call_uid"}:
+            probes.append((str(Path(path).resolve()), table, column))
+        return original(conn, table, column, decl)
+
+    monkeypatch.setattr(
+        token_tracker._State, "_add_column_if_missing", staticmethod(observed_probe)
+    )
+    state = token_tracker._State()
+    paths = [tmp_path / "one", tmp_path / "two"]
+    for path in paths:
+        path.mkdir()
+    state.record_latency("first", 1.0, base_path=str(paths[0]))
+    state.record_latency("second", 1.0, base_path=str(paths[0]))
+    state.record_latency("third", 1.0, base_path=str(paths[1]))
+    state.close_perf_dbs()
+
+    expected = {
+        (str((path / "telemetry.db").resolve()), table, column)
+        for path in paths
+        for table in ("tool_calls", "ranking_events")
+        for column in ("session_uid", "call_uid")
+    }
+    assert set(probes) == expected
+    for probe in expected:
+        assert probes.count(probe) == 1
+
+
+@pytest.mark.asyncio
+async def test_issue_456_one_dispatcher_entry_joins_ranking_and_latency(
+    monkeypatch, tmp_path
+):
+    _set_perf_enabled(monkeypatch, True)
+    state = token_tracker._State()
+
+    async def write_both(_name: str, _arguments: dict):
+        state.record_ranking_event(
+            tool="search_symbols",
+            repo="repo",
+            query="query",
+            returned_ids=["symbol"],
+            base_path=str(tmp_path),
+        )
+        state.record_latency(
+            "search_symbols", 2.0, repo="repo", base_path=str(tmp_path)
+        )
+        return []
+
+    monkeypatch.setattr(server, "_call_tool_impl", write_both)
+    await server.call_tool("search_symbols", {})
+    state.close_perf_dbs()
+
+    with sqlite3.connect(tmp_path / "telemetry.db") as conn:
+        ranking = conn.execute(
+            "SELECT session_uid, call_uid FROM ranking_events"
+        ).fetchone()
+        latency = conn.execute(
+            "SELECT session_uid, call_uid FROM tool_calls"
+        ).fetchone()
+    assert ranking == latency
+    assert ranking[0] == state._session_uid
+    assert ranking[1]
+
+
+@pytest.mark.asyncio
+async def test_issue_456_concurrent_dispatcher_entries_have_distinct_call_ids(
+    monkeypatch,
+):
+    observations: dict[str, tuple[str | None, str | None]] = {}
+
+    async def observe(name: str, _arguments: dict):
+        before = token_tracker._CURRENT_CALL_UID.get()
+        await asyncio.sleep(0)
+        observations[name] = (before, token_tracker._CURRENT_CALL_UID.get())
+        return []
+
+    monkeypatch.setattr(server, "_call_tool_impl", observe)
+    await asyncio.gather(server.call_tool("one", {}), server.call_tool("two", {}))
+
+    assert observations["one"][0] == observations["one"][1]
+    assert observations["two"][0] == observations["two"][1]
+    assert observations["one"][0] != observations["two"][0]
+    assert token_tracker._CURRENT_CALL_UID.get() is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["order", "route"])
+@pytest.mark.parametrize("failure", [None, "inner", "outer"])
+async def test_issue_456_reentrant_dispatch_restores_context_on_success_and_failure(
+    monkeypatch, mode, failure
+):
+    observed: dict[str, str | None] = {}
+    scenario = {"failure": failure}
+
+    monkeypatch.setattr(server, "_catalog_names", lambda: ["inner"])
+    monkeypatch.setattr(server._counter, "order_gate", lambda *args: None)
+    monkeypatch.setattr(
+        server._counter,
+        "classify_intent",
+        lambda *args: [{"action": "inner", "why": "test"}],
+    )
+    monkeypatch.setattr(
+        server._counter,
+        "shape_execute_args",
+        lambda *args: {"fail_inner": scenario["failure"] == "inner"},
+    )
+    monkeypatch.setattr(server._counter, "is_state_changing", lambda *args: False)
+
+    async def reentrant(name: str, arguments: dict):
+        if name in {"order", "route"}:
+            observed["outer_before"] = token_tracker._CURRENT_CALL_UID.get()
+            try:
+                result = await (
+                    server._handle_order(arguments)
+                    if name == "order"
+                    else server._handle_route(arguments)
+                )
+                if scenario["failure"] == "outer":
+                    raise RuntimeError("outer failure")
+                return result
+            finally:
+                observed["outer_after"] = token_tracker._CURRENT_CALL_UID.get()
+        observed["inner"] = token_tracker._CURRENT_CALL_UID.get()
+        if arguments.get("fail_inner"):
+            raise RuntimeError("inner failure")
+        return []
+
+    monkeypatch.setattr(server, "_call_tool_impl", reentrant)
+    arguments = (
+        {"action": "inner", "args": {"fail_inner": failure == "inner"}}
+        if mode == "order"
+        else {"task": "inner", "execute": True}
+    )
+    if failure:
+        with pytest.raises(RuntimeError, match=f"{failure} failure"):
+            await server.call_tool(mode, arguments)
+    else:
+        await server.call_tool(mode, arguments)
+
+    assert observed["outer_before"] == observed["outer_after"]
+    assert observed["inner"] != observed["outer_before"]
+    assert observed["inner"] and observed["outer_before"]
+    assert token_tracker._CURRENT_CALL_UID.get() is None
+
+
+def test_issue_456_writes_outside_dispatch_store_null_call_id(monkeypatch, tmp_path):
+    _set_perf_enabled(monkeypatch, True)
+    state = token_tracker._State()
+    state.record_latency("outside", 1.0, base_path=str(tmp_path))
+    state.record_ranking_event(
+        tool="outside",
+        repo=None,
+        query="outside",
+        returned_ids=[],
+        base_path=str(tmp_path),
+    )
+    state.close_perf_dbs()
+
+    with sqlite3.connect(tmp_path / "telemetry.db") as conn:
+        tool = conn.execute("SELECT session_uid, call_uid FROM tool_calls").fetchone()
+        ranking = conn.execute(
+            "SELECT session_uid, call_uid FROM ranking_events"
+        ).fetchone()
+    assert tool == ranking == (state._session_uid, None)
+
+
+def test_issue_456_telemetry_disabled_creates_no_database(monkeypatch, tmp_path):
+    _set_perf_enabled(monkeypatch, False)
+    state = token_tracker._State()
+    state.record_latency("disabled", 1.0, base_path=str(tmp_path))
+    state.record_ranking_event(
+        tool="disabled",
+        repo=None,
+        query="disabled",
+        returned_ids=[],
+        base_path=str(tmp_path),
+    )
+    assert not (tmp_path / "telemetry.db").exists()
+
+
+def test_issue_456_outbound_payload_has_exact_legacy_keys(monkeypatch):
+    captured: list[dict] = []
+    work_queue: queue.Queue = queue.Queue()
+    work_queue.put((1, 2, "anonymous"))
+    work_queue.put(None)
+    monkeypatch.setattr(token_tracker, "_telemetry_queue", work_queue)
+
+    import httpx
+
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda _url, *, json, timeout: captured.append(json),
+    )
+    token_tracker._telemetry_worker()
+
+    assert captured == [{"delta": 1, "total": 2, "anon_id": "anonymous"}]
+    assert not ({"session_uid", "call_uid"} & set(captured[0]))
+
+
+def test_issue_456_context_helpers_restore_nested_values():
+    assert token_tracker._CURRENT_CALL_UID.get() is None
+    outer = token_tracker.begin_call_context("outer")
+    try:
+        assert token_tracker._CURRENT_CALL_UID.get() == "outer"
+        inner = token_tracker.begin_call_context("inner")
+        try:
+            assert token_tracker._CURRENT_CALL_UID.get() == "inner"
+        finally:
+            token_tracker.end_call_context(inner)
+        assert token_tracker._CURRENT_CALL_UID.get() == "outer"
+    finally:
+        token_tracker.end_call_context(outer)
+    assert token_tracker._CURRENT_CALL_UID.get() is None

--- a/tests/test_issue_456_perf_correlation.py
+++ b/tests/test_issue_456_perf_correlation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import queue
 import sqlite3
 from pathlib import Path
@@ -12,6 +13,8 @@ import pytest
 from jcodemunch_mcp import config as config_module
 from jcodemunch_mcp import server
 from jcodemunch_mcp.storage import token_tracker
+from jcodemunch_mcp.tools.index_folder import index_folder
+from jcodemunch_mcp.tools.search_symbols import search_symbols
 
 
 def _set_perf_enabled(monkeypatch: pytest.MonkeyPatch, enabled: bool) -> None:
@@ -25,8 +28,26 @@ def _set_perf_enabled(monkeypatch: pytest.MonkeyPatch, enabled: bool) -> None:
     monkeypatch.setattr(config_module, "get", configured_get)
 
 
+@contextlib.contextmanager
+def _db(path):
+    """Commit like ``sqlite3``'s own context manager, and also CLOSE.
+
+    ``with sqlite3.connect(...)`` commits or rolls back; it does NOT close, and an
+    open handle blocks ``tmp_path`` teardown on Windows, which is the same reason
+    ``close_perf_dbs()`` is public. The inner ``with conn`` keeps the commit
+    semantics the callers below depend on: dropping it rolls back the legacy-schema
+    fixture, which is how this was caught.
+    """
+    conn = sqlite3.connect(path)
+    try:
+        with conn:
+            yield conn
+    finally:
+        conn.close()
+
+
 def _columns(db_path: Path, table: str) -> set[str]:
-    with sqlite3.connect(db_path) as conn:
+    with _db(db_path) as conn:
         return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
 
 
@@ -46,7 +67,7 @@ def test_issue_456_legacy_rows_remain_null_after_four_column_migration(
 ):
     _set_perf_enabled(monkeypatch, True)
     db_path = tmp_path / "telemetry.db"
-    with sqlite3.connect(db_path) as conn:
+    with _db(db_path) as conn:
         conn.execute(
             "CREATE TABLE tool_calls (ts REAL NOT NULL, tool TEXT NOT NULL, "
             "duration_ms REAL NOT NULL, ok INTEGER NOT NULL, repo TEXT)"
@@ -76,7 +97,7 @@ def test_issue_456_legacy_rows_remain_null_after_four_column_migration(
     )
     state.close_perf_dbs()
 
-    with sqlite3.connect(db_path) as conn:
+    with _db(db_path) as conn:
         assert conn.execute(
             "SELECT session_uid, call_uid FROM tool_calls WHERE tool='legacy-tool'"
         ).fetchone() == (None, None)
@@ -144,7 +165,7 @@ async def test_issue_456_one_dispatcher_entry_joins_ranking_and_latency(
     await server.call_tool("search_symbols", {})
     state.close_perf_dbs()
 
-    with sqlite3.connect(tmp_path / "telemetry.db") as conn:
+    with _db(tmp_path / "telemetry.db") as conn:
         ranking = conn.execute(
             "SELECT session_uid, call_uid FROM ranking_events"
         ).fetchone()
@@ -250,7 +271,7 @@ def test_issue_456_writes_outside_dispatch_store_null_call_id(monkeypatch, tmp_p
     )
     state.close_perf_dbs()
 
-    with sqlite3.connect(tmp_path / "telemetry.db") as conn:
+    with _db(tmp_path / "telemetry.db") as conn:
         tool = conn.execute("SELECT session_uid, call_uid FROM tool_calls").fetchone()
         ranking = conn.execute(
             "SELECT session_uid, call_uid FROM ranking_events"
@@ -290,6 +311,61 @@ def test_issue_456_outbound_payload_has_exact_legacy_keys(monkeypatch):
 
     assert captured == [{"delta": 1, "total": 2, "anon_id": "anonymous"}]
     assert not ({"session_uid", "call_uid"} & set(captured[0]))
+
+
+def test_issue_456_shipped_tool_writes_a_joinable_pair_through_module_state(
+    monkeypatch, tmp_path
+):
+    """The real tool, the module-level ``_state``, and a real ``LEFT JOIN``.
+
+    Every other test here drives a fresh ``_State()`` or stubs ``_call_tool_impl``.
+    The shipped tools write through the module singleton via the module-level
+    ``record_ranking_event``, so nothing above proves the ContextVar reaches the
+    object that actually does the writing. That is the seam where a later refactor
+    breaks this silently: the columns stay, those tests stay green, and ``call_uid``
+    quietly goes NULL.
+    """
+    _set_perf_enabled(monkeypatch, True)
+    project = tmp_path / "sample"
+    project.mkdir()
+    (project / "billing.py").write_text(
+        "def calculate_invoice_total(items):\n    return sum(items)\n", encoding="utf-8"
+    )
+    store = tmp_path / "store"
+    store.mkdir()
+
+    repo = index_folder(
+        path=str(project), use_ai_summaries=False, storage_path=str(store)
+    )["repo"]
+
+    token = token_tracker.begin_call_context()
+    try:
+        expected_call_uid = token_tracker._CURRENT_CALL_UID.get()
+        search_symbols(
+            repo=repo,
+            query="calculate_invoice_total",
+            storage_path=str(store),
+            max_results=5,
+        )
+        token_tracker.record_tool_latency(
+            "search_symbols", 3.0, ok=True, repo=repo, base_path=str(store)
+        )
+    finally:
+        token_tracker.end_call_context(token)
+    token_tracker._state.close_perf_dbs()
+
+    with _db(store / "telemetry.db") as conn:
+        joined = conn.execute(
+            "SELECT r.session_uid, r.call_uid, t.call_uid FROM ranking_events r "
+            "LEFT JOIN tool_calls t "
+            "  ON r.call_uid = t.call_uid AND r.session_uid = t.session_uid"
+        ).fetchall()
+
+    assert len(joined) == 1
+    ranking_session, ranking_call, latency_call = joined[0]
+    assert latency_call is not None, "the ranking row did not join a latency row"
+    assert ranking_call == latency_call == expected_call_uid
+    assert ranking_session == token_tracker._state._session_uid
 
 
 def test_issue_456_context_helpers_restore_nested_values():


### PR DESCRIPTION
Closes #456.

`ranking_events` and `tool_calls` now carry nullable `session_uid` and `call_uid`, so a ranking
event can be attributed to the call that produced it. Three files, 442 insertions, 5 deletions, 62
of them source.

```python
+            for _table in ("tool_calls", "ranking_events"):
+                self._add_column_if_missing(conn, _table, "session_uid", "TEXT")
+                self._add_column_if_missing(conn, _table, "call_uid", "TEXT")
```

```python
 async def call_tool(name: str, arguments: dict) -> list[TextContent] | CallToolResult:
+    call_token = begin_call_context()
+    try:
         return _enforce_response_cap(name, await _call_tool_impl(name, arguments))
+    finally:
+        end_call_context(call_token)
```

Both sinks read `self._session_uid` and `_CURRENT_CALL_UID.get()` at write time, so the six
`record_ranking_event` call sites and the single latency call site are unchanged.

## Why a ContextVar set at the dispatcher

The identity has to reach two sinks that no one call site owns: ranking
([`:913`](https://github.com/jgravelle/jcodemunch-mcp/blob/2e3883a/src/jcodemunch_mcp/storage/token_tracker.py#L913))
and latency
([`:956`](https://github.com/jgravelle/jcodemunch-mcp/blob/2e3883a/src/jcodemunch_mcp/storage/token_tracker.py#L956)),
written from different paths, with `record_latency` also reached directly by the front door.
Setting it once at the registered `call_tool`
([`:5280`](https://github.com/jgravelle/jcodemunch-mcp/blob/2e3883a/src/jcodemunch_mcp/server.py#L5280))
gives every route one identity with no call-site and no signature change.

The dispatcher is re-entrant. `order` and executable `route` both re-enter `call_tool`, so one
client request can produce two `tool_calls` rows, and each entry needs its own `call_uid` to keep a
ranking event joined to exactly one latency row. Reset is by token rather than by setting `None`,
which would clear the outer entry's value and write `NULL` for it. That analysis sits at the set
site in `server.py`.

The columns are added the additive way `returned_count` was
([`:798`](https://github.com/jgravelle/jcodemunch-mcp/blob/2e3883a/src/jcodemunch_mcp/storage/token_tracker.py#L798)),
not declared in `CREATE TABLE`, so the schema keeps one source of truth.

## The tests

The focused file collects 14 cases across nine named tests, in the order the issue names the
criteria. Existing upstream tests keep the telemetry-disabled coverage; this file adds the
issue-specific behaviour and the payload check.

- **Schema.** Both columns on both tables on a fresh database; legacy rows still `NULL` after a
  four-column migration; the probe runs once per resolved path per process.
- **Identity.** One dispatcher entry joins its ranking and latency rows; concurrent entries get
  distinct ids; re-entrant dispatch restores the outer context on both success and failure.
- **Boundaries.** A write outside any dispatched call stores `NULL` rather than inventing an
  identity, and the outbound payload keeps exactly its legacy keys.
- **The shipped path.** A real `server.call_tool("search_symbols", ...)` runs the whole chain: the
  dispatcher binds the identity, `_call_tool_impl` runs the tool through `asyncio.to_thread`, the
  tool writes its ranking row through the module singleton, and the latency row comes from
  `_call_tool_impl`'s own `finally`. Both rows carry the same non-null session and call id.

## Verification

- Focused suite: **14 passed**.
- **Blanking the read turns the suite red**, with the two sites gated separately rather than
  mutated together.
- Full suite under CI's own command on Windows 11 / Python 3.13.7: **7829 passed / 16 skipped**,
  against **7815 / 16** on the base: **+14**, no skip change. Both arms back to back from one
  checkout, coverage gate met at 79.67%.

  ```bash
  uv sync --locked --group dev --extra watch
  uv run pytest tests/ -v --tb=short --cov=src --cov-report=term-missing --cov-fail-under=74
  ```

  That is one leg. Your matrix covers Ubuntu and Windows across 3.10 to 3.13 and will report on
  the PR itself.
- `ruff check src/` clean, `compileall` clean.
- Rebased onto `2e3883a`. Every hunk header is unchanged: #473 substitutes two lines for two in
  `_perf_db_path` and shifts nothing under this branch.

## Existing installs

Existing databases migrate additively. `perf_telemetry_enabled` is `False` by default, so most
installs open no perf database at all; where it is on, the first write after upgrade adds the four
columns through the same `_add_column_if_missing` path `returned_count` uses. Both are nullable,
existing rows keep `NULL`, and nothing backfills them. No index, foreign key, retention or reader
change.

Two properties worth knowing before querying: `tool_calls` is trimmed to a rolling cap while
`ranking_events` is not, so the join is best-effort and wants `LEFT JOIN`; and `COUNT(DISTINCT
call_uid)` counts dispatcher entries rather than client requests, with the front-door row having no
matching ranking event. The `LEFT JOIN` contract sits at the migration site.