### PR TITLE
bench: measure the Counter front door, and stop quoting its saving

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,6 +286,27 @@ the r/codex result than the raw number suggests, not a stronger one.**
 default `full`, 6 / 1,030 at `counter`) and needs no API credits; what it does
 not measure is what that costs in practice.
 
+⚠ **Those two numbers are a 2026-07 snapshot from THIS harness and are not the
+canonical figures.** `benchmarks/schema_baseline.json` is, written by
+`benchmarks/harness/capture_schema_baseline.py` and guarded by
+`tests/test_schema_budget.py`; it counts a different payload shape, so the two
+sets will never agree digit for digit and neither is wrong. Quote the baseline
+file. ⚠⚠ **Reconciled 2026-08-14: the Counter avoids 95.9%, not the ~98% that
+`run_route_recall.py` asserted for two months** — that literal is now computed
+from the baseline at runtime, with a test that fails if any schema-saving
+percentage returns to that file. **The gap existed because the budget guardrail
+only walked `tool_profile`, which does not apply to the front door at all**, so
+the single largest lever in the project had no test under it.
+
+⚠⚠ **The same run killed `tool_profile: "standard"` as a token lever: it drops 9
+of 91 tools and 5.7% of the payload.** Anyone selecting it as the safe middle
+setting gets nothing measurable. `core` (74.0%) and `counter` (95.9%) are the
+only two settings that move the number; there is no gradient between them, and
+the config surface currently implies there is. ⚠ Where the rest sits, from
+`--breakdown`: under `full`, tool DESCRIPTIONS are 36% of the payload and
+`compact_schemas` rewrites input schemas only, never descriptions. Schema
+compaction is near its floor; descriptions are untouched ground.
+
 ⚠ Design flaw recorded so nobody repeats it: summing per-invocation input across
 a RESUMED conversation counts accumulated context on every step, so the total is
 dominated by how much the agent read early on, which compounds.

--- a/benchmarks/harness/capture_schema_baseline.py
+++ b/benchmarks/harness/capture_schema_baseline.py
@@ -1,20 +1,34 @@
-"""Capture tools/list schema token counts at each profile x compact combo.
+"""Capture tools/list schema token counts at each surface x profile x compact combo.
 
 §0 pre-flight for the v2.0.0 context-optimization work. These numbers become
 the regression guardrails in §7 (see tests/test_schema_budget.py).
 
 Run from the repo root:
     PYTHONPATH=src python benchmarks/harness/capture_schema_baseline.py
+    PYTHONPATH=src python benchmarks/harness/capture_schema_baseline.py --breakdown
 
 Output: benchmarks/schema_baseline.json
 
 Methodology: tokenize the JSON-serialized tool list with tiktoken cl100k_base
 (the OpenAI/Anthropic-compatible GPT-4 tokenizer). Schemas are serialized with
 the same compaction the server uses for its on-wire tool list.
+
+⚠ cl100k_base is a PROXY for the tokenizer any given client actually uses. The
+absolute counts here are approximate; the ratios between arms are not. Measured
+2026-08-14, the same arms in o200k_base and in raw UTF-8 bytes reproduce every
+percentage in this file to within 0.3 points. Publish the ratios, not the
+absolutes.
+
+⚠⚠ `tool_surface: "counter"` is measured here because it is the only arm that
+changes the answer by an order of magnitude, and it was previously quoted from
+memory rather than from a run. See --breakdown for where the remaining budget
+sits: under `full`, tool DESCRIPTIONS are ~36% of the payload and
+`compact_schemas` does not touch them.
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -33,6 +47,11 @@ from jcodemunch_mcp.server import _build_tools_list  # noqa: E402
 PROFILES = ["core", "standard", "full"]
 COMPACT_FLAGS = [True, False]
 
+# Keys that were frozen before `tool_surface` was measured. Every one of these
+# is an arm of `tool_surface: "full"`; the counter arms carry the surface in the
+# key so the two families can never be compared by accident.
+_CFG_KEYS = ("tool_profile", "compact_schemas", "tool_surface")
+
 
 def _tools_to_serialized(tools) -> str:
     payload = [
@@ -46,21 +65,35 @@ def _count_tokens(text: str, encoding) -> int:
     return len(encoding.encode(text))
 
 
+def _arms() -> list[tuple[str, dict]]:
+    """(baseline key, config overrides) for every measured arm."""
+    arms: list[tuple[str, dict]] = []
+    for profile in PROFILES:
+        for compact in COMPACT_FLAGS:
+            key = f"{profile}_{'compact' if compact else 'full'}"
+            arms.append(
+                (key, {"tool_surface": "full", "tool_profile": profile, "compact_schemas": compact})
+            )
+    # The front door replaces the catalog outright, so tool_profile does not
+    # apply to it. compact_schemas is measured anyway to record that it is a
+    # no-op here rather than to leave a reader guessing.
+    for compact in COMPACT_FLAGS:
+        key = f"counter_{'compact' if compact else 'full'}"
+        arms.append((key, {"tool_surface": "counter", "compact_schemas": compact}))
+    return arms
+
+
 def capture(out_path: Path) -> dict:
     encoding = tiktoken.get_encoding("cl100k_base")
     results: dict[str, int] = {}
     cfg = config_module._GLOBAL_CONFIG  # type: ignore[attr-defined]
-    original = {k: cfg.get(k) for k in ("tool_profile", "compact_schemas")}
+    original = {k: cfg.get(k) for k in _CFG_KEYS}
     try:
-        for profile in PROFILES:
-            for compact in COMPACT_FLAGS:
-                cfg["tool_profile"] = profile
-                cfg["compact_schemas"] = compact
-                tools = _build_tools_list()
-                text = _tools_to_serialized(tools)
-                key = f"{profile}_{'compact' if compact else 'full'}"
-                results[key] = _count_tokens(text, encoding)
-                print(f"  {key}: {results[key]} tokens ({len(tools)} tools)")
+        for key, overrides in _arms():
+            cfg.update(overrides)
+            tools = _build_tools_list()
+            results[key] = _count_tokens(_tools_to_serialized(tools), encoding)
+            print(f"  {key}: {results[key]} tokens ({len(tools)} tools)")
     finally:
         for k, v in original.items():
             if v is None:
@@ -73,8 +106,67 @@ def capture(out_path: Path) -> dict:
     return results
 
 
+def breakdown() -> None:
+    """Where the payload actually goes, per arm and per tool.
+
+    Answers the question the totals cannot: is there room left to cut, and in
+    which of the three components. Prints only — nothing here is frozen as a
+    guardrail, because per-tool costs move on every description edit.
+    """
+    encoding = tiktoken.get_encoding("cl100k_base")
+    cfg = config_module._GLOBAL_CONFIG  # type: ignore[attr-defined]
+    original = {k: cfg.get(k) for k in _CFG_KEYS}
+    try:
+        print(f"\n{'arm':18} {'names':>7} {'descriptions':>13} {'schemas':>9} {'desc share':>11}")
+        for key, overrides in _arms():
+            cfg.update(overrides)
+            tools = _build_tools_list()
+            names = sum(_count_tokens(t.name, encoding) for t in tools)
+            descs = sum(_count_tokens(t.description or "", encoding) for t in tools)
+            schemas = sum(
+                _count_tokens(json.dumps(t.inputSchema, separators=(",", ":")), encoding)
+                for t in tools
+            )
+            total = names + descs + schemas
+            share = descs / total * 100 if total else 0.0
+            print(f"{key:18} {names:7} {descs:13} {schemas:9} {share:10.1f}%")
+
+        cfg.update({"tool_surface": "full", "tool_profile": "full", "compact_schemas": False})
+        tools = _build_tools_list()
+        per_tool = {
+            t.name: _count_tokens(
+                json.dumps(
+                    {"name": t.name, "description": t.description, "inputSchema": t.inputSchema},
+                    separators=(",", ":"),
+                ),
+                encoding,
+            )
+            for t in tools
+        }
+        grand = sum(per_tool.values())
+        print("\ntop 10 schema cost (tool_surface=full, tool_profile=full):")
+        for name, count in sorted(per_tool.items(), key=lambda kv: -kv[1])[:10]:
+            print(f"  {name:34} {count:6}  {count / grand * 100:4.1f}%")
+    finally:
+        for k, v in original.items():
+            if v is None:
+                cfg.pop(k, None)
+            else:
+                cfg[k] = v
+
+
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--breakdown",
+        action="store_true",
+        help="also print the names/descriptions/schemas split and the 10 costliest tools",
+    )
+    args = parser.parse_args()
+
     out = Path(__file__).resolve().parent.parent / "schema_baseline.json"
     data = capture(out)
     print(f"\nWrote baseline to {out}")
     print(json.dumps(data, indent=2))
+    if args.breakdown:
+        breakdown()

--- a/benchmarks/route_recall/run_route_recall.py
+++ b/benchmarks/route_recall/run_route_recall.py
@@ -4,9 +4,20 @@ Answers one question: when a user phrases a task in their own words, does the
 Counter's front door propose the action that answers it?
 
 This gates whether ``tool_surface=counter`` can become the default. The Counter
-avoids ~98% of resident schema tokens; the cost it trades against is recall,
-because an action ``route`` never proposes is functionally absent. That cost has
-never been measured.
+avoids most of the resident schema tokens -- the exact share is printed at the
+top of every run, computed from ``benchmarks/schema_baseline.json`` -- and the
+cost it trades against is recall, because an action ``route`` never proposes is
+functionally absent. That cost has never been measured.
+
+⚠ This docstring asserted a hand-typed figure until 2026-08-14, when the arm was
+measured for the first time and came back lower. The number is now READ from the
+frozen baseline rather than written here, per maintenance practice #4: this file
+is a recall harness, so a schema-cost figure in it is a transcription with no run
+behind it and nothing that fails when it drifts. The old literal is deliberately
+not repeated in this note -- ``tests/test_schema_budget.py`` fails on any
+schema-saving percentage appearing in this file, including a historical one.
+⚠⚠ The direction is why it mattered: overstating the saving makes the recall
+trade this harness exists to price look cheaper than it is.
 
 Two paths are measured separately because they are different code:
 
@@ -39,6 +50,8 @@ HERE = Path(__file__).resolve().parent
 CORPUS = HERE / "queries.json"
 RESULTS = HERE / "results.json"
 
+SCHEMA_BASELINE = HERE.parent / "schema_baseline.json"
+
 MENU_KS = (1, 3, 5, 10)
 ROUTE_KS = (1, 3)
 MENU_LIMIT = 10
@@ -52,6 +65,27 @@ def _load_catalog():
     from jcodemunch_mcp.server import _catalog_names, _catalog_rows
 
     return _counter, _catalog_rows(), sorted(_catalog_names())
+
+
+def _schema_saving() -> str:
+    """What the Counter buys, read from the frozen baseline rather than typed.
+
+    The recall this harness measures is the price of that saving, so the two
+    belong on screen together. A missing or partial baseline returns a plain
+    'not measured' -- it must never fall back to a remembered figure, which is
+    the exact defect this replaced (the docstring said ~98%; it is lower).
+    """
+    try:
+        base = json.loads(SCHEMA_BASELINE.read_text(encoding="utf-8"))
+        full, counter = base["full_full"], base["counter_full"]
+    except (OSError, ValueError, KeyError):
+        return ("schema saving: not measured -- run "
+                "benchmarks/harness/capture_schema_baseline.py")
+    return (
+        f"schema saving: {100 * (full - counter) / full:.1f}% "
+        f"({counter} tokens at counter vs {full} at the default surface, "
+        f"cl100k_base, from {SCHEMA_BASELINE.name})"
+    )
 
 
 def _rank_of_target(ordered_actions, targets):
@@ -96,6 +130,8 @@ def main() -> int:
              "<corpus stem>_results.json for a non-default corpus)",
     )
     args = ap.parse_args()
+
+    print(_schema_saving())
 
     counter, rows, names = _load_catalog()
     name_set = set(names)

--- a/benchmarks/schema_baseline.json
+++ b/benchmarks/schema_baseline.json
@@ -1,8 +1,10 @@
 {
-  "core_compact": 3996,
-  "core_full": 5811,
-  "standard_compact": 18875,
-  "standard_full": 20927,
-  "full_compact": 20185,
-  "full_full": 22237
+  "core_compact": 3885,
+  "core_full": 5913,
+  "standard_compact": 19083,
+  "standard_full": 21431,
+  "full_compact": 20393,
+  "full_full": 22741,
+  "counter_compact": 939,
+  "counter_full": 939
 }

--- a/tests/test_schema_budget.py
+++ b/tests/test_schema_budget.py
@@ -43,11 +43,12 @@ def test_schema_tokens_within_baseline_tolerance():
     encoding = _tk.get_encoding("cl100k_base")
 
     cfg = config_module._GLOBAL_CONFIG  # type: ignore[attr-defined]
-    original = {k: cfg.get(k) for k in ("tool_profile", "compact_schemas")}
+    original = {k: cfg.get(k) for k in ("tool_profile", "compact_schemas", "tool_surface")}
     drifts: list[str] = []
     try:
         for profile in ("core", "standard", "full"):
             for compact in (True, False):
+                cfg["tool_surface"] = "full"
                 cfg["tool_profile"] = profile
                 cfg["compact_schemas"] = compact
                 tools = _build_tools_list()
@@ -80,6 +81,97 @@ def test_schema_tokens_within_baseline_tolerance():
         "Schema token budget exceeded. Either shrink the change or update "
         "benchmarks/schema_baseline.json in the same PR with justification. "
         f"Drifts: {drifts}"
+    )
+
+
+@pytest.mark.skipif(not _HAS_TIKTOKEN, reason="tiktoken not installed")
+@pytest.mark.skipif(not BASELINE.is_file(), reason="benchmarks/schema_baseline.json missing — run benchmarks/harness/capture_schema_baseline.py")
+def test_counter_surface_within_baseline_tolerance():
+    """`tool_surface: "counter"` is the largest lever this project has, and it
+    sat outside the guardrail until 2026-08-14 — the loop above only walks
+    tool_profile, which does not apply to the front door at all.
+
+    ⚠ The cost of that gap was not drift, it was a published number nothing
+    checked: `run_route_recall.py` claimed the Counter avoided ~98% of resident
+    schema tokens for two months. Measured, it is lower. A saving quoted in a
+    docstring with no test under it is a transcription, and this is the test.
+    """
+    import tiktoken as _tk
+
+    from jcodemunch_mcp import config as config_module
+    from jcodemunch_mcp.server import _build_tools_list
+
+    baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+    encoding = _tk.get_encoding("cl100k_base")
+
+    cfg = config_module._GLOBAL_CONFIG  # type: ignore[attr-defined]
+    original = {k: cfg.get(k) for k in ("tool_profile", "compact_schemas", "tool_surface")}
+    drifts: list[str] = []
+    try:
+        for compact in (True, False):
+            cfg["tool_surface"] = "counter"
+            cfg["compact_schemas"] = compact
+            tools = _build_tools_list()
+            payload = [
+                {"name": t.name, "description": t.description, "inputSchema": t.inputSchema}
+                for t in tools
+            ]
+            count = len(encoding.encode(json.dumps(payload, separators=(",", ":"))))
+
+            key = f"counter_{'compact' if compact else 'full'}"
+            base = baseline.get(key)
+            if base is None:
+                drifts.append(f"{key}: no baseline entry (add {count} to schema_baseline.json)")
+                continue
+            ceiling = int(base * (1 + DRIFT_TOLERANCE))
+            if count > ceiling:
+                drifts.append(
+                    f"{key}: {count} tokens > {ceiling} ceiling "
+                    f"(baseline {base}, +{(count - base) / base:.1%})"
+                )
+    finally:
+        for k, v in original.items():
+            if v is None:
+                cfg.pop(k, None)
+            else:
+                cfg[k] = v
+
+    assert not drifts, (
+        "Counter front-door token budget exceeded. The front door is six tools; "
+        "if it grew, that is a product decision that needs saying out loud, not a "
+        f"baseline regeneration. Drifts: {drifts}"
+    )
+
+
+@pytest.mark.skipif(not BASELINE.is_file(), reason="benchmarks/schema_baseline.json missing")
+def test_counter_saving_is_read_not_typed():
+    """`run_route_recall.py` must compute the Counter's saving from the baseline.
+
+    ⚠⚠ It used to assert `~98%` in its own docstring, which is why this test
+    exists in the negative: it fails if any hardcoded percentage returns to that
+    file. Maintenance practice #4 — never hand-type a benchmark number — and the
+    same failure shape as the four-month `jcm_reference.json` drift.
+    """
+    import re
+
+    harness = REPO_ROOT / "benchmarks" / "route_recall" / "run_route_recall.py"
+    text = harness.read_text(encoding="utf-8")
+
+    assert "_schema_saving" in text, (
+        "run_route_recall.py must read the saving from schema_baseline.json via "
+        "_schema_saving(); reinstating a literal is the defect this guards."
+    )
+    # A percentage adjacent to schema/token/resident wording is the transcription
+    # shape. Recall percentages (recall@3, per-group output) are formatted at
+    # runtime, so they never appear as literals in the source.
+    offenders = [
+        m.group(0)
+        for m in re.finditer(r"~?\d{1,3}(?:\.\d+)?%[^\n]{0,60}", text)
+        if re.search(r"schema|resident|token", m.group(0), re.IGNORECASE)
+    ]
+    assert not offenders, (
+        f"Hardcoded schema-saving percentage back in run_route_recall.py: {offenders}. "
+        "Read it from benchmarks/schema_baseline.json instead."
     )
 
 


### PR DESCRIPTION
## What this fixes

`benchmarks/route_recall/run_route_recall.py` claimed the Counter avoided
**~98%** of resident schema tokens. That figure had no run behind it.

Measured, it is **95.9%**.

## Why it survived

`tests/test_schema_budget.py` iterates `tool_profile`. `tool_profile` does not
apply to the Counter front door at all -- `tool_surface: "counter"` replaces the
catalog outright with six tools. So the project's largest context lever sat
outside its own guardrail, and the published number sat in a docstring where
nothing could fail when it drifted.

The direction is what makes it worth a PR rather than a typo fix. Overstating
the saving makes the recall trade `run_route_recall.py` exists to price look
cheaper than it is.

## What the numbers actually are

Measured with tiktoken `cl100k_base`, all arms, in `benchmarks/schema_baseline.json`:

| arm | tokens | vs `full_full` |
|---|---:|---:|
| `full_full` | 22,741 | baseline |
| `standard_full` | 21,431 | 5.8% |
| `core_compact` | 3,885 | 74.0% |
| `counter_full` | 939 | 95.9% |
| `counter_compact` | 939 | 95.9% |

Two findings beyond the fix:

- **`tool_profile: "standard"` is not a token lever.** 5.8%. Only `core` and
  `counter` move the number, and there is no gradient between them.
- **`compact_schemas` is a no-op under `counter`** -- measured, not assumed, so
  the identical pair above is a recorded fact rather than a reader's guess.
- **Descriptions are 36.2% of the `full` payload** and `compact_schemas` never
  touches them. `--breakdown` prints the names/descriptions/schemas split and
  the ten costliest tools. Any further cut has to come from there.

## Changes

- `benchmarks/harness/capture_schema_baseline.py` -- extended, not duplicated.
  A second script would have produced a third set of absolutes for the same
  question. Adds the two counter arms and a `--breakdown` mode.
- `benchmarks/schema_baseline.json` -- regenerated, two new keys.
- `benchmarks/route_recall/run_route_recall.py` -- `_schema_saving()` reads the
  baseline at runtime and prints it at the top of every run. A missing baseline
  prints "not measured"; it never falls back to a remembered figure.
- `tests/test_schema_budget.py` -- `test_counter_surface_within_baseline_tolerance`
  puts the counter arms under the same 5% ceiling; `test_counter_saving_is_read_not_typed`
  fails if any schema-saving percentage returns to the harness as a literal.
- `CLAUDE.md` -- names `schema_baseline.json` as canonical and marks
  `benchmarks/codex_surface/`'s 24,007/1,030 as a 2026-07 snapshot from a
  different payload shape, so the next reader does not read the gap as a
  regression.

## Verification

Both new tests confirmed **non-vacuous** against pre-fix `main`: 2 failed / 4
passed before, 6 passed after. The regex half was checked separately, because
the cheaper `_schema_saving in text` assertion fails first and would have
masked it.

`uv run ruff check src/` clean; the three touched files clean. 20 pre-existing
ruff errors elsewhere under `benchmarks/` are untouched.

## Notes for review

- **No `CHANGELOG.md` entry.** There is no `[Unreleased]` section, and #443 is
  an open fork PR -- our changelog edits are what conflict it.
- **Methodology caveat, stated in the harness docstring.** `cl100k_base` is a
  proxy for whatever tokenizer a client actually uses, so the absolute counts
  are approximate. The ratios are not: `o200k_base` and raw UTF-8 bytes
  reproduce every percentage above to within 0.3 points. Publish the ratios.
- **Scope.** These are the counts for this server's own tool list. A session
  behind the jmunch proxy carries the proxy's facade tools too, so real resident
  cost there is higher than `full_full`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
