### PR TITLE
fix(parser): extract Rust, Go, Java and PHP constants (#428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,69 @@
 # Changelog
 
+## [Unreleased] - A declared pattern with no implementation reads as a language without constants
+
+### Rust, Go, Java and PHP constants are extracted ([#428](https://github.com/jgravelle/jcodemunch-mcp/issues/428))
+
+Reported by [@mussonking](https://github.com/jgravelle/jcodemunch-mcp/issues/428),
+who found it on a generated Rust contract file holding 935 `pub const` and getting
+back zero symbols. The Kotlin and Bash halves shipped in v1.108.267; these four
+were left for the PR he offered. They are implemented here — see the note at the
+end about why, and the credit stands unchanged.
+
+All four declared `constant_patterns` in `LANGUAGE_REGISTRY` and had no branch in
+`_extract_constant`, so the walker dispatched on the node type and fell through to
+`return None`. **The declaration looked like coverage from every angle a caller
+can see**: `search_symbols` returned nothing, which is indistinguishable from a
+language that has no constants.
+
+`const_item` / `static_item` (Rust), `const_declaration` (Go, PHP) and
+`field_declaration` (Java) now extract.
+
+⚠ **Three of the four bind N names per declaration**, which is why
+`_extract_constants` is plural. Go alone does it two ways at once — `const ( ... )`
+groups one spec per line, and `const A, B = 1, 2` binds two names in one spec. A
+single-symbol return would have reported the first name of a 935-line grouped
+block and dropped the rest, which reads as success.
+
+⚠ **No naming heuristic on any of them.** Python needs `name.isupper()` because an
+assignment is a constant only by convention; `const` *is* the declaration. Filtering
+on case would have silently dropped Go's unexported constants, which are lowercase
+by the language's own visibility rule.
+
+⚠ **What is excluded, and why the exclusions are the careful half.** Rust `static mut`
+carries a `mutable_specifier` — the declaration itself says the binding can change.
+A Java constant is `static final`; a bare `final` field is per-instance and a bare
+`static` field is mutable shared state, so admitting either would reclassify ordinary
+fields as constants in every Java class in an index. A missing constant is a recall
+bug the reporter could see; a field arriving as `kind="constant"` is a precision bug
+nobody would go looking for.
+
+⚠⚠ **Java needed more than a branch, and the fix is deliberately narrow.** The
+constant walk was gated on `parent_symbol is None`, which keeps function locals out
+— and a Java constant is a class member, so `field_declaration` sat in
+`constant_patterns` while being unreachable by construction. The gate now also
+accepts a *container* parent, for languages named in `_CLASS_SCOPED_CONSTANT_LANGUAGES`
+(currently `{"java"}`) and never for a function parent. **Relaxing it for every
+language was declined**: Python class bodies, JS class fields and PHP class constants
+would all start emitting constants they never have, moving symbol counts in every
+index and every published dead-code grade. One named set, one sample per member.
+
+`tests/test_v1_108_281.py` (10) covers the shapes the guard's minimal samples cannot
+— the reporter's nested `pub mod`, the N-name forms, and each exclusion. **9 of the
+10 fail against `d10490e`**; the one that passes both sides is the control asserting
+that Java function locals are still not constants, which is a boundary that must not
+move.
+
+The four exemptions in `tests/test_constant_extraction_guard.py` are deleted, which
+its ratchet forced: that file fails while an exemption outlives its defect. `EXEMPT`
+is now empty and every language declaring `constant_patterns` extracts one.
+
+⚠ **On taking this back:** #428's remaining half was @mussonking's by an open offer
+with no date on it, and closing it ourselves is a reversal, not a handoff expiring.
+It was done at the maintainer's direction to clear the tracker. The credit for the
+report and for the design of the plural helper is his, and the offer should never
+have been left open-ended — every handoff gets a date and a stated default now.
+
 ## [1.108.280] - 2026-08-14 - A cache keyed on a spelling is keyed on the caller's working directory
 
 ### The perf-db connection cache used the unresolved path ([#465](https://github.com/jgravelle/jcodemunch-mcp/issues/465))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,44 @@ compaction is near its floor; descriptions are untouched ground.
 a RESUMED conversation counts accumulated context on every step, so the total is
 dominated by how much the agent read early on, which compounds.
 
+**2026-08-15: #428's remaining four languages IMPLEMENTED BY US (Rust, Go, Java,
+PHP), closing it.** Unreleased; see CHANGELOG `[Unreleased]`.
+⚠⚠ **This is a REVERSAL of an open handoff, not a timebox expiring, and it was
+jjg's call.** The half was @mussonking's by an offer with **no date on it** — the
+standing rule is that every handoff names a date AND the default that fires on
+it, and this one named neither, which is exactly how it sat seven days. Credit
+for the report and for the plural-helper design stays his in the CHANGELOG.
+**The process lesson is the open-ended offer, not the reversal.**
+[[feedback_never_hand_off_without_a_timebox]]
+⚠⚠ **Java needed more than a branch and the gate was the real defect.** The
+constant walk was `parent_symbol is None`, which keeps function locals out — and
+a Java constant is a class member, so `field_declaration` sat in
+`constant_patterns` **unreachable by construction**. The gate now also accepts a
+CONTAINER parent for `_CLASS_SCOPED_CONSTANT_LANGUAGES` (`{"java"}`), never a
+function parent. ⚠ **Relaxing it for every language was DECLINED**: Python class
+bodies, JS class fields and PHP class constants would all start emitting
+constants they never have, moving symbol counts in every index and **every
+published dead-code grade**. One named set, one sample per member, asserted by
+name in `test_only_named_languages_reach_constants_through_a_container`.
+⚠ **Scala looked like a counter-example and is not** — its `val_definition` is in
+`symbol_node_types`, so it never touches the constant gate at all. Checking that
+before copying its shape is what kept the widening narrow.
+⚠ **The exclusions are the careful half**: Rust `static mut` (a
+`mutable_specifier` says the binding changes), Java bare `final` (per-instance)
+and bare `static` (mutable shared state). **A missing constant is a recall bug
+the reporter could see; an ordinary field arriving as `kind="constant"` is a
+precision bug nobody goes looking for.**
+⚠ **Grammar shapes were DUMPED, not assumed** — the TOML left-recursion defect
+came from assuming. Go binds N names two ways at once (`const ( ... )` groups
+plus `const A, B = 1, 2`), which is what `_extract_constants` being plural is
+for. ⚠ No case heuristic anywhere: `const` IS the declaration, and filtering on
+case would silently drop Go's unexported lowercase constants.
+⚠ `tests/test_v1_108_281.py` (10), **9 fail against `d10490e`**; the 1 passing
+both sides is the control that Java function locals are still not constants.
+`EXEMPT` in `test_constant_extraction_guard.py` is now **EMPTY** — the ratchet
+forced its own deletion, and its parametrize-over-nothing SKIP is the ratchet at
+rest, not a lost test.
+
 **Merged 2026-08-14: #473 (@rknighton) closes #465** — the perf-db connection
 cache keyed on the caller's SPELLING, not the resolved path, so a relative
 `storage_path` wrote one store's telemetry rows into another's after a chdir.

--- a/src/jcodemunch_mcp/parser/extractor.py
+++ b/src/jcodemunch_mcp/parser/extractor.py
@@ -18,6 +18,13 @@ from .complexity import compute_complexity
 
 logger = logging.getLogger(__name__)
 
+# Languages whose constants can only be written INSIDE a type, so the constant
+# walk must accept a container parent as well as no parent (#428). Membership is
+# a statement about the LANGUAGE, not a preference: Java has no file-scope
+# constant to find. Adding a language here without a sample in
+# tests/test_constant_extraction_guard.py is the failure that issue is about.
+_CLASS_SCOPED_CONSTANT_LANGUAGES = frozenset({"java"})
+
 
 class ByteSlicedSource:
     """A text view indexed by BYTE offsets, not character offsets.
@@ -593,7 +600,25 @@ def _walk_tree(
             symbols.append(var_func)
 
     # Check for constant patterns (top-level assignments with UPPER_CASE names)
-    if node.type in spec.constant_patterns and parent_symbol is None:
+    #
+    # ⚠⚠ **The `parent_symbol is None` gate is what keeps LOCALS out**, and it is
+    # kept. `_CLASS_SCOPED_CONSTANT_LANGUAGES` widens it to a CONTAINER parent
+    # only, never to a function parent, for languages whose constants cannot be
+    # written at file scope at all: a Java constant is a `static final` field, so
+    # under the unwidened gate `field_declaration` sat in `constant_patterns`
+    # while being unreachable by construction (#428).
+    #
+    # ⚠ **Declined: relaxing this to `parent_is_container` for EVERY language.**
+    # It reads like the general fix and it is a different change -- Python class
+    # bodies, JS class fields and PHP class constants would all start emitting
+    # constants they never have, moving symbol counts in every index and every
+    # published dead-code grade. One named set, extended per language with a
+    # sample in tests/test_constant_extraction_guard.py, keeps the blast radius
+    # equal to the defect.
+    if node.type in spec.constant_patterns and (
+        parent_symbol is None
+        or (parent_is_container and language in _CLASS_SCOPED_CONSTANT_LANGUAGES)
+    ):
         symbols.extend(_extract_constants(node, spec, source_bytes, filename, language))
 
     # A JS/TS class field INITIALIZER is not the class body. Everything the
@@ -1466,9 +1491,118 @@ def _extract_constants(
     """
     if node.type == "declaration_command" and language == "bash":
         return _extract_bash_constants(node, source_bytes, filename, language)
+    if node.type == "const_declaration" and language == "go":
+        return _extract_go_constants(node, source_bytes, filename, language)
+    if node.type == "const_declaration" and language == "php":
+        return _extract_php_constants(node, source_bytes, filename, language)
+    if node.type == "field_declaration" and language == "java":
+        return _extract_java_constants(node, source_bytes, filename, language)
 
     single = _extract_constant(node, spec, source_bytes, filename, language)
     return [single] if single else []
+
+
+def _constant_symbol(
+    name: str, decl_node, source_bytes: bytes, filename: str, language: str
+) -> Symbol:
+    """One constant symbol spanning its whole declaration.
+
+    The N-name languages all report the same span for every name they bind: the
+    declaration is what the reader opens, and `const ( A = 1; B = 2 )` has no
+    narrower node that contains `B` alone in Go's grammar anyway. Sharing the
+    span keeps `byte_offset`/`byte_length` pointing at real source text rather
+    than at a synthesised range (#414's rule: an offset must address bytes that
+    exist).
+    """
+    sig = source_bytes[decl_node.start_byte:decl_node.end_byte].decode("utf-8", "replace").strip()
+    return Symbol(
+        id=make_symbol_id(filename, name, "constant"),
+        file=filename,
+        name=name,
+        qualified_name=name,
+        kind="constant",
+        language=language,
+        signature=sig[:200],
+        line=decl_node.start_point[0] + 1,
+        end_line=decl_node.end_point[0] + 1,
+        byte_offset=decl_node.start_byte,
+        byte_length=decl_node.end_byte - decl_node.start_byte,
+        content_hash=compute_content_hash(source_bytes[decl_node.start_byte:decl_node.end_byte]),
+    )
+
+
+def _extract_go_constants(
+    node, source_bytes: bytes, filename: str, language: str
+) -> list[Symbol]:
+    """Go `const`, which binds N names through two nestings at once (#428).
+
+    `const_declaration` holds one `const_spec` for a single declaration and one
+    per line inside a `const ( ... )` block, and a spec itself can bind several
+    names (`const D, E = 1, 2`). Both are walked, so a grouped block of 935
+    constants yields 935 symbols rather than one.
+
+    ⚠ No naming heuristic. Python needs `name.isupper()` because an assignment
+    is a constant only by convention; `const` IS the declaration, so filtering
+    on case here would silently drop Go's unexported constants -- lowercase by
+    the language's own visibility rule, not by accident.
+    """
+    found: list[Symbol] = []
+    for spec_node in node.children:
+        if spec_node.type != "const_spec":
+            continue
+        for child in spec_node.children:
+            # Names precede the `=`; the value side lives in an expression_list.
+            if child.type == "=":
+                break
+            if child.type == "identifier":
+                name = source_bytes[child.start_byte:child.end_byte].decode("utf-8", "replace")
+                found.append(_constant_symbol(name, node, source_bytes, filename, language))
+    return found
+
+
+def _extract_php_constants(
+    node, source_bytes: bytes, filename: str, language: str
+) -> list[Symbol]:
+    """PHP `const A = 1, B = 2;` -- one `const_element` per bound name (#428)."""
+    found: list[Symbol] = []
+    for element in node.children:
+        if element.type != "const_element":
+            continue
+        name_node = _first_named_child(element)
+        if name_node is None or name_node.type != "name":
+            continue
+        name = source_bytes[name_node.start_byte:name_node.end_byte].decode("utf-8", "replace")
+        found.append(_constant_symbol(name, node, source_bytes, filename, language))
+    return found
+
+
+def _extract_java_constants(
+    node, source_bytes: bytes, filename: str, language: str
+) -> list[Symbol]:
+    """Java constants are `static final` fields, N declarators per node (#428).
+
+    ⚠ **Both modifiers are required, and that is the whole discriminator.** A
+    bare `final int x` is per-instance and a bare `static int x` is mutable
+    shared state; neither is a constant, and admitting either would put ordinary
+    fields into `kind="constant"` for every Java class in an index.
+    """
+    modifiers = next((c for c in node.children if c.type == "modifiers"), None)
+    if modifiers is None:
+        return []
+    present = {c.type for c in modifiers.children}
+    if not {"static", "final"} <= present:
+        return []
+
+    found: list[Symbol] = []
+    for declarator in node.children:
+        if declarator.type != "variable_declarator":
+            continue
+        name_node = declarator.child_by_field_name("name")
+        if name_node is None:
+            continue
+        name = source_bytes[name_node.start_byte:name_node.end_byte].decode("utf-8", "replace")
+        found.append(_constant_symbol(name, node, source_bytes, filename, language))
+    return found
 
 
 def _extract_bash_constants(
@@ -1741,6 +1875,26 @@ def _extract_constant(
             byte_length=node.end_byte - node.start_byte,
             content_hash=c_hash,
         )
+
+    # Rust `const NAME: T = ...;` and `static NAME: T = ...;` (#428).
+    #
+    # ⚠ **`static mut` is excluded, and the exclusion is the declaration's own
+    # word.** A `mutable_specifier` child says the binding can change, which is
+    # the one thing a constant cannot do -- the same evidence-not-heuristic rule
+    # Bash uses to accept `readonly` and reject a bare `declare`.
+    #
+    # ⚠ No UPPER_CASE filter. Rust's convention is SCREAMING_SNAKE, but `const`
+    # is a declaration rather than a convention, so a case test could only
+    # remove correct results. This was the reporter's file: 935 `pub const`
+    # inside nested `pub mod`s, indexed as zero symbols.
+    if node.type in ("const_item", "static_item") and language == "rust":
+        if any(c.type == "mutable_specifier" for c in node.children):
+            return None
+        name_node = node.child_by_field_name("name")
+        if name_node is None:
+            return None
+        name = source_bytes[name_node.start_byte:name_node.end_byte].decode("utf-8", "replace")
+        return _constant_symbol(name, node, source_bytes, filename, language)
 
     # JS/TS/TSX: index `const` declarations as constants.
     # `export const foo = ...` appears as a lexical_declaration under an export_statement;

--- a/tests/test_constant_extraction_guard.py
+++ b/tests/test_constant_extraction_guard.py
@@ -53,15 +53,16 @@ SAMPLES: dict[str, tuple[str, str]] = {
 # directory and never a category -- an exemption that covers a class hides the
 # next member of it.
 #
-# These four are @mussonking's, left for the PR he offered on #428. The
-# `test_exemptions_are_not_stale` ratchet below FAILS once any of them starts
-# working, so landing a fix forces its own exemption out of this list.
-EXEMPT: dict[str, str] = {
-    "rust": "#428: const_item/static_item declared, no branch in _extract_constant",
-    "go": "#428: const_declaration declared, no branch; const ( ... ) binds N names",
-    "java": "#428: field_declaration declared, no branch; N declarators per node",
-    "php": "#428: const_declaration declared, no branch",
-}
+# EMPTY, and that is the end state this ratchet was built to reach. The four
+# entries here (rust, go, java, php) were @mussonking's half of #428; they were
+# implemented on 2026-08-15 and `test_exemptions_are_not_stale` below failed
+# until they were deleted, which is the mechanism working rather than a chore.
+#
+# ⚠ An empty set means `test_exemptions_are_not_stale` parametrizes over nothing
+# and pytest reports it as a SKIP ("got empty parameter set"). That skip is the
+# ratchet at rest, not a lost test -- it re-arms the moment anyone adds an
+# exemption. Same shape as `_JS_VARIANT_EXEMPT` in the v1.108.273 sweep.
+EXEMPT: dict[str, str] = {}
 
 DECLARING = sorted(
     lang

--- a/tests/test_v1_108_281.py
+++ b/tests/test_v1_108_281.py
@@ -1,0 +1,196 @@
+"""Rust, Go, Java and PHP constants (#428, second half).
+
+`tests/test_constant_extraction_guard.py` asserts the CLAIM -- a language that
+declares `constant_patterns` extracts at least one constant -- against one
+minimal sample each. That is the right shape for a ratchet and it is deliberately
+thin: one constant proves the branch exists and nothing about what it accepts.
+
+This file covers what the minimal samples cannot, one test per decision that was
+actually made while implementing:
+
+* the reporter's own shape (constants nested inside `pub mod`), which is what
+  read as zero symbols,
+* the N-names-per-declaration forms that made `_extract_constants` plural,
+* and the three exclusions, each of which is a thing that is NOT a constant and
+  would otherwise arrive as one.
+
+⚠ The exclusions matter more than the inclusions here. A missing constant is a
+recall bug the reporter could see; `notStatic` or a function-local arriving as
+`kind="constant"` is a precision bug nobody would look for.
+"""
+import pytest
+
+from jcodemunch_mcp.parser.extractor import parse_file
+
+
+@pytest.fixture(autouse=True)
+def _all_languages_enabled(monkeypatch):
+    """Answer the parser, not the developer's config file (#411)."""
+    monkeypatch.setattr(
+        "jcodemunch_mcp.config.is_language_enabled",
+        lambda language, repo=None: True,
+    )
+
+
+def _constants(source: str, filename: str, language: str) -> list[str]:
+    return [s.name for s in parse_file(source, filename, language) if s.kind == "constant"]
+
+
+def _symbols(source: str, filename: str, language: str) -> list[tuple[str, str]]:
+    return [(s.kind, s.name) for s in parse_file(source, filename, language)]
+
+
+# ── Rust ────────────────────────────────────────────────────────────────────
+
+def test_rust_constants_inside_nested_modules_are_extracted():
+    """The reporter's file: `pub const` inside `pub mod`, indexed as zero symbols.
+
+    935 constants in one generated contract file, and `index_folder` reported it
+    in `no_symbols_files`. The nesting was his first hypothesis and the wrong
+    one -- no Rust const was extracted anywhere -- but the nested shape is what
+    the real file looks like, so it is what the regression test uses.
+    """
+    source = (
+        "pub mod invoice {\n"
+        '    pub const DOC_TYPE: &str = "invoice";\n'
+        "    pub mod line {\n"
+        '        pub const UNIT: &str = "each";\n'
+        "    }\n"
+        "}\n"
+        'const TOP_LEVEL: &str = "a";\n'
+    )
+    assert _constants(source, "contract.rs", "rust") == ["DOC_TYPE", "UNIT", "TOP_LEVEL"]
+
+
+def test_rust_static_mut_is_not_a_constant():
+    """`static mut` says in its own declaration that it can change.
+
+    The discriminator is the grammar's `mutable_specifier`, not a naming rule --
+    the same evidence-over-heuristic choice Bash makes by accepting `readonly`
+    and rejecting a bare `declare`.
+    """
+    source = (
+        'const KEPT: &str = "a";\n'
+        'static ALSO_KEPT: &str = "b";\n'
+        "static mut COUNTER: i32 = 0;\n"
+    )
+    assert _constants(source, "probe.rs", "rust") == ["KEPT", "ALSO_KEPT"]
+
+
+def test_rust_lowercase_constants_are_not_filtered_out():
+    """No UPPER_CASE test on a language where `const` IS the declaration.
+
+    Python needs the case heuristic because an assignment is a constant only by
+    convention. Applying it to Rust could only delete correct results.
+    """
+    source = 'const lowercase_but_still_const: u8 = 1;\n'
+    assert _constants(source, "probe.rs", "rust") == ["lowercase_but_still_const"]
+
+
+# ── Go ──────────────────────────────────────────────────────────────────────
+
+def test_go_grouped_and_multi_name_declarations_yield_every_name():
+    """Two nestings bind N names: `const ( ... )` blocks and `const A, B = 1, 2`.
+
+    This is why `_extract_constants` is plural. A single-symbol return would
+    have reported the first name of a 935-line grouped block and dropped the
+    rest, which looks like success.
+    """
+    source = (
+        "package p\n\n"
+        'const SINGLE = "x"\n\n'
+        "const (\n\tGROUPED_A = 1\n\tGROUPED_B = 2\n)\n\n"
+        "const MULTI_A, MULTI_B = 1, 2\n"
+    )
+    assert _constants(source, "probe.go", "go") == [
+        "SINGLE",
+        "GROUPED_A",
+        "GROUPED_B",
+        "MULTI_A",
+        "MULTI_B",
+    ]
+
+
+def test_go_unexported_lowercase_constants_are_kept():
+    """Lowercase is Go's visibility rule, not an accident to filter on."""
+    source = 'package p\n\nconst unexported = "x"\n'
+    assert _constants(source, "probe.go", "go") == ["unexported"]
+
+
+# ── PHP ─────────────────────────────────────────────────────────────────────
+
+def test_php_comma_separated_constants_yield_every_name():
+    source = "<?php\nconst FIRST = 'a', SECOND = 'b';\nfunction visible() {}\n"
+    assert _constants(source, "probe.php", "php") == ["FIRST", "SECOND"]
+
+
+# ── Java ────────────────────────────────────────────────────────────────────
+
+def test_java_requires_both_static_and_final():
+    """A Java constant is `static final`. Neither modifier alone qualifies.
+
+    ⚠ This is the precision half. `final int` is per-instance and `static int`
+    is mutable shared state; admitting either would reclassify ordinary fields
+    as constants in every Java class in an index.
+    """
+    source = (
+        "class Probe {\n"
+        "  static final int KEPT = 1, ALSO_KEPT = 2;\n"
+        "  final int instanceFinal = 3;\n"
+        "  static int mutableShared = 4;\n"
+        "  int plain = 5;\n"
+        "  void visible() {}\n"
+        "}\n"
+    )
+    assert _constants(source, "Probe.java", "java") == ["KEPT", "ALSO_KEPT"]
+
+
+def test_java_function_locals_never_become_constants():
+    """The widened gate accepts a CONTAINER parent, never a function parent.
+
+    `parent_symbol is None` is what kept locals out before #428, and widening it
+    to reach class fields must not also reach method bodies -- so this asserts
+    the boundary of the widening rather than the widening itself.
+    """
+    source = (
+        "class Probe {\n"
+        "  void visible() {\n"
+        "    final int localFinal = 9;\n"
+        "    int local = 10;\n"
+        "  }\n"
+        "}\n"
+    )
+    assert _constants(source, "Probe.java", "java") == []
+
+
+def test_java_class_and_method_symbols_are_unchanged():
+    """The widening must add constants without disturbing the existing walk."""
+    source = "class Probe {\n  static final int K = 1;\n  void visible() {}\n}\n"
+    # Source order: the constant is declared before the method, and the walk
+    # emits in the order it meets nodes.
+    assert _symbols(source, "Probe.java", "java") == [
+        ("class", "Probe"),
+        ("constant", "K"),
+        ("method", "visible"),
+    ]
+
+
+# ── The widening is named, not general ──────────────────────────────────────
+
+def test_only_named_languages_reach_constants_through_a_container():
+    """A container parent unlocks the constant walk for Java and nothing else.
+
+    ⚠⚠ The general version of this fix -- accepting `parent_is_container` for
+    every language -- was declined. Python class bodies would start emitting
+    constants they have never emitted, moving symbol counts in every index and
+    every published dead-code grade. This test is what makes the narrow choice
+    durable: widen the set deliberately, with a sample, or not at all.
+    """
+    from jcodemunch_mcp.parser.extractor import _CLASS_SCOPED_CONSTANT_LANGUAGES
+
+    assert _CLASS_SCOPED_CONSTANT_LANGUAGES == frozenset({"java"})
+
+    # A Python class body holds an UPPER_CASE assignment, which is the exact
+    # shape the general widening would have admitted.
+    source = "class Config:\n    TIMEOUT = 30\n\n\nMODULE_LEVEL = 1\n"
+    assert _constants(source, "conf.py", "python") == ["MODULE_LEVEL"]


### PR DESCRIPTION
Closes #428.

The Kotlin and Bash halves shipped in v1.108.267. These four were left for the PR @mussonking offered; they are implemented here at the maintainer's direction — see the last section, and the credit is unchanged.

All four declared `constant_patterns` in `LANGUAGE_REGISTRY` and had **no branch** in `_extract_constant`, so the walker dispatched on the node type and fell off the end to `return None`. Nothing errored. `search_symbols` returned nothing, which is indistinguishable from a language that has no constants — that is the defect, not any single missing branch, and it is why his 935-constant Rust file came back in `no_symbols_files`.

## What changed

`const_item` / `static_item` (Rust), `const_declaration` (Go, PHP) and `field_declaration` (Java) now extract. Grammar shapes were dumped from tree-sitter rather than inferred, because the TOML left-recursion defect in #378 came from inferring.

**Three of the four bind N names per declaration**, which is what @mussonking's plural `_extract_constants` was built for. Go does it two ways at once:

```go
const (            // one const_spec per line
    B = 1
    C = 2
)
const D, E = 1, 2  // two identifiers in ONE const_spec
```

A single-symbol return would have reported the first name of a 935-line grouped block and dropped the rest, which reads as success.

**No naming heuristic on any of them.** Python needs `name.isupper()` because an assignment is a constant only by convention; `const` *is* the declaration. Filtering on case would silently drop Go's unexported constants, which are lowercase by the language's own visibility rule.

## The exclusions are the careful half

Rust `static mut` carries a `mutable_specifier` — the declaration says the binding can change. A Java constant is `static final`: a bare `final` field is per-instance, a bare `static` field is mutable shared state.

A missing constant is a recall bug the reporter could see. An ordinary field arriving as `kind="constant"` in every Java class in an index is a precision bug nobody goes looking for.

## Java needed the gate widened, narrowly

The constant walk was gated on `parent_symbol is None`, which is what keeps function locals out. A Java constant is a class member, so `field_declaration` sat in `constant_patterns` **unreachable by construction** — a branch alone would not have fixed it.

The gate now also accepts a *container* parent, for languages in `_CLASS_SCOPED_CONSTANT_LANGUAGES` (currently `{"java"}`), and never for a function parent.

**Relaxing it to `parent_is_container` for every language was declined.** Python class bodies, JS class fields and PHP class constants would all start emitting constants they have never emitted, moving symbol counts in every index and every published dead-code grade. `test_only_named_languages_reach_constants_through_a_container` pins the set by name so widening it stays a decision.

Scala looked like a counter-example — its constant sits inside an `object` and works today — but its `val_definition` is in `symbol_node_types` and never touches this gate at all.

## Verification

- `tests/test_v1_108_281.py` (10): the reporter's nested `pub mod` shape, the N-name forms, and each exclusion.
- **9 of the 10 fail against `d10490e`.** The one that passes both sides is the control asserting Java function locals are still not constants — a boundary that must not move.
- The four entries in `EXEMPT` are deleted, which the ratchet in `test_constant_extraction_guard.py` forced. `EXEMPT` is now empty and all 17 declaring languages extract.
- Full suite **7848 passed / 10 skipped / 0 failed**; `ruff check src/` clean.
- **7858 collected against 7847 on `main`, +11**, reconciled by a same-tree collect rather than arithmetic: 10 new tests, plus a net +1 as four languages move out of `EXEMPT` into the extract check while the four exemption cases collapse into one empty-parametrize skip. That skip is also the 9th-to-10th.

## On taking this back

#428's remaining half was @mussonking's by an open offer **with no date on it**, so this is a reversal rather than a timebox expiring, and it was the maintainer's call to clear the tracker.

The report and the design of the plural helper are his and are credited in the CHANGELOG. The process failure worth recording is ours: the offer should never have been left open-ended. Every handoff names a date and the default that fires on it now.
