### PR TITLE
test: run the suite in parallel under pytest-xdist, and fix the two defects that exposed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,26 @@ jobs:
         run: uv sync --locked --group dev --extra watch
 
       - name: Run tests
-        run: uv run pytest tests/ -v --tb=short --cov=src --cov-report=term-missing --cov-fail-under=74
+        # `-n 4 --dist loadfile` — parallel across processes, whole file per
+        # worker. Measured 2026-08-16 on a 24-core box: 599s serial vs 183s
+        # parallel, both collecting 7859.
+        #
+        # ⚠⚠ `--dist loadfile` is load-bearing. The default `--dist load` spreads
+        # individual tests across workers and breaks any file whose tests share
+        # module-level state. Keeping a file whole preserves within-file order,
+        # which is the only ordering guarantee the serial run actually gave us.
+        #
+        # ⚠ Pinned to 4, NOT `-n auto`. GitHub's standard runners are 4-core, so
+        # `auto` resolves to 4 today and would silently jump if GitHub resizes
+        # them. More workers is not free here: tests that do not isolate their
+        # storage contend on the same `~/.code-index` process-lock scopes, and
+        # that contention is the documented cause of the 47-minute outlier on
+        # the 1.108.261 run. Raise this only with a measurement attached.
+        #
+        # ⚠ `-v` is deliberately dropped: under xdist it interleaves output from
+        # 4 workers, which is less readable than the default progress line, not
+        # more. `--tb=short` still gives full tracebacks on failure.
+        run: uv run pytest tests/ -n 4 --dist loadfile --tb=short --cov=src --cov-report=term-missing --cov-fail-under=74
 
       - name: Verify sdist contains no sensitive paths
         if: runner.os == 'Linux'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 ## [Unreleased]
 
+### The test suite runs in parallel, and doing it found a test that only passed because of the file that ran before it
+
+The suite is 7,859 tests and took 599 seconds. It now runs under `pytest-xdist`
+at `-n 4 --dist loadfile`. Measured on a 24-core box: **599s serial vs 183s
+parallel**, both collecting the same 7,859. CI runs the same flags; with coverage
+instrumentation the local run of CI's exact command is 258s.
+
+⚠ **`--dist loadfile` is load-bearing, not tuning.** It keeps a whole file on one
+worker, which preserves within-file ordering. The default `--dist load` spreads
+individual tests across workers and would break any file whose tests share
+module-level state.
+
+⚠ **Worker isolation is STRONGER than the serial run, not weaker.** Everything
+`conftest.py` resets per test — `_GLOBAL_CONFIG`, the index cache, perf-DB
+handles — is process-global, and each xdist worker is its own process. What
+parallelism takes away is the accidental cross-FILE ordering the serial run
+provided for free, and one test was living on it.
+
+⚠⚠ **The two failures the parallel run produced were NOT caused by parallelism —
+they reproduce serially in isolation, and they had been latent for as long as the
+files existed.** `tests/test_css.py` and `tests/test_json.py` imported through
+`src.jcodemunch_mcp`, which is a **different module object** from
+`jcodemunch_mcp` (`is` → `False`). The twin carries its own
+`config._GLOBAL_CONFIG` that conftest never resets, so it lazily loaded the
+developer's real `~/.code-index/config.jsonc`; `is_language_enabled` gated the
+language out of any `languages` allowlist that omits it, and `parse_file`
+returned `[]` while the direct extractor returned 10 symbols.
+
+⚠ **The mechanism is confirmed by which half failed.** `test_css.py` exercises
+both `css` and `scss` through `parse_file` and only the `scss` assertion broke —
+`css` is in the allowlist, `scss` is not. They passed in the full serial run only
+because `test_config.py` (also `src.`-prefixed) overwrote the twin's config
+earlier in alphabetical order.
+
+⚠ **This is Maintenance Practice #8's class in a spelling the guard cannot see.**
+`tests/test_config_isolation_guard.py` has no knowledge of the `src.` prefix.
+**Fourteen test files still import through the twin**, and two are the same defect
+unfired: `test_al.py` and `test_blade.py` both reach `parse_file` that way and
+pass only because `al` and `blade` happen to be in this box's config. On a
+contributor's box with a narrower allowlist they fail exactly as `scss` did.
+Not fixed here; the two live failures are.
+
+⚠ **CI is pinned to `-n 4`, not `-n auto`.** GitHub's standard runners are 4-core
+so `auto` resolves to 4 today and would jump silently if they are resized. More
+workers is not free: tests that do not isolate their storage contend on the same
+`~/.code-index` process-lock scopes, and that contention is the documented cause
+of the 47-minute outlier on the 1.108.261 run. Raise it only with a measurement.
+
+⚠⚠ **Adding the dependency required a re-lock, and the local-uv hazard in
+`test.yml`'s comment fired in its third direction.** A local uv 0.12.1 against
+the CI pin of 0.9.5 produced 76 insertions / 52 deletions: beyond the known
+nvidia marker widening it **stripped `python_full_version` guards off the
+google-api deps and `typing-extensions`**, changing what installs on 3.10 versus
+3.14, on a change whose only intent was adding a test runner. Re-locked via
+`uvx --from uv==0.9.5 uv lock` — 24 insertions, zero deletions, `execnet` and
+`pytest-xdist` only. **Check `git diff --stat uv.lock` after every lock, not just
+after version bumps.**
+
 ### Relative storage paths are resolved before they become cache keys ([#475](https://github.com/jgravelle/jcodemunch-mcp/issues/475))
 
 Reported and fixed by [@mikemikimike](https://github.com/jgravelle/jcodemunch-mcp/pull/479).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## [Unreleased]
 
+### The dispatcher ate its caller's `format` argument ([#482](https://github.com/jgravelle/jcodemunch-mcp/pull/482))
+
+`call_tool` extracts `format` because it belongs to no tool's schema, and did it
+with `arguments.pop("format")` — on the caller's own dict. A caller that reuses
+one args object got JSON on its first call and whatever `server_output` resolves
+to on every call after. The dispatcher now pops from its own copy.
+
+⚠⚠ **The first call proving the argument works is what makes this expensive.**
+Nothing errors and nothing warns; the response is still valid, just encoded
+differently from what was asked for. A caller that checked the first response and
+moved on would never look again.
+
+⚠ **Over the wire this is invisible** — every MCP request arrives as a freshly
+parsed dict, so no remote client can hit it. The exposed callers are in-process:
+the Counter front door re-dispatching into `call_tool`, and the test suite.
+
+⚠⚠ **It presented as an environment quirk, and that is the part worth
+remembering.** The second call falls back to `auto`, where the **15% encoding
+gate decides per response** — and the response carries `timing_ms`. Coverage
+instrumentation slows the call, changes that number, changes the byte count, and
+tips the gate. So the same defect was red on ubuntu 3.10/3.11/3.12, green on
+ubuntu 3.13, green on all four Windows legs, green locally without `--cov` and
+red locally with it. **Chasing the platforms would have found nothing; the
+argument dict is the same everywhere.**
+
+⚠ `tests/test_dispatcher_arg_mutation.py` (3) asserts on the ARGUMENT DICT, not
+on the response encoding, precisely so it does not inherit the gate's
+environment-sensitivity. Reverting the fix turns 2 of the 3 red; the third is the
+control that `format` is still honoured and passes both sides.
+
 ### The test suite runs in parallel, and doing it found a test that only passed because of the file that ran before it
 
 The suite is 7,859 tests and took 599 seconds. It now runs under `pytest-xdist`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,10 +383,33 @@ added a test runner.** Local uv 0.12.1 vs the CI pin 0.9.5 gave 76 insertions /
 changing what installs on 3.10 vs 3.14. Re-locked with `uvx --from uv==0.9.5 uv
 lock`: 24 insertions, 0 deletions. **Diff the lock after EVERY `uv lock`, not
 just version bumps.**
-⚠ Suite at this point: **7845 passed, 16 skipped, 0 failed** + `ruff check src/`
-clean, coverage 79.66%. Delta from the pre-merge 7859 total is EXACTLY **+2**,
-#479's `test_storage_path_resolution.py`. **Fold into the `Tests:` line at
-release, not before.**
+⚠⚠ **It went RED on CI and the failure was a REAL production defect the serial
+runner had never exercised — `call_tool` ate its caller's `format` argument.**
+`arguments.pop("format")` popped from the CALLER's dict, so a caller reusing one
+args object got JSON first and `server_output`'s default after. Fixed at the
+dispatcher (`arguments = dict(arguments)`), not in the tests, because the Counter
+front door re-dispatches through the same path. Over the wire it is unreachable —
+every request arrives as a fresh dict — so only in-process callers are exposed.
+⚠⚠ **It presented as an environment quirk and that is the reusable part.** The
+second call falls back to `auto`, where the **15% encoding gate decides per
+response**, and the response carries `timing_ms`. Coverage instrumentation slows
+the call, moves that number, moves the byte count, tips the gate. Red on ubuntu
+3.10/3.11/3.12, GREEN on ubuntu 3.13, green on all four Windows legs, green
+locally without `--cov`, red locally with it. **Chasing the platform matrix would
+have found nothing.**
+⚠ **Reproduced on a WSL Ubuntu 3.12 copy, which is what made it cheap** — Windows
+cannot produce it at all, and a CI cycle is 4 minutes against WSL's 3. Docker
+Desktop was not running; `wsl -d Ubuntu` with a `tar`-copied tree and its own uv
+was enough. ⚠ WSL interop expands `$PATH` into the command string and the Windows
+PATH contains parens, so `bash -lc` dies on a syntax error — use absolute paths
+and no variables.
+⚠ `tests/test_dispatcher_arg_mutation.py` (3) asserts on the ARGUMENT DICT, never
+on the response encoding, so it does not inherit the gate's environment
+sensitivity. Reverting turns 2 of 3 red; the third is the control.
+⚠ Suite with the fix: WSL Linux 3.12 **7833 passed, 0 failed** (+9 sdist errors
+that are an artifact of copying without `.git`); Windows **see release line**.
+Delta decomposes as 7828 + 2 fixed + 3 new = 7833. **Fold into the `Tests:` line
+at release, not before.**
 
 **2026-08-15: #428's remaining four languages IMPLEMENTED BY US (Rust, Go, Java,
 PHP), closing it.** Shipped as 1.108.281 via PR #478; see Current State.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,67 @@ compaction is near its floor; descriptions are untouched ground.
 a RESUMED conversation counts accumulated context on every step, so the total is
 dominated by how much the agent read early on, which compounds.
 
+**Merged 2026-08-16: #479 (@mikemikimike) closes #475** — `IndexStore` /
+`SQLiteIndexStore` keyed their init caches on the SPELLING of `base_path`, so a
+relative `storage_path` skipped `mkdir` and schema setup for the second store
+after a chdir. Two source lines. Unreleased; see CHANGELOG `[Unreleased]`.
+⚠ **The mock cleanup is the larger half.** `patch("...Path.resolve",
+return_value=X)` replaces `resolve` on the `Path` CLASS, so it answered for every
+path in the process — including the storage path `IndexStore` resolves at
+construction. Four `test_tools.py` tests then CREATED their index directory at
+the faked location (a stray `C:\work\project` locally; `mkdir` death at
+`/workspaces/myrepo` and `\\server\share\` in CI). ⚠⚠ **Nothing in the suite
+could have reported it, because the writes landed where no assertion was
+looking** — same family as #439's blanket `os.path.exists` mock. `_resolve_only`
+in `tests/__init__.py` is narrow, and needs `autospec=True` so `self` reaches the
+side effect. All 19 patch sites converted; the other 15 were wrong too, just
+inert. ⚠ The `expanduser()` half MOVES an existing case (a literal `~` in
+`storage_path` built a directory named `~`); disclosed, not migrated.
+
+**2026-08-16: the suite runs in PARALLEL, and that surfaced a test living on file
+ordering.** `pytest-xdist` at `-n 4 --dist loadfile`, wired into `test.yml`.
+Measured on a 24-core box: **599s serial vs 183s parallel**, same 7,859
+collected; CI's exact command (with coverage) is 258s locally. Test-only + CI, no
+version bump; rides the next release.
+⚠ **`--dist loadfile` is load-bearing.** Whole file per worker preserves
+within-file order; the default `--dist load` spreads individual tests and breaks
+any file sharing module-level state.
+⚠ **Worker isolation is STRONGER, not weaker** — everything conftest resets
+(`_GLOBAL_CONFIG`, index cache, perf-DB handles) is process-global and each
+worker is its own process. What parallelism removes is the accidental
+cross-FILE ordering the serial run gave for free.
+⚠⚠ **The two failures it produced were NOT caused by parallelism — they
+reproduce serially in isolation.** `test_css.py` and `test_json.py` imported via
+`src.jcodemunch_mcp`, a **different module object** from `jcodemunch_mcp` (`is`
+→ `False`) carrying its own `config._GLOBAL_CONFIG` that conftest never resets.
+The twin lazily read the developer's real `~/.code-index/config.jsonc`,
+`is_language_enabled` gated the language out of the `languages` allowlist, and
+`parse_file` returned `[]` against a direct extractor's 10 symbols.
+⚠ **Which half failed is the proof of mechanism**: `test_css.py` drives BOTH
+`css` and `scss` through `parse_file` and only `scss` broke — `css` is in the
+allowlist, `scss` is not. They passed serially only because `test_config.py`
+(also `src.`-prefixed) overwrote the twin earlier in alphabetical order.
+⚠ **Maintenance Practice #8 in a spelling its guard cannot see** —
+`test_config_isolation_guard.py` knows nothing of the `src.` prefix. **14 files
+still import through the twin**, and `test_al.py` / `test_blade.py` are the same
+defect UNFIRED, passing only because `al` and `blade` sit in this box's config.
+**Not fixed; the two live failures are.** Next sweep starts there.
+⚠ **CI pinned to `-n 4`, deliberately not `-n auto`** — GitHub runners are
+4-core so `auto` matches today and would jump silently on a resize, and extra
+workers contend on the same `~/.code-index` process-lock scopes that caused
+.261's 47m outlier.
+⚠⚠ **The local-uv lock hazard fired in its THIRD direction on a change that only
+added a test runner.** Local uv 0.12.1 vs the CI pin 0.9.5 gave 76 insertions /
+52 deletions, and beyond the known nvidia widening it **stripped
+`python_full_version` guards off the google-api deps and `typing-extensions`**,
+changing what installs on 3.10 vs 3.14. Re-locked with `uvx --from uv==0.9.5 uv
+lock`: 24 insertions, 0 deletions. **Diff the lock after EVERY `uv lock`, not
+just version bumps.**
+⚠ Suite at this point: **7845 passed, 16 skipped, 0 failed** + `ruff check src/`
+clean, coverage 79.66%. Delta from the pre-merge 7859 total is EXACTLY **+2**,
+#479's `test_storage_path_resolution.py`. **Fold into the `Tests:` line at
+release, not before.**
+
 **2026-08-15: #428's remaining four languages IMPLEMENTED BY US (Rust, Go, Java,
 PHP), closing it.** Shipped as 1.108.281 via PR #478; see Current State.
 ⚠⚠ **This is a REVERSAL of an open handoff, not a timebox expiring, and it was

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,22 @@ dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.0.0",
+    # Parallel test execution. Measured 2026-08-16 on a 24-core box: the serial
+    # suite is 599s, `-n auto --dist loadfile` is 183s, both collecting 7859.
+    #
+    # ⚠⚠ `--dist loadfile` is REQUIRED, not a tuning choice. It keeps a whole
+    # file on one worker, preserving within-file order. The default `--dist load`
+    # spreads individual tests and would break any file whose tests share
+    # module-level state.
+    #
+    # ⚠ Worker isolation is STRONGER than the serial run, not weaker: everything
+    # conftest resets per test (`_GLOBAL_CONFIG`, the index cache, perf-DB
+    # handles) is process-global, and each xdist worker is its own process. What
+    # parallelism removes is the accidental cross-FILE ordering the serial run
+    # provides for free -- which is how it surfaced the test_css/test_json
+    # config-twin defect that had been latent on any box with a `languages`
+    # allowlist.
+    "pytest-xdist>=3.6.0",
     "hypothesis>=6.0.0",
     "ruff>=0.6.0",
     # Not a package dependency: the benchmark harnesses in benchmarks/ import it.

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -5357,6 +5357,20 @@ async def _call_tool_impl(name: str, arguments: dict) -> list[TextContent] | Cal
         # `format` controls compact-output encoding (see .encoding package).
         _requested_format = None
         if isinstance(arguments, dict) and "format" in arguments:
+            # ⚠⚠ COPY BEFORE POPPING. `pop` on the caller's own dict strips
+            # `format` from it, so a caller that reuses one args object gets
+            # JSON on the first call and whatever `server_output` resolves to
+            # on every call after — silently, because the first call proves the
+            # argument works. Over the wire each call arrives as a fresh dict
+            # and nothing shows; the exposed callers are in-process ones, which
+            # includes the Counter front door re-dispatching through here.
+            #
+            # Found via #482: two tests reusing one `args` dict got a MUNCH
+            # payload on their second call and failed in `json.loads` at char 0.
+            # ⚠ It only surfaced on 3 of 8 CI legs, because the second call
+            # lands on `auto` and the 15% encoding gate then decides per
+            # response — so the same defect reads as an environment quirk.
+            arguments = dict(arguments)
             _requested_format = arguments.pop("format")
         # Coerce stringified booleans/integers/numbers before routing
         schema = (await _ensure_tool_schemas()).get(name)

--- a/tests/test_css.py
+++ b/tests/test_css.py
@@ -2,8 +2,16 @@
 
 import pytest
 
-from src.jcodemunch_mcp.parser.extractor import parse_file, _parse_css_symbols, _parse_scss_symbols
-from src.jcodemunch_mcp.parser.languages import get_language_for_path, LANGUAGE_EXTENSIONS
+# ⚠ Import via `jcodemunch_mcp`, NEVER `src.jcodemunch_mcp`. The two spellings
+# produce two DISTINCT module objects, each with its own `config._GLOBAL_CONFIG`.
+# conftest's `_reset_global_config` resets only the canonical one, so a
+# `src.`-prefixed `parse_file` consults the developer's real
+# `~/.code-index/config.jsonc` — and `is_language_enabled` there gates `scss`
+# out of any allowlist that omits it, making `parse_file` return []. These tests
+# then passed only because `test_config.py` (also `src.`-prefixed) happened to
+# overwrite the twin's config earlier in the serial run.
+from jcodemunch_mcp.parser.extractor import parse_file, _parse_css_symbols, _parse_scss_symbols
+from jcodemunch_mcp.parser.languages import get_language_for_path, LANGUAGE_EXTENSIONS
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dispatcher_arg_mutation.py
+++ b/tests/test_dispatcher_arg_mutation.py
@@ -1,0 +1,72 @@
+"""The dispatcher must not eat the caller's `arguments` dict (#482).
+
+`call_tool` extracts `format` because it belongs to no tool's schema. It used
+to do that with `arguments.pop("format")` — on the caller's own object. A
+caller that reuses one args dict across two calls therefore got its `format`
+stripped by the first call, and every call after it fell back to whatever
+`server_output` resolves to.
+
+⚠⚠ **The first call proving the argument works is what makes this expensive.**
+Nothing errors, nothing warns, and the response is still valid — just encoded
+differently from what was asked for.
+
+⚠ Over the wire this is invisible: every MCP request arrives as a freshly
+parsed dict. The exposed callers are in-process ones, which includes the
+Counter front door re-dispatching into `call_tool` and the whole test suite.
+
+⚠ These assertions are deliberately about the ARGUMENT DICT, not about the
+response encoding. The observed failure was a `json.loads` error on a MUNCH
+payload, but that only happens when the 15% encoding gate fires, which depends
+on the exact response bytes — it showed on 3 of 8 CI legs and on neither local
+platform. Asserting the mutation itself is deterministic everywhere.
+"""
+
+import pytest
+
+from jcodemunch_mcp import server
+
+
+@pytest.mark.asyncio
+async def test_call_tool_does_not_strip_format_from_the_caller_dict():
+    args = {"repo": "no-such-repo", "query": "anything", "format": "json"}
+
+    # The repo does not resolve; that is fine. The extraction happens before
+    # any routing, so an in-band error response still exercises the path.
+    await server.call_tool("search_symbols", args)
+
+    assert args["format"] == "json", (
+        "call_tool popped `format` off the caller's dict; a caller reusing one "
+        "args object silently loses its requested encoding on the second call"
+    )
+
+
+@pytest.mark.asyncio
+async def test_repeated_calls_with_one_args_dict_keep_the_requested_format():
+    """The end-to-end shape of the defect: same dict, two calls."""
+    args = {"repo": "no-such-repo", "query": "anything", "format": "json"}
+
+    await server.call_tool("search_symbols", args)
+    second = await server.call_tool("search_symbols", args)
+
+    # Whatever the second call returns, it must have been asked for JSON --
+    # i.e. the argument survived to be read a second time.
+    assert args.get("format") == "json"
+    assert second is not None
+
+
+@pytest.mark.asyncio
+async def test_the_dispatcher_still_honours_format_when_it_is_present():
+    """Non-vacuity: copying the dict must not stop `format` being read.
+
+    A fix that simply stopped popping would leave `format` in `arguments` and
+    hand an unexpected keyword to the tool, so this pins that the extraction
+    still happens on the dispatcher's own copy.
+    """
+    import json
+
+    args = {"repo": "no-such-repo", "query": "anything", "format": "json"}
+    res = await server.call_tool("search_symbols", args)
+
+    content = res.content if hasattr(res, "content") else res
+    # JSON was requested, so the payload must parse as JSON rather than MUNCH.
+    json.loads(content[0].text)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,7 +1,11 @@
 """Tests for JSON symbol extraction."""
 
-from src.jcodemunch_mcp.parser.extractor import parse_file, _parse_json_symbols
-from src.jcodemunch_mcp.parser.languages import get_language_for_path, LANGUAGE_EXTENSIONS
+# ⚠ Import via `jcodemunch_mcp`, NEVER `src.jcodemunch_mcp` — see the note in
+# tests/test_css.py. The two spellings are two module objects with two configs;
+# conftest resets only the canonical one, so the `src.` twin reads the
+# developer's real `~/.code-index/config.jsonc` and gates `json` out.
+from jcodemunch_mcp.parser.extractor import parse_file, _parse_json_symbols
+from jcodemunch_mcp.parser.languages import get_language_for_path, LANGUAGE_EXTENSIONS
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -572,6 +572,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1100,6 +1109,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "tiktoken" },
 ]
@@ -1160,6 +1170,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.0" },
     { name = "ruff", specifier = ">=0.6.0" },
     { name = "tiktoken", specifier = ">=0.7.0" },
 ]
@@ -2317,6 +2328,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

The suite is 7,864 tests and took 599 seconds. It now runs under `pytest-xdist` at `-n 4 --dist loadfile`.

Measured on a 24-core box, same tree, back to back:

| Run | Wall clock | Result |
|---|---|---|
| serial | 599s | 7843 passed, 16 skipped |
| `-n auto --dist loadfile` | 183s | same collection |
| CI's exact command (with coverage), final tree | 277s | 7848 passed, 16 skipped, coverage 79.67% |

CI wall clock per leg: ubuntu ~9-10 min to **3m05s-3m51s**; Windows to **7m18s-9m11s**. Windows gains less — those runners are slower per-test and 4 workers' process startup eats more of the win.

**The speedup is not the headline.** Parallelism acted as a detector: it surfaced one latent test defect and one genuine production sharp edge, neither of which the serial runner had exercised in ~7,800 tests.

## `--dist loadfile` is load-bearing, not tuning

It keeps a whole file on one worker, preserving within-file ordering. The default `--dist load` spreads individual tests across workers and would break any file whose tests share module-level state.

Worker isolation is *stronger* than the serial run, not weaker: everything `conftest.py` resets per test — `_GLOBAL_CONFIG`, the index cache, perf-DB handles — is process-global, and each xdist worker is its own process. What parallelism removes is the accidental cross-**file** ordering the serial run provided for free.

---

## Defect 1: the config twin (`test_css.py`, `test_json.py`)

These reproduce **serially, in isolation** — `pytest tests/test_css.py tests/test_json.py` was 2 failed / 56 passed before this change. Parallelism exposed them; it did not cause them.

Both imported through `src.jcodemunch_mcp`, which is a **different module object** from `jcodemunch_mcp` (`is` returns `False`). The twin carries its own `config._GLOBAL_CONFIG` that conftest never resets, so it lazily loaded the developer's real `~/.code-index/config.jsonc`. `is_language_enabled` then gated the language out of any `languages` allowlist omitting it, and `parse_file` returned `[]` while the direct extractor returned 10 symbols.

The mechanism is confirmed by which half failed: `test_css.py` drives **both** `css` and `scss` through `parse_file`, and only the `scss` assertion broke — `css` is in the allowlist, `scss` is not. They passed in the full serial run only because `test_config.py` (also `src.`-prefixed) overwrote the twin's config earlier in alphabetical order.

This is Maintenance Practice #8's class in a spelling its guard cannot see: `tests/test_config_isolation_guard.py` has no knowledge of the `src.` prefix.

### Known follow-up, deliberately not in this PR

**14 files still import through the twin**, and two are the same defect unfired: `test_al.py` and `test_blade.py` both reach `parse_file` that way and pass only because `al` and `blade` happen to be in this box's config. On a contributor's box with a narrower allowlist they fail exactly as `scss` did. The two live failures are fixed here; the sweep is not, and widening the guard belongs with it.

---

## Defect 2: the dispatcher ate its caller's `format` argument

This one is a **production** defect, not a test artifact, and it is why the first push went red on 3 of 8 legs.

`call_tool` extracts `format` because it belongs to no tool's schema, and did it with `arguments.pop("format")` — on the caller's own dict. A caller reusing one args object got JSON on the first call and whatever `server_output` resolves to on every call after. Proven directly: after one `call_tool`, `format` is gone from the caller's object.

**The first call proving the argument works is what makes this expensive.** Nothing errors and nothing warns; the response stays valid, just encoded differently from what was asked for.

Over the wire it is unreachable — every MCP request arrives as a freshly parsed dict. The exposed callers are in-process: **the Counter front door re-dispatching into `call_tool`**, and the test suite.

### It presented as an environment quirk

The second call falls back to `auto`, where the **15% encoding gate decides per response** — and the response carries `timing_ms`. Coverage instrumentation slows the call, moves that number, moves the byte count, and tips the gate. Hence:

- red on ubuntu 3.10 / 3.11 / 3.12
- **green on ubuntu 3.13**
- green on all four Windows legs
- green locally without `--cov`, **red locally with it**

Chasing the platform matrix would have found nothing. The argument dict is identical everywhere.

Diagnosed by reproducing on a WSL Ubuntu 3.12 copy — Windows cannot produce it at all, and Docker Desktop was not running. The failure was a MUNCH payload whose first byte is not valid JSON, which raises the same `Expecting value: line 1 column 1 (char 0)` as an empty string would.

Fixed at the dispatcher (`arguments = dict(arguments)` before the pop), not in the tests, because the front door shares the path.

`tests/test_dispatcher_arg_mutation.py` (3) asserts on the **argument dict**, never on the response encoding, so it does not inherit the gate's environment sensitivity. Reverting the fix turns 2 of the 3 red; the third is the control that `format` is still honoured and passes both sides.

---

## Why `-n 4` and not `-n auto`

GitHub's standard runners are 4-core, so `auto` resolves to 4 today and would jump silently if they are resized. More workers is not free: tests that do not isolate their storage contend on the same `~/.code-index` process-lock scopes, and that contention is the documented cause of the 47-minute outlier on the 1.108.261 run. Raise it only with a measurement attached.

## Lock note

Adding the dependency required a re-lock, and the local-uv hazard documented in `test.yml` fired in its third direction. Local uv 0.12.1 against the CI pin of 0.9.5 produced 76 insertions / 52 deletions: beyond the known nvidia marker widening, it **stripped `python_full_version` guards off the google-api deps and `typing-extensions`**, changing what installs on 3.10 versus 3.14 — on a change whose only intent was adding a test runner.

Re-locked via `uvx --from uv==0.9.5 uv lock`: 24 insertions, zero deletions, `execnet` and `pytest-xdist` only. Worth generalising the existing note — diff the lock after **every** `uv lock`, not just version bumps.

## Verification

- All 11 CI checks green, including the three ubuntu legs that failed the first push
- Windows local: **7848 passed, 16 skipped, 0 failed**, coverage 79.67%
- WSL Linux 3.12: **7833 passed, 0 failed** (+9 `test_sdist_exclusions` errors that are an artifact of copying the tree without `.git`)
- `uv run ruff check src/` clean
- Counts decompose exactly: 7861 → +3 dispatcher tests → 7864

One source line changed in `src/`. Everything else is tests, CI config, and the lock. No version bump; rides the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
