### PR TITLE
fix(telemetry): trim each perf database on its own row count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 ## [Unreleased]
 
+### One telemetry database spent another's trim ([#476](https://github.com/jgravelle/jcodemunch-mcp/issues/476))
+
+Reported by [@rknighton](https://github.com/rknighton), who pinned the cause to
+the line.
+
+`_perf_rows_since_trim` was a single int on the `_State` process singleton, while
+the trim it fires runs on `conn` — the connection belonging to whichever store
+made the 1000th write. With two stores alternating, every store's writes advanced
+a counter toward a trim spent somewhere else, so one `tool_calls` table was never
+trimmed and grew past `perf_telemetry_max_rows`. It is now a dict keyed by
+resolved path.
+
+⚠ **Severity is low and the report says so itself.** Telemetry is opt-in and
+local-only, nothing is misrouted, and a single-store install cannot reach it. The
+cost is disk: that store's `telemetry.db` grows for as long as the process runs,
+and the rows stay after it exits. Nothing is backfilled — an existing oversized
+`tool_calls` is trimmed on its own next cycle, not retroactively.
+
+⚠⚠ **The counter is keyed by the SAME `str(path)` the connection cache uses, and
+that is the whole fix rather than an implementation detail.** A counter keyed on
+anything else — the raw `base_path` string, say — is the same defect wearing a
+new key: two spellings of one directory would each get their own budget toward a
+trim on one shared table. v1.108.280 resolved exactly that spelling problem for
+the connection cache after #465; this inherits it instead of re-opening it.
+
+⚠ **`_ensure_perf_db_locked` gained a `_with_key` sibling rather than a second
+`_perf_db_path` call.** Re-deriving the key at the trim site would repeat that
+helper's `mkdir` on every write, and #442 exists because per-write cost on this
+exact path was the entire problem. The two callers that need only a connection
+keep the old signature.
+
+⚠ **`close_perf_dbs()` clears the counters with the connections**, so a key
+cannot outlive the store it names. The cost is bounded and deliberate: a database
+whose connection is dropped mid-cycle forgets its progress, so `tool_calls` can
+carry up to ~1000 rows of slack before the next trim. The cap is already an
+every-1000-writes approximation, and two structures disagreeing about which
+stores exist is the class of bug this entry is about.
+
+⚠ `tests/test_perf_trim_is_per_database.py` (4) asserts on the COUNTER MAP, not
+on row counts after 1000 writes — writing 2000 rows to two databases to observe
+one trim would be slow and would pin the trim interval, and the defect is that
+the bookkeeping is not per-database. All 4 turn red against a restored single
+counter.
+
 ### The package twin is retired, and the guard that could not see it now can
 
 Fourteen test modules imported the package as `src.jcodemunch_mcp`. That is a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,48 @@ compaction is near its floor; descriptions are untouched ground.
 a RESUMED conversation counts accumulated context on every step, so the total is
 dominated by how much the agent read early on, which compounds.
 
+**2026-08-17: #476 (@rknighton) FIXED BY US — one telemetry db spent another's
+trim.** `_perf_rows_since_trim` was one int on the `_State` process singleton
+while the trim runs on `conn`, so with two stores alternating one `tool_calls`
+was never trimmed. Now a dict. Unreleased; see CHANGELOG `[Unreleased]`.
+⚠ **Low severity and the REPORT said so** — opt-in, local-only, single-store
+installs cannot reach it, cost is disk. He rates his own findings honestly; the
+standing note that he understates still holds, but check each time.
+⚠⚠ **Keyed by the SAME `str(path)` the connection cache uses, and that IS the
+fix.** Keyed on the raw `base_path` instead, two spellings of one directory each
+get their own budget toward a trim on one shared table — the same defect wearing
+a new key. v1.108.280 resolved that spelling problem for the cache after #465;
+this inherits it rather than re-opening it. [[feedback_guard_every_path_that_shares_the_hazard]]
+⚠ **Added `_ensure_perf_db_locked_with_key` rather than calling `_perf_db_path`
+twice** — re-deriving the key at the trim site repeats that helper's `mkdir` on
+every write, and #442 exists because per-write cost on this exact path was the
+whole problem. Two callers keep the old connection-only signature.
+⚠ `close_perf_dbs()` clears the counters with the connections so a key cannot
+outlive its store; the bounded cost is ~1000 rows of slack for a database whose
+connection is dropped mid-cycle, against a cap that is already an
+every-1000-writes approximation.
+⚠ Nothing is backfilled: an already-oversized `tool_calls` trims on its own next
+cycle.
+⚠ `tests/test_perf_trim_is_per_database.py` (4) asserts on the COUNTER MAP, not
+row counts after 1000 writes — 2000 rows across two databases would be slow and
+would pin the trim interval. **All 4 red against a restored single counter.**
+
+**2026-08-17: #443's conflict was OURS and we resolved it on their branch.**
+elfrost's PR sat `CONFLICTING/DIRTY` since 2026-08-12 — and **a conflicting fork
+PR has no `refs/pull/N/merge`, so it gets NO CI AT ALL**, which is why it read as
+stalled contributor work when it was our CHANGELOG merges. Merged `main` in,
+resolved to one `## [Unreleased]` heading with their section first, pushed to
+their fork, said on the thread that the conflict was ours. `MERGEABLE` again,
+suite green (7856/17, +6 = their tests).
+⚠ **Checked before promising: elfrost is a User, not an Organization**, so the
+`maintainerCanModify`-lies trap did not apply and the push worked.
+⚠ **The CLA status SURVIVED this push** — the documented erase-on-push hazard did
+not fire here. Do not treat either outcome as the rule; read the status.
+⚠⚠ **#447 was NOT implemented, deliberately.** Its window is posted publicly to
+**2026-08-20** and jjg reaffirmed it stands as posted. Resolving the conflict is
+the move that respects the promise AND unblocks them — it removes the reason the
+PR was dark without shortening anything.
+
 **Merged 2026-08-16: #479 (@mikemikimike) closes #475** — `IndexStore` /
 `SQLiteIndexStore` keyed their init caches on the SPELLING of `base_path`, so a
 relative `storage_path` skipped `mkdir` and schema setup for the second store

--- a/src/jcodemunch_mcp/storage/token_tracker.py
+++ b/src/jcodemunch_mcp/storage/token_tracker.py
@@ -168,7 +168,14 @@ class _State:
         # v1.108.276 (#442). Resolved-path -> open connection. Held for the
         # process; see _ensure_perf_db_locked and close_perf_dbs.
         self._perf_conns: dict = {}
-        self._perf_rows_since_trim: int = 0
+        # #476. Resolved-path -> rows written to THAT database since its last
+        # trim. ⚠⚠ One int here counted writes across every store while the
+        # trim it triggered ran on whichever store happened to make the 1000th
+        # write, so with two stores alternating one `tool_calls` table was
+        # never trimmed and grew past the cap. Keyed by the SAME `str(path)`
+        # the connection cache uses -- a counter keyed differently from the
+        # connection it guards is the same defect wearing a new key.
+        self._perf_rows_since_trim: dict = {}
 
     def _ensure_loaded(self, base_path: Optional[str]) -> None:
         """Load persisted total from disk (once per process)."""
@@ -682,6 +689,15 @@ class _State:
         with self._lock:
             conns = list(self._perf_conns.items())
             self._perf_conns.clear()
+            # #476. Same lifetime as the connections it is keyed alongside, so
+            # a key cannot outlive the store it names. ⚠ The cost is bounded
+            # and deliberate: a database whose connection is dropped mid-cycle
+            # forgets its progress toward the next trim, so `tool_calls` can
+            # carry up to ~1000 rows of slack over the cap before the next one
+            # fires. The cap is already an every-1000-writes approximation, and
+            # this keeps the two structures from disagreeing about which stores
+            # exist -- which is the class of bug #476 itself was.
+            self._perf_rows_since_trim.clear()
         closed = 0
         for _path, conn in conns:
             try:
@@ -693,6 +709,20 @@ class _State:
 
     def _ensure_perf_db_locked(self, base_path: Optional[str] = None) -> Optional[sqlite3.Connection]:
         """Return an open perf SQLite db connection, creating schema on first use.
+
+        Thin wrapper over :meth:`_ensure_perf_db_locked_with_key` for the two
+        callers that need only the connection. ⚠ Per-database bookkeeping must
+        use the with-key form: re-deriving the key by calling ``_perf_db_path``
+        a second time would repeat its ``mkdir`` on every write, and #442 exists
+        because per-write cost on this path was already the whole problem.
+        """
+        conn, _key = self._ensure_perf_db_locked_with_key(base_path)
+        return conn
+
+    def _ensure_perf_db_locked_with_key(
+        self, base_path: Optional[str] = None
+    ) -> tuple[Optional[sqlite3.Connection], Optional[str]]:
+        """Return ``(connection, cache_key)``; the key identifies the database.
 
         ⚠⚠ v1.108.276 (#442). The connection is CACHED for the process and the
         caller must NOT close it -- use ``close_perf_dbs()`` instead. Every event
@@ -731,14 +761,14 @@ class _State:
           unwritable caller-supplied path cannot disable telemetry process-wide.
         """
         if self._perf_db_failed:
-            return None
+            return None, None
         path = self._perf_db_path(base_path)
         if path is None:
-            return None
+            return None, None
         cached = self._perf_conns.get(str(path))
         if cached is not None:
             if self._perf_conn_usable(cached, path):
-                return cached
+                return cached, str(path)
             # Poisoned or orphaned -- drop it and fall through to a fresh open
             # rather than returning something that silently discards writes.
             self._perf_conns.pop(str(path), None)
@@ -816,7 +846,7 @@ class _State:
                 self._add_column_if_missing(conn, _table, "session_uid", "TEXT")
                 self._add_column_if_missing(conn, _table, "call_uid", "TEXT")
             self._perf_conns[str(path)] = conn
-            return conn
+            return conn, str(path)
         except Exception:
             logger.debug("Failed to open perf db at %s", path, exc_info=True)
             # v1.108.188. The kill-switch covers the DEFAULT db only. One unwritable
@@ -825,7 +855,7 @@ class _State:
             # could ever mean.
             if base_path is None:
                 self._perf_db_failed = True
-            return None
+            return None, None
 
     def _persist_session_yield_locked(self, base_path: Optional[str] = None) -> None:
         """Upsert this session's delivery counts into the perf db. Lock held.
@@ -969,7 +999,7 @@ class _State:
         repo: Optional[str],
         base_path: Optional[str] = None,
     ) -> None:
-        conn = self._ensure_perf_db_locked(base_path)
+        conn, db_key = self._ensure_perf_db_locked_with_key(base_path)
         if conn is None:
             return
         try:
@@ -979,8 +1009,12 @@ class _State:
                 (time.time(), tool, float(duration_ms), 1 if ok else 0, repo or None,
                  self._session_uid, _CURRENT_CALL_UID.get()),
             )
-            self._perf_rows_since_trim += 1
-            if self._perf_rows_since_trim >= 1000:
+            # #476. Count against THIS database. The trim below runs on `conn`,
+            # so the counter that triggers it has to name the same store, or a
+            # second store's writes spend a trim on the first one's table.
+            rows_since_trim = self._perf_rows_since_trim.get(db_key, 0) + 1
+            self._perf_rows_since_trim[db_key] = rows_since_trim
+            if rows_since_trim >= 1000:
                 cap = max(1000, int(_config.get("perf_telemetry_max_rows", _PERF_DB_MAX_ROWS_DEFAULT)))
                 conn.execute(
                     "DELETE FROM tool_calls WHERE rowid IN ("
@@ -990,7 +1024,7 @@ class _State:
                     ")",
                     (cap,),
                 )
-                self._perf_rows_since_trim = 0
+                self._perf_rows_since_trim[db_key] = 0
         except Exception:
             logger.debug("Failed to persist perf row for %s", tool, exc_info=True)
         finally:

--- a/tests/test_perf_trim_is_per_database.py
+++ b/tests/test_perf_trim_is_per_database.py
@@ -1,0 +1,109 @@
+"""One telemetry database must not spend another's trim (#476).
+
+`_perf_rows_since_trim` was a single int on the `_State` process singleton
+while the trim it triggers runs on `conn` — the connection belonging to
+whichever store made the 1000th write. With two stores alternating, every
+store's writes advanced a counter toward a trim spent somewhere else, so one
+`tool_calls` table was never trimmed and grew past `perf_telemetry_max_rows`.
+
+⚠ Severity is low and stated as such in the report: telemetry is opt-in and
+local-only, nothing is misrouted, and a single-store install cannot reach it.
+The cost is disk.
+
+⚠⚠ These tests drive `_persist_perf_locked` with an explicit `base_path` per
+store and assert on the COUNTER MAP, not on row counts after 1000 writes.
+Writing 2000 rows to two SQLite databases to observe one trim would be slow and
+would couple the test to the trim interval; the defect is that the bookkeeping
+is not per-database, and that is observable directly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jcodemunch_mcp.storage import token_tracker
+
+
+@pytest.fixture
+def tracker(tmp_path, monkeypatch):
+    """A fresh _State with perf telemetry on and both stores under tmp_path."""
+    monkeypatch.setattr(token_tracker._config, "get", lambda key, default=None, **kw: (
+        True if key == "perf_telemetry_enabled" else default
+    ))
+    state = token_tracker._State()
+    yield state
+    state.close_perf_dbs()
+
+
+def _store(tmp_path, name):
+    p = tmp_path / name
+    p.mkdir(parents=True, exist_ok=True)
+    return str(p)
+
+
+def test_two_stores_count_their_own_rows(tracker, tmp_path):
+    a = _store(tmp_path, "store-a")
+    b = _store(tmp_path, "store-b")
+
+    with tracker._lock:
+        for _ in range(3):
+            tracker._persist_perf_locked("search_symbols", 1.0, True, None, base_path=a)
+        for _ in range(2):
+            tracker._persist_perf_locked("search_symbols", 1.0, True, None, base_path=b)
+
+    counts = tracker._perf_rows_since_trim
+    assert isinstance(counts, dict), (
+        "the trim counter is process-wide; one store's writes advance the "
+        "counter that triggers another store's trim (#476)"
+    )
+    # Two distinct databases, counted separately: 3 and 2, never a shared 5.
+    assert sorted(counts.values()) == [2, 3], counts
+    assert len(counts) == 2, counts
+
+
+def test_the_counter_is_keyed_like_the_connection_cache(tracker, tmp_path):
+    """The key must be the one the connection is cached under.
+
+    A counter keyed on anything else — the raw `base_path` string, say — is the
+    same defect in a new key, because two spellings of one directory would then
+    each get their own budget toward a trim on one shared table. v1.108.280
+    resolved that spelling problem for the connection cache; the counter has to
+    inherit it rather than re-open it.
+    """
+    a = _store(tmp_path, "store-a")
+
+    with tracker._lock:
+        tracker._persist_perf_locked("search_symbols", 1.0, True, None, base_path=a)
+
+    assert set(tracker._perf_rows_since_trim) == set(tracker._perf_conns), (
+        "counter keys and connection-cache keys have diverged; they must name "
+        "the same databases by the same resolved path"
+    )
+
+
+def test_a_relative_and_absolute_spelling_share_one_budget(tracker, tmp_path, monkeypatch):
+    """Two spellings of ONE directory are one database, so one counter."""
+    a = _store(tmp_path, "store-a")
+    monkeypatch.chdir(tmp_path)
+
+    with tracker._lock:
+        tracker._persist_perf_locked("search_symbols", 1.0, True, None, base_path=a)
+        tracker._persist_perf_locked("search_symbols", 1.0, True, None, base_path="store-a")
+
+    assert len(tracker._perf_rows_since_trim) == 1, (
+        f"one directory produced {len(tracker._perf_rows_since_trim)} counters: "
+        f"{tracker._perf_rows_since_trim}"
+    )
+    assert list(tracker._perf_rows_since_trim.values()) == [2]
+
+
+def test_close_drops_the_counters_with_the_connections(tracker, tmp_path):
+    """Lifetimes match, so a key cannot outlive the store it names."""
+    a = _store(tmp_path, "store-a")
+    with tracker._lock:
+        tracker._persist_perf_locked("search_symbols", 1.0, True, None, base_path=a)
+    assert tracker._perf_rows_since_trim
+
+    tracker.close_perf_dbs()
+    assert tracker._perf_rows_since_trim == {}
+    assert tracker._perf_conns == {}


### PR DESCRIPTION
Closes #476. Reported by @rknighton, who pinned the cause to the line.

## The defect

`_perf_rows_since_trim` was a single int on the `_State` process singleton, while the trim it fires runs on `conn` — the connection belonging to whichever store made the 1000th write. With two stores alternating, every store's writes advanced a counter toward a trim spent somewhere else, so one `tool_calls` table was never trimmed and grew past `perf_telemetry_max_rows`.

It is now a dict keyed by resolved path.

**Severity is low, and the report says so itself.** Telemetry is opt-in and local-only, nothing is misrouted, and a single-store install cannot reach it. The cost is disk. Nothing is backfilled — an already-oversized `tool_calls` trims on its own next cycle rather than retroactively.

## Three things worth review

**The key is the fix.** The counter uses the same `str(path)` the connection cache uses. Keyed on anything else — the raw `base_path` string, say — it would be the same defect wearing a new key: two spellings of one directory would each get their own budget toward a trim on one shared table. v1.108.280 resolved exactly that spelling problem for the connection cache after #465, and this inherits it rather than re-opening it. `test_a_relative_and_absolute_spelling_share_one_budget` pins that.

**`_ensure_perf_db_locked` gained a `_with_key` sibling instead of a second `_perf_db_path` call.** Re-deriving the key at the trim site would repeat that helper's `mkdir` on every write, and #442 exists precisely because per-write cost on this path was the entire problem. The two callers that need only a connection keep the old signature.

**`close_perf_dbs()` clears the counters with the connections**, so a key cannot outlive the store it names. The cost is bounded and deliberate: a database whose connection is dropped mid-cycle forgets its progress, so `tool_calls` can carry up to ~1000 rows of slack before the next trim fires. The cap is already an every-1000-writes approximation, and two structures disagreeing about which stores exist is the class of bug this PR is about.

## Tests

`tests/test_perf_trim_is_per_database.py` (4) asserts on the **counter map**, not on row counts after 1000 writes. Writing 2000 rows to two SQLite databases to observe one trim would be slow and would couple the tests to the trim interval; the defect is that the bookkeeping is not per-database, which is directly observable.

Non-vacuity checked: all 4 turn red against a restored single counter.

## Verification

- **7854 passed, 17 skipped, 0 failed** — +4 over `main`'s 7867 total, exactly the new tests
- `uv run ruff check src/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
