### PR TITLE
fix(search): publish the BM25 cache readiness key last (#490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 ## [Unreleased]
 
+### A cache that announced it was ready one key before it was (#490, @rknighton)
+
+`search_symbols` could raise `KeyError: 'centrality'` — surfacing through the
+dispatcher as `Internal error processing search_symbols` — when a second search
+arrived while the first was still building the lexical corpus.
+
+The BM25 corpus cache is built once per loaded index behind a check-then-build
+guarded on `idf`. It publishes **four** keys, and the statement that looked
+atomic is not:
+
+```python
+cache["idf"], cache["avgdl"], cache["inverted"] = _compute_bm25(index.symbols)
+cache["centrality"] = _compute_centrality(...)
+```
+
+That is four separate `__setitem__` calls. `idf` — the key every reader checked
+before deciding the cache was ready — lands first, and `centrality` lands after
+a full pass over the corpus. A caller arriving between the two passed the
+readiness check, skipped the build, and read a key that did not exist yet.
+
+⚠⚠ **The window is not a narrow one.** It is the entire runtime of
+`_compute_centrality`, which walks every import in the repository. The larger
+the corpus, the wider the window — so the installs most likely to hit it are the
+ones where a rebuild is most expensive.
+
+⚠ **The lock was real and was not the problem.** `_bm25_lock` exists on
+`CodeIndex` and was correctly acquired. The build was single-flight, as
+#370's fix intended; what leaked was the *readiness signal*, which is read
+outside the lock by design and must therefore not be true early.
+
+The build now runs in one shared `ensure_bm25_cache(index)` helper that writes
+`avgdl`, `inverted` and `centrality` first and `idf` last, and whose fast path
+checks all four keys rather than the sentinel alone — so a future edit that
+reorders the writes costs an extra lock acquisition instead of a `KeyError`.
+
+⚠ **The same four-key publish existed in three modules** — `search_symbols`,
+`get_ranked_context` and `plan_turn` — so fixing the reported one would have
+left two. All three now call the helper. `tests/test_bm25_cache_single_flight.py`
+fails if a fourth appears.
+
+⚠ **The `pagerank` and `name_map` blocks were checked and deliberately left
+alone.** Each writes the one key it also checks, so they are atomic by
+construction and share none of this hazard. Their
+`getattr(index, "_bm25_lock", None) or threading.Lock()` fallback is a separate
+and milder weakness — a fresh lock per caller guards nothing, so if an index
+ever arrived without `_bm25_lock` they would duplicate work rather than crash.
+Unreachable today, since both `CodeIndex` and `SelectiveIndexView` carry the
+lock. Recorded rather than swept, so a later pass does not read the silence as
+"already handled". The new helper uses a module-level fallback instead.
+
+⚠⚠ **The first version of the shipped-path test passed against the broken
+source**, which is the part worth keeping. Signalling from inside the build and
+letting the second thread race is not enough on a two-file corpus — the builder
+finishes before the racer arrives. The test holds the build open until the
+second caller is demonstrably inside its call. **A concurrency test that does
+not pin the interleaving is testing its own machine's scheduler.** Seven of the
+eight tests were red against the pre-fix tree without it; all eight are now.
+
+
 ## [1.108.284] - 2026-08-17 - A documented setting the storage layer never read
 
 ### `CODE_INDEX_PATH` now moves the index store and the lock directory

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,47 @@ compaction is near its floor; descriptions are untouched ground.
 a RESUMED conversation counts accumulated context on every step, so the total is
 dominated by how much the agent read early on, which compounds.
 
+**2026-08-17: #490 (@rknighton) FIXED BY US via PR #494 — a cache that
+announced readiness one key early.** The BM25 corpus cache publishes FOUR keys
+behind a check-then-build guarded on `idf` alone, and
+`cache["idf"], cache["avgdl"], cache["inverted"] = _compute_bm25(...)` is THREE
+`__setitem__` calls, with `centrality` a fourth statement after a whole pass
+over the corpus. A second caller passed the readiness check and raised
+`KeyError: 'centrality'` — through the dispatcher, `Internal error processing
+search_symbols`. Unreleased; see CHANGELOG `[Unreleased]`.
+⚠⚠ **The window is the entire runtime of `_compute_centrality`, so it WIDENS
+with corpus size** — the installs most likely to hit it are the ones where the
+rebuild is most expensive. Do not file this shape as "a narrow race".
+⚠ **The lock was real and correctly held; the build WAS single-flight** as #370
+intended. What leaked is the readiness SIGNAL, which is read outside the lock by
+design and therefore must not become true early. **Diagnose which of the two the
+defect is before reaching for the lock.**
+⚠⚠ **THREE modules carried the identical block** (`search_symbols`,
+`get_ranked_context`, `plan_turn`), so fixing the reported one leaves two —
+[[feedback_guard_every_path_that_shares_the_hazard]] again. One
+`ensure_bm25_cache()` helper now serves all three; the fast path checks ALL FOUR
+keys, not the sentinel, so a future reorder costs a lock acquisition instead of
+a KeyError.
+⚠ **`pagerank` and `name_map` were CHECKED and deliberately LEFT** — each writes
+the one key it also checks, atomic by construction. Their
+`getattr(index, "_bm25_lock", None) or threading.Lock()` fallback is a separate,
+milder weakness (a fresh lock per caller guards NOTHING, so a lockless index
+would duplicate work rather than crash); unreachable today because both
+`CodeIndex` and `SelectiveIndexView` carry the lock. **Recorded rather than
+swept**, same treatment as #473's module-level `perf_db_path()`.
+⚠⚠ **THE FIRST SHIPPED-PATH TEST PASSED AGAINST THE BROKEN SOURCE.** Signalling
+from inside the build and letting the second thread race is not enough on a
+two-file corpus: the builder finishes before the racer arrives. Only when the
+build is held open until the second caller is demonstrably INSIDE its call does
+it go red. **A concurrency test that does not pin the interleaving is testing
+its own machine's scheduler**, and the tell is the non-vacuity pass: 7 of 8 red
+first time, 8 of 8 after. [[a-concurrency-test-must-pin-the-interleaving]]
+⚠ His `Event` framing said this in the issue body — "it does not create a
+window" — and the first test ignored it. **Read the reporter's note about their
+own harness; it is usually load-bearing.**
+⚠ Suite: **7902 passed, 17 skipped, 0 failed** + ruff clean. Total 7919 against
+.284's 7911 = exactly the 8 new tests, so nothing else moved.
+
 **2026-08-17: #476 (@rknighton) FIXED BY US — one telemetry db spent another's
 trim.** `_perf_rows_since_trim` was one int on the `_State` process singleton
 while the trim runs on `conn`, so with two stores alternating one `tool_calls`

--- a/src/jcodemunch_mcp/tools/get_ranked_context.py
+++ b/src/jcodemunch_mcp/tools/get_ranked_context.py
@@ -10,10 +10,10 @@ from ._utils import index_status_to_tool_error, ledger_base_path as _ledger_base
 from .get_context_bundle import _count_tokens
 from .search_symbols import (
     _tokenize,
-    _compute_bm25,
     _bm25_score,
     _NEGATIVE_EVIDENCE_THRESHOLD,
     BYTES_PER_TOKEN,
+    ensure_bm25_cache,
 )
 
 # Weight for PageRank when strategy="combined"
@@ -297,15 +297,9 @@ def get_ranked_context(
     query_terms = _tokenize(query) or [query.lower()]
     # Guard: empty string in query_terms causes "" to match every filename
     query_terms = [t for t in query_terms if t]
-    cache = index._bm25_cache
-    if "idf" not in cache:
-        # Single-flight: concurrent cold callers must not each build the
-        # full-corpus BM25 state (#370)
-        with getattr(index, "_bm25_lock", None) or threading.Lock():
-            if "idf" not in cache:
-                from .search_symbols import _compute_centrality  # noqa: PLC0415
-                cache["idf"], cache["avgdl"], cache["inverted"] = _compute_bm25(index.symbols)
-                cache["centrality"] = _compute_centrality(index.symbols, index.imports, index.alias_map, getattr(index, "psr4_map", None))
+    # Single-flight: concurrent cold callers must not each build the
+    # full-corpus BM25 state (#370), nor observe a half-published one (#490).
+    cache = ensure_bm25_cache(index)
     idf = cache["idf"]
     avgdl = cache["avgdl"]
     inverted = cache["inverted"]

--- a/src/jcodemunch_mcp/tools/plan_turn.py
+++ b/src/jcodemunch_mcp/tools/plan_turn.py
@@ -1,16 +1,14 @@
 """Plan the next turn — recommend symbols/files based on query."""
 
 import heapq
-import threading
 import time
 from typing import Optional
 
 from ._utils import load_repo_index_or_error
 from .search_symbols import (
     _tokenize,
-    _compute_bm25,
     _bm25_score,
-    _compute_centrality,
+    ensure_bm25_cache,
 )
 
 # Confidence thresholds
@@ -56,16 +54,9 @@ def plan_turn(
     owner, name = index.owner, index.name
 
     # Get BM25 cache
-    cache = index._bm25_cache
-    if "idf" not in cache:
-        # Single-flight: concurrent cold callers must not each build the
-        # full-corpus BM25 state (#370)
-        with getattr(index, "_bm25_lock", None) or threading.Lock():
-            if "idf" not in cache:
-                cache["idf"], cache["avgdl"], cache["inverted"] = _compute_bm25(index.symbols)
-                cache["centrality"] = _compute_centrality(
-                    index.symbols, index.imports, index.alias_map, getattr(index, "psr4_map", None)
-                )
+    # Single-flight: concurrent cold callers must not each build the
+    # full-corpus BM25 state (#370), nor observe a half-published one (#490).
+    cache = ensure_bm25_cache(index)
     idf = cache["idf"]
     avgdl = cache["avgdl"]
     centrality = cache["centrality"]

--- a/src/jcodemunch_mcp/tools/search_symbols.py
+++ b/src/jcodemunch_mcp/tools/search_symbols.py
@@ -364,6 +364,59 @@ def _compute_centrality(
     return {f: math.log(1 + c) * _CENTRALITY_WEIGHT for f, c in counts.items()}
 
 
+# The four keys the lexical corpus cache publishes together. ``idf`` is the
+# readiness sentinel every historical call site checked, so it stays the last
+# one written; the fast path below checks all four anyway, so a future edit that
+# reorders the writes degrades to an extra lock acquisition instead of a
+# KeyError (#490).
+_BM25_CORPUS_KEYS = ("avgdl", "inverted", "centrality", "idf")
+
+# Used only if an index arrives without its own lock. A process-wide lock is
+# slower than a per-index one and correct; the `threading.Lock()` this replaces
+# was a NEW lock per caller, i.e. no mutual exclusion at all, which is the
+# failure this whole helper exists to remove.
+_BM25_FALLBACK_LOCK = threading.Lock()
+
+
+def ensure_bm25_cache(index) -> dict:
+    """Populate and return ``index._bm25_cache``'s lexical corpus stats.
+
+    Builds ``idf`` / ``avgdl`` / ``inverted`` / ``centrality`` exactly once per
+    loaded index, under the index's own lock, and returns the cache dict.
+
+    LIMITATION: this covers only the lexical corpus keys. ``pagerank`` and
+    ``name_map`` are built by their own single-key blocks elsewhere; each writes
+    the one key it also checks, so those are atomic by construction and are not
+    routed through here.
+
+    ⚠⚠ The build must never publish a key a reader treats as "cache ready"
+    before the keys that reader will go on to read. Three call sites wrote
+    ``cache["idf"], cache["avgdl"], cache["inverted"] = _compute_bm25(...)`` and
+    then ``cache["centrality"] = ...`` as a separate statement -- four
+    ``__setitem__`` calls behind a check-then-build guarded on ``idf`` alone. A
+    second caller arriving in that window passed the readiness check and raised
+    ``KeyError: 'centrality'`` (#490). The window is not narrow: it is the whole
+    runtime of ``_compute_centrality`` over the corpus.
+    """
+    cache = index._bm25_cache
+    if all(k in cache for k in _BM25_CORPUS_KEYS):
+        return cache
+    with getattr(index, "_bm25_lock", None) or _BM25_FALLBACK_LOCK:
+        if all(k in cache for k in _BM25_CORPUS_KEYS):
+            return cache
+        idf, avgdl, inverted = _compute_bm25(index.symbols)
+        centrality = _compute_centrality(
+            index.symbols, index.imports, index.alias_map,
+            getattr(index, "psr4_map", None),
+        )
+        cache["avgdl"] = avgdl
+        cache["inverted"] = inverted
+        cache["centrality"] = centrality
+        # Sentinel last: see the module note above.
+        cache["idf"] = idf
+    return cache
+
+
 def _identity_score(sym: dict, query_joined: str, raw_query: str = "") -> float:
     """Identity channel: exact, normalised, or prefix match on symbol name/ID.
 
@@ -875,14 +928,9 @@ def search_symbols(
     query_terms = _tokenize(query) or [query.lower()]
     # Guard: empty string in query_terms causes "" to match every filename
     query_terms = [t for t in query_terms if t]
-    cache = index._bm25_cache
-    if "idf" not in cache:
-        # Single-flight: concurrent cold searches must not each build the
-        # full-corpus BM25 state (#370)
-        with getattr(index, "_bm25_lock", None) or threading.Lock():
-            if "idf" not in cache:
-                cache["idf"], cache["avgdl"], cache["inverted"] = _compute_bm25(index.symbols)
-                cache["centrality"] = _compute_centrality(index.symbols, index.imports, index.alias_map, getattr(index, "psr4_map", None))
+    # Single-flight: concurrent cold searches must not each build the
+    # full-corpus BM25 state (#370), nor observe a half-published one (#490).
+    cache = ensure_bm25_cache(index)
     idf = cache["idf"]
     avgdl = cache["avgdl"]
     centrality = cache["centrality"]

--- a/tests/test_bm25_cache_single_flight.py
+++ b/tests/test_bm25_cache_single_flight.py
@@ -1,0 +1,239 @@
+"""#490: the lexical cache must never advertise readiness before it is ready.
+
+The BM25 corpus cache is built behind a check-then-build guarded on ``idf``.
+Three call sites published FOUR keys behind that one sentinel: the tuple unpack
+that wrote the first three is three separate ``__setitem__`` calls, followed by
+a fourth statement for ``centrality``. A caller arriving after ``idf`` appeared
+and before ``centrality`` did passed the readiness check and raised
+``KeyError: 'centrality'``.
+
+The window is the entire runtime of ``_compute_centrality`` over the corpus,
+which on a large repository is not narrow.
+"""
+
+import importlib
+import pathlib
+import re
+import threading
+import time
+
+import pytest
+
+from jcodemunch_mcp.tools import search_symbols as ss
+from jcodemunch_mcp.tools.index_folder import index_folder
+from jcodemunch_mcp.tools.search_symbols import search_symbols
+
+# The keys a reader of this cache goes on to read once it believes it is ready.
+CORPUS_KEYS = ("idf", "avgdl", "inverted", "centrality")
+
+# Every module that built the corpus inline before #490.
+CALL_SITES = (
+    "jcodemunch_mcp.tools.search_symbols",
+    "jcodemunch_mcp.tools.get_ranked_context",
+    "jcodemunch_mcp.tools.plan_turn",
+)
+
+
+@pytest.fixture
+def indexed(tmp_path):
+    """A tiny real repo plus its store. Returns (repo_id, store_path)."""
+    src = tmp_path / "src"
+    src.mkdir()
+    store = tmp_path / "store"
+    store.mkdir()
+    (src / "observer.py").write_text(
+        "class _NativeObserverOwner:\n    pass\n\n\n"
+        "class _ObserverLaunchContainment:\n    pass\n\n\n"
+        "def collect_async_io_observation():\n    return None\n"
+    )
+    (src / "other.py").write_text("import observer\n\n\ndef use():\n    return 1\n")
+    result = index_folder(str(src), use_ai_summaries=False, storage_path=str(store))
+    assert result["success"] is True
+    return result["repo"], str(store)
+
+
+def _load(repo_id, store):
+    from jcodemunch_mcp.tools._utils import load_repo_index_or_error
+
+    index, error, _status = load_repo_index_or_error(repo_id, store)
+    assert error is None, error
+    return index
+
+
+class TestReadinessIsNeverAdvertisedEarly:
+    """The defect, stated as an invariant rather than as a stack trace."""
+
+    def test_no_sentinel_is_visible_before_the_keys_a_reader_will_need(
+        self, indexed, monkeypatch
+    ):
+        """Observe the cache from INSIDE the build.
+
+        No threads needed: the pre-fix code had already published ``idf`` by the
+        time ``_compute_centrality`` ran, so a single-threaded probe at that
+        moment sees exactly the partial state a second caller would.
+        """
+        repo_id, store = indexed
+        index = _load(repo_id, store)
+        observations = []
+        real = ss._compute_centrality
+
+        def probing(*args, **kwargs):
+            observations.append({k: k in index._bm25_cache for k in CORPUS_KEYS})
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(ss, "_compute_centrality", probing)
+        ss.ensure_bm25_cache(index)
+
+        assert observations, "the build never ran; the probe proves nothing"
+        for seen in observations:
+            if not seen["idf"]:
+                continue
+            missing = [k for k in CORPUS_KEYS if not seen[k]]
+            assert not missing, (
+                f"cache advertised ready (idf present) while {missing} were "
+                "absent - a second caller reads those and raises KeyError"
+            )
+
+    def test_the_sentinel_is_written_last(self, indexed):
+        """Pin the write ORDER, not just the end state.
+
+        The end state is identical in the fixed and the broken version; only the
+        order differs, so an end-state assertion would pass on both sides.
+        """
+        repo_id, store = indexed
+        index = _load(repo_id, store)
+        written = []
+
+        class RecordingDict(dict):
+            def __setitem__(self, key, value):
+                written.append(key)
+                super().__setitem__(key, value)
+
+        index._bm25_cache = RecordingDict()
+        ss.ensure_bm25_cache(index)
+
+        corpus_writes = [k for k in written if k in CORPUS_KEYS]
+        assert set(corpus_writes) == set(CORPUS_KEYS), corpus_writes
+        assert corpus_writes[-1] == "idf", (
+            f"idf must be published last; write order was {corpus_writes}"
+        )
+
+
+class TestShippedPath:
+    """A unit invariant is not a user-visible outcome. This is the outcome."""
+
+    def test_concurrent_cold_searches_both_return_results(self, indexed, monkeypatch):
+        """⚠ The hold below is load-bearing, and the first version of this test
+        did not have it: signalling from inside the build and letting the second
+        caller race was not enough on a two-file corpus, so it passed against
+        the BROKEN source too. A is held open until B has entered its call and
+        had time to reach the cache. Pre-fix B reads a missing ``centrality``
+        in that window; post-fix B waits on the lock and then succeeds.
+        """
+        repo_id, store = indexed
+        builder_inside = threading.Event()
+        second_caller_started = threading.Event()
+        real = ss._compute_centrality
+
+        def slow(*args, **kwargs):
+            builder_inside.set()
+            # Keep the window open until the second caller is inside its call,
+            # plus enough slack for it to perform two dict lookups.
+            second_caller_started.wait(timeout=30)
+            time.sleep(0.5)
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(ss, "_compute_centrality", slow)
+        out = {}
+
+        def call(tag, query, wait_first):
+            if wait_first:
+                assert builder_inside.wait(timeout=30)
+                second_caller_started.set()
+            try:
+                response = search_symbols(
+                    repo=repo_id,
+                    query=query,
+                    detail_level="compact",
+                    max_results=10,
+                    storage_path=store,
+                )
+                rows = response.get("symbols") or response.get("results") or []
+                out[tag] = ("ok", len(rows))
+            except BaseException as exc:  # noqa: BLE001 - the failure IS the finding
+                out[tag] = ("raised", f"{type(exc).__name__}: {exc}")
+
+        a = threading.Thread(
+            target=call, args=("A", "_ObserverLaunchContainment", False), name="A"
+        )
+        b = threading.Thread(
+            target=call, args=("B", "_NativeObserverOwner", True), name="B"
+        )
+        a.start()
+        b.start()
+        a.join(timeout=60)
+        b.join(timeout=60)
+
+        assert out.get("A", ("missing",))[0] == "ok", out
+        assert out.get("B", ("missing",))[0] == "ok", out
+
+    def test_single_flight_is_preserved(self, indexed, monkeypatch):
+        """#370's guarantee must survive #490's fix: the corpus builds ONCE.
+
+        Control for the obvious wrong fix. Deleting the check-then-build and
+        letting every caller rebuild would satisfy every assertion above.
+        """
+        repo_id, store = indexed
+        index = _load(repo_id, store)
+        calls = []
+        real = ss._compute_bm25
+        gate = threading.Barrier(4, timeout=30)
+
+        def counting(*args, **kwargs):
+            calls.append(1)
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(ss, "_compute_bm25", counting)
+
+        def worker():
+            gate.wait()
+            ss.ensure_bm25_cache(index)
+
+        threads = [threading.Thread(target=worker) for _ in range(4)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=60)
+
+        assert len(calls) == 1, f"corpus built {len(calls)} times, expected once"
+
+
+class TestEveryCallSiteShares:
+    """The same four-key publish lived in THREE modules, so a fix in one is a
+    fix in one. This is the ratchet that stops a fourth appearing."""
+
+    def test_no_module_publishes_the_sentinel_outside_the_helper(self):
+        root = pathlib.Path(ss.__file__).resolve().parent.parent
+        helper_file = pathlib.Path(ss.__file__).resolve()
+        # A WRITE to the sentinel: `cache["idf"] =` or `cache["idf"], ... =`.
+        write = re.compile(r'cache\["idf"\]\s*(,|=[^=])')
+        offenders = []
+        for path in sorted(root.rglob("*.py")):
+            if path.resolve() == helper_file:
+                continue  # the helper itself is the one legitimate writer
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for lineno, line in enumerate(text.splitlines(), 1):
+                if write.search(line):
+                    offenders.append(f"{path.relative_to(root)}:{lineno}")
+        assert not offenders, (
+            "these publish the readiness sentinel outside ensure_bm25_cache: "
+            + ", ".join(offenders)
+        )
+
+    @pytest.mark.parametrize("module_name", CALL_SITES)
+    def test_the_known_call_sites_reach_the_helper(self, module_name):
+        mod = importlib.import_module(module_name)
+        assert hasattr(mod, "ensure_bm25_cache"), (
+            f"{module_name} built the corpus inline before #490; it must now go "
+            "through the shared helper"
+        )


### PR DESCRIPTION
Closes #490.

## What was wrong

The BM25 corpus cache is built once per loaded index behind a check-then-build guarded on `idf`. It publishes **four** keys, and the statement that looks atomic is not:

```python
cache["idf"], cache["avgdl"], cache["inverted"] = _compute_bm25(index.symbols)
cache["centrality"] = _compute_centrality(...)
```

Four separate `__setitem__` calls. `idf` — the key every reader checks before deciding the cache is ready — lands first; `centrality` lands after a full pass over the corpus. A caller arriving between the two passes the readiness check, skips the build, and reads a key that does not exist.

The window is the entire runtime of `_compute_centrality`, so it widens with corpus size: the installs most likely to hit this are the ones where the rebuild is most expensive.

The lock was real and correctly held. The build was single-flight, as #370 intended. What leaked was the readiness *signal*, which is read outside the lock by design and therefore must not become true early.

## The fix

One `ensure_bm25_cache(index)` helper. It writes `avgdl`, `inverted` and `centrality` first and `idf` last, and its fast path checks all four keys rather than the sentinel alone — so a future edit that reorders the writes costs an extra lock acquisition instead of a `KeyError`.

**The same four-key publish existed in three modules** — `search_symbols`, `get_ranked_context` and `plan_turn` — so fixing the reported one would have left two. All three now route through the helper, and the test fails if a fourth appears.

**Checked and deliberately left alone:** the `pagerank` and `name_map` blocks each write the one key they also check, so they are atomic by construction and share none of this hazard. Their `getattr(index, "_bm25_lock", None) or threading.Lock()` fallback is a separate, milder weakness — a fresh lock per caller guards nothing, so an index arriving without `_bm25_lock` would duplicate work rather than crash. Unreachable today, since both `CodeIndex` and `SelectiveIndexView` carry the lock. Recorded rather than swept, so a later pass does not read the silence as "already handled".

## Verification

@rknighton's reproduction, verbatim, against this branch and against `b85ef61`:

```text
=== PATCHED ===
thread A (builder)              : ok, results=3
thread B (concurrent cold search): ok, results=3
control after build             : ok, results=3

=== BASELINE b85ef61 ===
thread A (builder)              : ok, results=3
thread B (concurrent cold search): KeyError: 'centrality'
control after build             : ok, results=3
```

`tests/test_bm25_cache_single_flight.py`, 8 tests, **all 8 red against the pre-fix tree** — B raising exactly `KeyError: 'centrality'`.

⚠ **The first version of the shipped-path test passed against the broken source**, which is the part worth recording. Signalling from inside the build and letting the second thread race is not enough on a two-file corpus: the builder finishes before the racer arrives. The test now holds the build open until the second caller is demonstrably inside its call. A concurrency test that does not pin the interleaving is testing its own machine's scheduler.

`test_single_flight_is_preserved` is the control against the obvious wrong fix: deleting the check-then-build entirely would satisfy every other assertion in the file.

Suite: **7902 passed, 17 skipped, 0 failed** (`uv run pytest tests/ -n 4 --dist loadfile`), `uv run ruff check src/` clean. Total 7919 against v1.108.284's 7911 is exactly the 8 new tests, so nothing else moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
