### PR TITLE
fix(index_file): advance git_head only for a corpus shown to match it (#493)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 ## [Unreleased]
 
+### A single-file refresh no longer certifies a corpus it never re-read (#493, @rknighton)
+
+`index_file` wrote live HEAD as the repository's stored SHA. `repo_is_stale` is
+defined as "index SHA differs from live HEAD", so refreshing one file out of a
+two-file commit **cleared the staleness signal for the file that was never
+refreshed**. `get_file_content` on that file then served commit-A content
+reporting `channels.index: fresh`, against a clean working tree.
+
+⚠⚠ **The write is not the defect; what has been proven before it is.**
+`index_folder`'s `_refresh_git_head_if_advanced` performs the *identical* write
+on a no-change run (#330), and it is correct there — that run walked the corpus
+and established that nothing indexed had changed, so the corpus really does
+correspond to the new head. `index_file` established something far weaker, that
+one requested file now matches, and advanced the repository-level head anyway.
+**Two calls, one write, opposite correctness, and the difference is entirely in
+what came before.**
+
+The head now advances only when refreshing this one file is what brought the
+corpus into line: every other path that moved between the stored head and live
+HEAD must be one the index does not carry and would not index. That is one
+`git diff --name-only --relative` against the stored head — no walk, no
+per-file work.
+
+⚠ **Unknown resolves to "do not advance".** A head left behind reads `stale` for
+a repository that may match, costing a re-index; a head advanced without proof
+reads `fresh` for one that does not, costing a wrong answer with no signal
+attached. Same asymmetry as v1.108.209's rule that `classify()` must never
+answer `fresh` for a comparison it could not make. `_paths_changed_between`
+returns `None` for "could not ask" and never an empty set, so a failed git call
+cannot read as a clean diff.
+
+⚠ **`--relative` is load-bearing.** It scopes the diff to `source_root`, so a
+monorepo subtree index is not held back by a commit that touched a sibling it
+never indexed.
+
+⚠ **An ADDED source file blocks the advance too**, though it is in no corpus and
+so cannot be "a file we carry that moved". The indexer would take it, so
+advancing would certify a complete index over a corpus missing a file — an
+absence claim with nothing behind it.
+
+⚠ **A no-change `index_folder` run still advances the head** (#330 does not
+regress), a full re-index still records it, and a single-file commit refreshed
+by `index_file` still clears staleness. Those three are the constraints on the
+fix, not side effects of it: a guard that simply never advanced would satisfy
+every assertion about the reported bug and leave every repository reading stale
+forever.
+
+⚠ **The branch-delta path is deliberately unchanged.** It writes `branch_meta`
+rather than the repository-level `meta` row, and carries its own `base_head`, so
+it is a different question — the reporter said as much and made no claim about
+it. Recorded rather than swept.
+
+⚠ `tests/test_index_file_head_advance.py` (10). Five are red against `b85ef61`;
+the other five are the constraint tests above and pass on both sides by design.
+
+
 ### A cache that announced it was ready one key before it was (#490, @rknighton)
 
 `search_symbols` could raise `KeyError: 'centrality'` — surfacing through the

--- a/src/jcodemunch_mcp/tools/index_file.py
+++ b/src/jcodemunch_mcp/tools/index_file.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import subprocess
 import time
 from pathlib import Path
 from typing import Callable, Optional
@@ -53,6 +54,89 @@ def _sibling_checkout_error(file_path: Path, store: IndexStore) -> Optional[str]
     except Exception:
         logger.debug("Sibling-checkout probe failed", exc_info=True)
         return None
+
+
+def _paths_changed_between(source_root: Path, old_head: str, new_head: str) -> Optional[set[str]]:
+    """Repo-relative posix paths that differ between two commits, or None.
+
+    ``None`` means the question could not be answered — a git failure, a missing
+    commit, a tree that is not a repository. It is NEVER an empty set: callers
+    must treat unknown as "cannot prove", not as "nothing changed".
+
+    ``--relative`` scopes the answer to ``source_root``, so a monorepo subtree
+    index is not held back by a commit that touched a sibling it never indexed.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "--relative", old_head, new_head],
+            cwd=str(source_root),
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=15, stdin=subprocess.DEVNULL,
+        )
+    except Exception:
+        logger.debug("git diff failed for %s", source_root, exc_info=True)
+        return None
+    if result.returncode != 0:
+        logger.debug(
+            "git diff %s..%s returned %s for %s",
+            old_head[:12], new_head[:12], result.returncode, source_root,
+        )
+        return None
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
+def _head_may_advance(
+    index, source_root: Path, stored_head: str, live_head: str, refreshed_rel: str,
+) -> bool:
+    """May this single-file refresh record ``live_head`` as the corpus's head?
+
+    Only when refreshing this one file is what brought the corpus into line with
+    ``live_head``: every other path that moved between the two commits must be
+    one the index does not carry and would not index.
+
+    ⚠⚠ **The write is not the defect; what has been proven before it is.**
+    ``index_folder``'s ``_refresh_git_head_if_advanced`` performs the identical
+    write on a no-change run (#330), and it is correct there because that run
+    walked the corpus and established that nothing indexed had changed.
+    ``index_file`` establishes something far weaker — that ONE requested file now
+    matches — and then advanced the repository-level head anyway, clearing
+    ``repo_is_stale`` for every file that moved in the same commit and was never
+    refreshed (#493). Nothing errored: the served content was simply the old
+    commit's, reported ``fresh``.
+
+    ⚠ Unknown resolves to False. A head left behind reads ``stale`` for a
+    repository that may in fact match, which costs a re-index; a head advanced
+    without proof reads ``fresh`` for one that does not, which costs a wrong
+    answer with no signal attached. Same asymmetry as v1.108.209's rule that
+    ``classify()`` must never answer ``fresh`` for a comparison it could not
+    make.
+    """
+    if not live_head:
+        return False
+    if not stored_head:
+        # No baseline to diff against, so nothing can be proven. The index keeps
+        # its empty head and `repo_is_stale` keeps reporting False for want of a
+        # SHA, exactly as before this call; a full `index_folder` sets it.
+        return False
+    if stored_head == live_head:
+        return True  # nothing moved; the write is a no-op
+
+    changed = _paths_changed_between(source_root, stored_head, live_head)
+    if changed is None:
+        return False
+
+    indexed_paths = set(getattr(index, "source_files", None) or ())
+    for path in changed:
+        if path == refreshed_rel:
+            continue
+        if path in indexed_paths:
+            return False  # a file we carry moved and we did not re-read it
+        if get_language_for_path(path) is not None:
+            # Not in the corpus but the indexer would take it: an added source
+            # file. Advancing here would report a complete index over a corpus
+            # that is missing a file, which is an absence claim we cannot back.
+            return False
+    return True
 
 
 def index_file(
@@ -235,7 +319,14 @@ def index_file(
         )
     )
 
-    git_head = _get_git_head(source_root) or ""
+    live_head = _get_git_head(source_root) or ""
+    stored_head = (getattr(base_index, "git_head", "") or "") if base_index else ""
+    # #493: advance the repository-level head only when refreshing this one file
+    # is what brought the corpus into line with it. See _head_may_advance.
+    head_advanced = _head_may_advance(
+        index, source_root, stored_head, live_head, rel_path,
+    )
+    git_head = live_head if head_advanced else stored_head
     ctx_metadata = collect_metadata(active_providers) if active_providers else None
 
     # Determine changed vs new
@@ -248,7 +339,10 @@ def index_file(
             changed_files=changed_files, new_files=new_files, deleted_files=[],
             new_symbols=new_symbols,
             raw_files={rel_path: content},
-            git_head=git_head,
+            # ⚠ The branch-delta path writes `branch_meta`, not the
+            # repository-level `meta` row #493 is about, and carries its own
+            # `base_head`. Left on the live head deliberately; see CHANGELOG.
+            git_head=live_head,
             base_head=base_index.git_head if base_index else "",
             file_hashes={rel_path: file_hash},
             file_mtimes={rel_path: file_mtime},

--- a/tests/test_index_file_head_advance.py
+++ b/tests/test_index_file_head_advance.py
@@ -1,0 +1,242 @@
+"""#493: a single-file refresh must not certify a corpus it never re-read.
+
+``index_file`` wrote live HEAD as the repository's stored SHA. ``repo_is_stale``
+is "index SHA differs from live HEAD", so refreshing one file out of a two-file
+commit cleared the staleness signal for the file that was never refreshed, and
+``get_file_content`` served commit-A content reporting ``channels.index: fresh``
+against a clean working tree.
+
+The write itself is not the defect. ``index_folder``'s
+``_refresh_git_head_if_advanced`` performs the identical write on a no-change run
+(#330) and is correct, because that run walked the corpus first. What differs is
+what has been proven before the write, which is where the fix lives.
+"""
+
+import subprocess
+
+import pytest
+
+from jcodemunch_mcp.tools import index_file as index_file_mod
+from jcodemunch_mcp.tools.get_file_content import get_file_content
+from jcodemunch_mcp.tools.index_file import index_file
+from jcodemunch_mcp.tools.index_folder import index_folder
+from jcodemunch_mcp.tools.list_repos import list_repos
+from jcodemunch_mcp.tools.search_symbols import search_symbols
+
+
+def _git(cwd, *args):
+    return subprocess.run(
+        ["git", *args], cwd=str(cwd), check=True,
+        capture_output=True, text=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A two-file git repo at commit A, indexed. Returns a small helper object."""
+    work = tmp_path / "repo"
+    work.mkdir()
+    store = tmp_path / "store"
+    store.mkdir()
+    _git(work, "init", "-q")
+    _git(work, "config", "user.email", "repro@example.invalid")
+    _git(work, "config", "user.name", "repro")
+    (work / "alpha.py").write_text("def alpha_v1():\n    return 1\n")
+    (work / "beta.py").write_text("def beta_v1():\n    return 1\n")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-q", "-m", "A")
+
+    result = index_folder(
+        path=str(work), identity_mode="local", use_ai_summaries=False,
+        storage_path=str(store),
+    )
+    assert result["success"] is True
+
+    class Repo:
+        path = work
+        store_path = str(store)
+        repo_id = result["repo"]
+
+        @staticmethod
+        def stored_head():
+            for entry in list_repos(storage_path=str(store)).get("repos", []):
+                if entry.get("repo") == result["repo"]:
+                    return entry.get("git_head") or ""
+            return ""
+
+        @staticmethod
+        def live_head():
+            return _git(work, "rev-parse", "HEAD")
+
+        @staticmethod
+        def repo_is_stale():
+            response = search_symbols(
+                repo=result["repo"], query="beta", detail_level="full",
+                max_results=5, storage_path=str(store),
+            )
+            freshness = (response.get("_meta") or {}).get("freshness") or {}
+            return freshness.get("repo_is_stale")
+
+        @staticmethod
+        def refresh(name):
+            return index_file(
+                path=str(work / name), use_ai_summaries=False,
+                storage_path=str(store),
+            )
+
+    return Repo
+
+
+class TestAPartialRefreshDoesNotCertifyTheCorpus:
+    """The reported defect, as its two observable halves."""
+
+    def test_multi_file_commit_then_one_refresh_leaves_the_repo_stale(self, repo):
+        (repo.path / "alpha.py").write_text("def alpha_v2():\n    return 2\n")
+        (repo.path / "beta.py").write_text("def beta_v2():\n    return 2\n")
+        _git(repo.path, "add", "-A")
+        _git(repo.path, "commit", "-q", "-m", "B")
+        assert repo.repo_is_stale() is True, "precondition: the repo moved"
+
+        repo.refresh("alpha.py")
+
+        assert repo.repo_is_stale() is True, (
+            "refreshing alpha.py cleared the staleness signal for beta.py, "
+            "which is still at commit A"
+        )
+
+    def test_the_unrefreshed_file_is_not_served_as_fresh(self, repo):
+        (repo.path / "alpha.py").write_text("def alpha_v2():\n    return 2\n")
+        (repo.path / "beta.py").write_text("def beta_v2():\n    return 2\n")
+        _git(repo.path, "add", "-A")
+        _git(repo.path, "commit", "-q", "-m", "B")
+        repo.refresh("alpha.py")
+
+        got = get_file_content(
+            repo=repo.repo_id, file_path="beta.py", storage_path=repo.store_path,
+        )
+        # The served bytes really are the old commit's - that half is expected,
+        # and is why the signal matters.
+        assert "beta_v1" in got.get("content", "")
+        channels = ((got.get("_meta") or {}).get("verdict") or {}).get("channels") or {}
+        assert channels.get("index") != "fresh", (
+            f"served commit-A content with channels.index={channels.get('index')!r} "
+            "against a clean working tree"
+        )
+
+
+class TestTheHeadStillAdvancesWhenItIsEarned:
+    """These are what constrain the fix. Refusing to ever advance would pass
+    every assertion in the class above and be a worse bug: every repository
+    would read stale forever."""
+
+    def test_head_advances_when_the_refreshed_file_was_the_only_change(self, repo):
+        (repo.path / "alpha.py").write_text("def alpha_v2():\n    return 2\n")
+        _git(repo.path, "add", "-A")
+        _git(repo.path, "commit", "-q", "-m", "B")
+        assert repo.repo_is_stale() is True
+
+        repo.refresh("alpha.py")
+
+        assert repo.stored_head() == repo.live_head()
+        assert repo.repo_is_stale() is False, (
+            "the refresh brought the corpus into line with HEAD; the head must "
+            "advance or every single-file commit leaves the repo reading stale"
+        )
+
+    def test_an_uncommitted_edit_leaves_the_head_where_it_was(self, repo):
+        """The hook path: PostToolUse refreshes on every write, with no commit.
+
+        Control - stored and live head are equal, so the write is a no-op either
+        way. It passes before and after the fix.
+        """
+        before = repo.stored_head()
+        (repo.path / "alpha.py").write_text("def alpha_v2():\n    return 2\n")
+        repo.refresh("alpha.py")
+        assert repo.stored_head() == before == repo.live_head()
+
+    def test_a_non_source_file_change_does_not_block_the_advance(self, repo):
+        """#330's intent, applied here: a commit touching only files the indexer
+        would never carry leaves the corpus accurate."""
+        (repo.path / "alpha.py").write_text("def alpha_v2():\n    return 2\n")
+        (repo.path / "NOTES.txt").write_text("not indexed\n")
+        _git(repo.path, "add", "-A")
+        _git(repo.path, "commit", "-q", "-m", "B")
+
+        repo.refresh("alpha.py")
+
+        assert repo.stored_head() == repo.live_head()
+
+    def test_a_no_change_index_folder_run_still_advances_the_head(self, repo):
+        """#330 must not regress. That fix is the same write, made correct by a
+        walk that established nothing indexed had changed."""
+        (repo.path / "NOTES.txt").write_text("not indexed\n")
+        _git(repo.path, "add", "-A")
+        _git(repo.path, "commit", "-q", "-m", "B")
+
+        index_folder(
+            path=str(repo.path), identity_mode="local", use_ai_summaries=False,
+            storage_path=repo.store_path,
+        )
+
+        assert repo.stored_head() == repo.live_head()
+        assert repo.repo_is_stale() is False
+
+    def test_a_full_reindex_records_the_current_head(self, repo):
+        (repo.path / "alpha.py").write_text("def alpha_v2():\n    return 2\n")
+        (repo.path / "beta.py").write_text("def beta_v2():\n    return 2\n")
+        _git(repo.path, "add", "-A")
+        _git(repo.path, "commit", "-q", "-m", "B")
+
+        index_folder(
+            path=str(repo.path), identity_mode="local", use_ai_summaries=False,
+            storage_path=repo.store_path,
+        )
+
+        assert repo.stored_head() == repo.live_head()
+        assert repo.repo_is_stale() is False
+
+
+class TestUnknownIsNeverProof:
+    """v1.108.209's rule, applied to a different comparison: never answer
+    'fresh' for a question that could not be asked."""
+
+    def test_an_added_source_file_blocks_the_advance(self, repo):
+        """Not in the corpus, so it cannot be 'a file we carry that moved' - but
+        the indexer would take it, so advancing certifies an index missing a
+        file."""
+        (repo.path / "alpha.py").write_text("def alpha_v2():\n    return 2\n")
+        (repo.path / "gamma.py").write_text("def gamma():\n    return 3\n")
+        _git(repo.path, "add", "-A")
+        _git(repo.path, "commit", "-q", "-m", "B")
+
+        repo.refresh("alpha.py")
+
+        assert repo.stored_head() != repo.live_head()
+        assert repo.repo_is_stale() is True
+
+    def test_an_unanswerable_diff_does_not_advance(self, repo, monkeypatch):
+        (repo.path / "alpha.py").write_text("def alpha_v2():\n    return 2\n")
+        _git(repo.path, "add", "-A")
+        _git(repo.path, "commit", "-q", "-m", "B")
+        before = repo.stored_head()
+
+        monkeypatch.setattr(
+            index_file_mod, "_paths_changed_between", lambda *a, **k: None
+        )
+        repo.refresh("alpha.py")
+
+        assert repo.stored_head() == before, (
+            "a git failure must leave the head behind - unknown resolves to "
+            "'cannot prove', never to 'nothing changed'"
+        )
+
+    def test_an_empty_result_is_distinguishable_from_a_failure(self, repo):
+        """The helper returns None for 'could not ask' and a set for 'asked'.
+        Collapsing the two would make a failed git call read as a clean diff,
+        which is the defect this whole file is about wearing a new hat."""
+        head = repo.live_head()
+        same = index_file_mod._paths_changed_between(repo.path, head, head)
+        assert same == set(), "two identical commits differ in no paths"
+        assert index_file_mod._paths_changed_between(
+            repo.path, "0" * 40, head
+        ) is None, "an unknown commit is unanswerable, not empty"


### PR DESCRIPTION
Closes #493.

## What was wrong

`index_file` wrote live HEAD as the repository's stored SHA. `repo_is_stale` is "index SHA differs from live HEAD", so refreshing one file out of a two-file commit cleared the staleness signal for the file that was never refreshed. `get_file_content` then served commit-A content reporting `channels.index: fresh`, against a clean working tree.

**The write is not the defect; what has been proven before it is.** `index_folder`'s `_refresh_git_head_if_advanced` makes the *identical* write on a no-change run (#330) and is correct there — that run walked the corpus and established nothing indexed had changed. `index_file` established that one requested file now matches, and advanced the repository-level head anyway. Two calls, one write, opposite correctness. @rknighton drew that distinction in the report and the fix is built on it.

## The fix

The head advances only when refreshing this one file is what brought the corpus into line: every other path that moved between the stored head and live HEAD must be one the index neither carries nor would index. One `git diff --name-only --relative` against the stored head — no walk, no per-file work.

- **Unknown resolves to "do not advance."** `_paths_changed_between` returns `None` for "could not ask", never an empty set, so a failed git call cannot read as a clean diff. A head left behind costs a re-index; a head advanced without proof costs a wrong answer with no signal attached — v1.108.209's asymmetry.
- **`--relative` is load-bearing:** a monorepo subtree index is not held back by a commit that touched a sibling it never indexed.
- **An added source file blocks too.** It is in no corpus, so it cannot be "a file we carry that moved" — but the indexer would take it, so advancing would certify a complete index over a corpus missing a file.
- **The branch-delta path is deliberately unchanged.** It writes `branch_meta`, not the repository-level `meta` row, and carries its own `base_head`. You said as much and made no claim about it; recorded rather than swept.

## Verification

Your reproduction, verbatim, against this branch:

```text
1. after full index      : git_head=6bb2ea082cdb  repo_is_stale=False
2. after commit B        : git_head=6bb2ea082cdb  repo_is_stale=True
3. after index_file(alpha): git_head=6bb2ea082cdb  repo_is_stale=True

   verdict : {"state": "ok", "channels": {"index": "stale"}, ...}
```

Acceptance criteria 1 and 2 both hold — `repo_is_stale` survives the refresh, and the unrefreshed file no longer reads `channels.index: fresh`.

`tests/test_index_file_head_advance.py`, 10 tests. **Five red against `b85ef61`.** The other five are criteria 3–5 plus two boundary cases, and pass on both sides *by design* — they pin what the fix must not break. A guard that simply never advanced would satisfy every assertion about the reported bug and leave every repository reading stale forever.

Suite: **7923 passed, 17 skipped, 0 failed**, ruff clean (measured with #492 in the same tree; +21 over the post-#490 total decomposes as 10 here and 11 there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
