### PR TITLE
fix(resolve_repo): stop containment resolving across a nested repo boundary (#492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ## [Unreleased]
 
+### `resolve_repo` no longer answers a repository question with a filesystem fact (#492, @rknighton)
+
+Fast path 1 matched on `source_root` containment alone, so a path inside an
+**independent git repository nested in an indexed parent** came back as the
+parent index with `found: true`, `indexed: true`, `loadable: true` and
+`match_path: source_root_containment`. Nothing in that branch consulted git
+identity. The caller was bound to a corpus built from a different checkout with
+a different history.
+
+⚠⚠ **Whether it looks wrong depends on something irrelevant to the defect.**
+When the nested repository is gitignored by the parent, the read fails and
+returns `absent` — correct for the corpus that was searched, and the reason it
+reads as a normal empty result. When the parent's walk absorbed the nested
+files, the same wrong repository is returned and **the read succeeds with
+`state: ok`**. The mis-resolution is identical; only the symptom differs. Both
+cases change here.
+
+The guard is a `.git` stat between the requested path and the matched
+`source_root`. ⚠ **A subprocess would have been the wrong fix at the right
+place**: fast path 1 exists precisely to avoid the `resolve_index_identity`
+walk that can hang in large agent-worktree environments (#303), so a
+correctness guard on it must not reintroduce a process spawn. A test asserts no
+`subprocess.run` on the ordinary containment path.
+
+⚠ **Classify by where `.git` POINTS, not by whether it is a file.** A `.git`
+directory is an independent repository; a `.git` file carries a `gitdir:`
+pointer, and `.git/worktrees/<name>` versus `.git/modules/<name>` is exactly the
+distinction #372 drew. **Submodules deliberately still resolve to the parent** —
+their content is indexed into it, and #372 excluded linked worktrees without
+changing that. Linked worktrees are also left alone: fast path 2 already answers
+for them via `canonical_candidates`, and diverting them here would change #303's
+answer. `git clone --separate-git-dir` leaves a `.git` file pointing at neither,
+and counts as independent — a file/directory test would have read it as a
+submodule.
+
+⚠ **A file outside the parent's corpus still resolves to the parent.** Being
+gitignored, oversize or in a skipped directory is not the same condition as
+belonging to another repository, and only the second changes which repository is
+returned.
+
+⚠ `tests/test_resolve_repo_nested_repo_boundary.py` (11). Seven are red against
+`b85ef61`; the remaining four are the boundary tests above and pass on both
+sides by design.
+
+
 ### A single-file refresh no longer certifies a corpus it never re-read (#493, @rknighton)
 
 `index_file` wrote live HEAD as the repository's stored SHA. `repo_is_stale` is

--- a/src/jcodemunch_mcp/tools/resolve_repo.py
+++ b/src/jcodemunch_mcp/tools/resolve_repo.py
@@ -13,6 +13,76 @@ from ..storage.git_root import resolve_index_identity
 logger = logging.getLogger(__name__)
 
 
+def _dotgit_kind(directory: Path) -> Optional[str]:
+    """Classify a ``.git`` entry: "repo", "submodule", "worktree", or None.
+
+    A ``.git`` DIRECTORY is an independent repository. A ``.git`` FILE carries a
+    ``gitdir:`` pointer, and where it points is the whole distinction #372 drew:
+    ``.git/worktrees/<name>`` is a linked worktree, ``.git/modules/<name>`` is a
+    submodule. Anything else pointing outside both is a ``--separate-git-dir``
+    clone, which is independent.
+    """
+    dotgit = directory / ".git"
+    try:
+        if dotgit.is_dir():
+            return "repo"
+        if not dotgit.is_file():
+            return None
+        text = dotgit.read_text(encoding="utf-8", errors="ignore").strip()
+    except OSError:
+        return None
+    if not text.startswith("gitdir:"):
+        return None
+    target = Path(text[len("gitdir:"):].strip())
+    if not target.is_absolute():
+        target = directory / target
+    parent_name = target.parent.name
+    if parent_name == "worktrees":
+        return "worktree"
+    if parent_name == "modules":
+        return "submodule"
+    return "repo"
+
+
+def _independent_repo_between(p_resolved: Path, source_root: Path) -> Optional[Path]:
+    """Root of an independent git repository between a path and a source root.
+
+    Returns the deepest such root, or None when the path really does belong to
+    ``source_root``'s repository.
+
+    ⚠⚠ Containment is a statement about the FILESYSTEM; the caller wants one
+    about the REPOSITORY. A nested independent clone inside an indexed parent
+    satisfies the first and fails the second, and before #493's sibling #492 the
+    resolver returned the parent as ``indexed: true`` for it, binding the caller
+    to a corpus from a different checkout with a different history.
+
+    ⚠ Submodules deliberately do NOT count. Their content IS indexed into the
+    parent, which is the boundary #372 drew when it excluded linked worktrees
+    without changing submodule behaviour. Linked worktrees are left alone here
+    too: fast path 2 already answers for them via ``canonical_candidates``, and
+    diverting them into this branch would change #303's answer.
+
+    ⚠ Stats only, no subprocess — fast path 1 exists to avoid the
+    ``resolve_index_identity`` walk that can hang (#303), so a correctness guard
+    on it must not reintroduce a process spawn.
+    """
+    try:
+        candidates = [p_resolved, *p_resolved.parents]
+    except (OSError, ValueError):
+        return None
+    for directory in candidates:
+        if directory == source_root:
+            return None  # reached the indexed root without crossing a boundary
+        try:
+            if not directory.is_relative_to(source_root):
+                return None
+        except (OSError, ValueError, AttributeError):
+            return None
+        if _dotgit_kind(directory) == "repo":
+            return directory
+    return None
+
+
 def _compute_repo_id(folder_path: Path, store: Optional[IndexStore] = None) -> str:
     """Compute the repo ID that index_folder would use for a directory path."""
     decision = resolve_index_identity(str(folder_path), mode="config", store=store)
@@ -266,10 +336,21 @@ def _resolve_repo_impl(path: str, storage_path: Optional[str] = None) -> dict:
                 return built
         else:
             try:
-                if p_resolved.is_relative_to(sr_path):
-                    containment_hits.append((len(str(sr_path)), entry))
+                if not p_resolved.is_relative_to(sr_path):
+                    continue
             except (OSError, ValueError, AttributeError):
                 continue
+            # #492: containment is a filesystem fact, not a repository one. An
+            # independent clone nested inside an indexed parent is contained by
+            # it and belongs to neither its corpus nor its history.
+            boundary = _independent_repo_between(p_resolved, sr_path)
+            if boundary is not None:
+                logger.debug(
+                    "resolve_repo: %s is inside independent repo %s, not %s",
+                    p_resolved, boundary, sr_path,
+                )
+                continue
+            containment_hits.append((len(str(sr_path)), entry))
 
     if containment_hits:
         # Deepest source_root wins (most specific match).

--- a/tests/test_resolve_repo_nested_repo_boundary.py
+++ b/tests/test_resolve_repo_nested_repo_boundary.py
@@ -1,0 +1,239 @@
+"""#492: containment is a filesystem fact; the caller wants a repository one.
+
+``resolve_repo``'s fast path 1 matched on ``source_root`` containment alone and
+returned the enclosing parent index as ``indexed: true`` for a path belonging to
+an independent git repository nested inside it. The caller was then bound to a
+corpus built from a different checkout with a different history, and nothing in
+the response said so.
+
+The ordering is deliberate - fast path 1 exists to avoid the
+``resolve_index_identity`` walk that can hang (#303) - so the guard is a
+filesystem stat, never a subprocess.
+"""
+
+import subprocess
+
+import pytest
+
+from jcodemunch_mcp.tools import resolve_repo as resolve_repo_mod
+from jcodemunch_mcp.tools.index_folder import index_folder
+from jcodemunch_mcp.tools.resolve_repo import resolve_repo
+
+
+def _git(cwd, *args):
+    return subprocess.run(
+        ["git", *args], cwd=str(cwd), check=True,
+        capture_output=True, text=True,
+    ).stdout.strip()
+
+
+def _make_repo(path, files, gitignore=None):
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "repro@example.invalid")
+    _git(path, "config", "user.name", "repro")
+    for name, text in files.items():
+        (path / name).write_text(text)
+    if gitignore:
+        (path / ".gitignore").write_text(gitignore)
+    _git(path, "add", "-A")
+    _git(path, "commit", "-q", "-m", "init")
+    return path
+
+
+@pytest.fixture
+def store(tmp_path):
+    d = tmp_path / "store"
+    d.mkdir()
+    return str(d)
+
+
+class TestANestedIndependentRepoIsNotTheParent:
+    """The reported defect. Both cases must change, not just the visible one."""
+
+    @pytest.mark.parametrize(
+        "gitignored",
+        [
+            pytest.param(True, id="nested-gitignored-by-parent"),
+            pytest.param(False, id="parent-absorbed-nested-files"),
+        ],
+    )
+    def test_a_path_in_a_nested_clone_does_not_resolve_to_the_parent(
+        self, tmp_path, store, gitignored
+    ):
+        """⚠ The second case is the one that matters for the acceptance
+        criteria. When the parent's walk absorbed the nested files the read
+        SUCCEEDS and nothing looks wrong - same mis-resolution, no symptom.
+        """
+        parent = _make_repo(
+            tmp_path / "parent",
+            {"marker.py": "def marker():\n    return 1\n"},
+            gitignore="nested-repo/\n" if gitignored else None,
+        )
+        nested = _make_repo(
+            parent / "nested-repo", {"alpha.py": "def alpha():\n    return 1\n"}
+        )
+        parent_result = index_folder(
+            path=str(parent), identity_mode="local", use_ai_summaries=False,
+            storage_path=store,
+        )
+        assert parent_result["success"] is True
+
+        got = resolve_repo(path=str(nested / "alpha.py"), storage_path=store)
+
+        assert got.get("indexed") is not True, (
+            f"returned the parent index as indexed for a path in another "
+            f"repository: {got.get('repo')!r} via "
+            f"{(got.get('_meta') or {}).get('match_path')!r}"
+        )
+        assert got.get("repo") != parent_result["repo"]
+
+    def test_the_nested_repo_resolves_to_itself_once_indexed(self, tmp_path, store):
+        """Control: the resolver does the right thing as soon as an exact index
+        exists, which holds the path and both repositories valid."""
+        parent = _make_repo(
+            tmp_path / "parent", {"marker.py": "def marker():\n    return 1\n"},
+            gitignore="nested-repo/\n",
+        )
+        nested = _make_repo(
+            parent / "nested-repo", {"alpha.py": "def alpha():\n    return 1\n"}
+        )
+        index_folder(path=str(parent), identity_mode="local",
+                     use_ai_summaries=False, storage_path=store)
+        nested_result = index_folder(path=str(nested), identity_mode="local",
+                                     use_ai_summaries=False, storage_path=store)
+
+        got = resolve_repo(path=str(nested / "alpha.py"), storage_path=store)
+
+        assert got.get("repo") == nested_result["repo"]
+        assert got.get("indexed") is True
+        assert (got.get("_meta") or {}).get("match_path") == "exact_source_root"
+
+
+class TestTheBoundariesTheGuardMustNotCross:
+    """These constrain the fix. A guard that blocked everything would satisfy
+    the class above and break more than it fixed, so each of these passes both
+    before and after by design."""
+
+    def test_a_path_in_a_submodule_still_resolves_to_the_parent(
+        self, tmp_path, store
+    ):
+        """Submodule content IS indexed into the parent. #372 excluded linked
+        worktrees specifically WITHOUT changing submodule behaviour, and this
+        keeps that boundary where it was."""
+        upstream = _make_repo(
+            tmp_path / "upstream", {"s.py": "def s():\n    return 1\n"}
+        )
+        parent = _make_repo(
+            tmp_path / "parent", {"p.py": "def p():\n    return 1\n"}
+        )
+        subprocess.run(
+            ["git", "-c", "protocol.file.allow=always", "submodule", "add", "-q",
+             str(upstream), "vendor"],
+            cwd=str(parent), check=True, capture_output=True, text=True,
+        )
+        assert (parent / "vendor" / ".git").is_file(), "expected a submodule marker"
+        parent_result = index_folder(
+            path=str(parent), identity_mode="local", use_ai_summaries=False,
+            storage_path=store,
+        )
+
+        got = resolve_repo(path=str(parent / "vendor" / "s.py"), storage_path=store)
+
+        assert got.get("repo") == parent_result["repo"]
+        assert got.get("indexed") is True
+
+    def test_a_file_outside_the_corpus_still_resolves_to_the_parent(
+        self, tmp_path, store
+    ):
+        """Being outside the corpus and belonging to another repository are
+        different conditions. Only the second changes which repo is returned."""
+        parent = _make_repo(
+            tmp_path / "parent", {"p.py": "def p():\n    return 1\n"},
+            gitignore="ignored/\n",
+        )
+        (parent / "ignored").mkdir()
+        (parent / "ignored" / "skipped.py").write_text("def skipped():\n    return 1\n")
+        parent_result = index_folder(
+            path=str(parent), identity_mode="local", use_ai_summaries=False,
+            storage_path=store,
+        )
+
+        got = resolve_repo(
+            path=str(parent / "ignored" / "skipped.py"), storage_path=store
+        )
+
+        assert got.get("repo") == parent_result["repo"]
+        assert got.get("indexed") is True
+
+    def test_an_ordinary_path_resolves_by_containment_with_no_subprocess(
+        self, tmp_path, store, monkeypatch
+    ):
+        """⚠ Fast path 1 exists to avoid a walk that can HANG (#303). A
+        correctness guard on it that spawns a process would trade the reported
+        bug for the one the fast path was built to prevent."""
+        parent = _make_repo(
+            tmp_path / "parent", {"p.py": "def p():\n    return 1\n"}
+        )
+        (parent / "pkg").mkdir()
+        (parent / "pkg" / "mod.py").write_text("def mod():\n    return 1\n")
+        _git(parent, "add", "-A")
+        _git(parent, "commit", "-q", "-m", "pkg")
+        parent_result = index_folder(
+            path=str(parent), identity_mode="local", use_ai_summaries=False,
+            storage_path=store,
+        )
+
+        def forbidden(*args, **kwargs):
+            raise AssertionError(f"fast path 1 spawned a subprocess: {args!r}")
+
+        monkeypatch.setattr(resolve_repo_mod.subprocess, "run", forbidden)
+        got = resolve_repo(path=str(parent / "pkg" / "mod.py"), storage_path=store)
+
+        assert got.get("repo") == parent_result["repo"]
+        assert got.get("indexed") is True
+        assert (got.get("_meta") or {}).get("match_path") == "source_root_containment"
+
+
+class TestTheClassifier:
+    """``_dotgit_kind`` is where the whole distinction lives, so test it against
+    real git layouts rather than only through the resolver."""
+
+    def test_a_plain_clone_is_a_repo(self, tmp_path):
+        path = _make_repo(tmp_path / "plain", {"a.py": "x = 1\n"})
+        assert resolve_repo_mod._dotgit_kind(path) == "repo"
+
+    def test_a_submodule_marker_is_a_submodule(self, tmp_path):
+        upstream = _make_repo(tmp_path / "up", {"s.py": "x = 1\n"})
+        parent = _make_repo(tmp_path / "par", {"p.py": "x = 1\n"})
+        subprocess.run(
+            ["git", "-c", "protocol.file.allow=always", "submodule", "add", "-q",
+             str(upstream), "vendor"],
+            cwd=str(parent), check=True, capture_output=True, text=True,
+        )
+        assert resolve_repo_mod._dotgit_kind(parent / "vendor") == "submodule"
+
+    def test_a_linked_worktree_marker_is_a_worktree(self, tmp_path):
+        main = _make_repo(tmp_path / "main", {"a.py": "x = 1\n"})
+        wt = tmp_path / "main" / "wt"
+        _git(main, "worktree", "add", "-q", str(wt), "-b", "side")
+        assert resolve_repo_mod._dotgit_kind(wt) == "worktree"
+
+    def test_a_directory_with_no_dotgit_is_nothing(self, tmp_path):
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        assert resolve_repo_mod._dotgit_kind(plain) is None
+
+    def test_a_separate_git_dir_clone_counts_as_independent(self, tmp_path):
+        """``git clone --separate-git-dir`` leaves a ``.git`` FILE pointing at
+        neither ``worktrees/`` nor ``modules/``. Classifying by "is it a file"
+        instead of by where it points would read this as a submodule."""
+        work = tmp_path / "work"
+        work.mkdir()
+        gitdir = tmp_path / "elsewhere.git"
+        subprocess.run(
+            ["git", "init", "-q", "--separate-git-dir", str(gitdir), str(work)],
+            check=True, capture_output=True, text=True,
+        )
+        assert (work / ".git").is_file()
+        assert resolve_repo_mod._dotgit_kind(work) == "repo"


### PR DESCRIPTION
Closes #492.

> Stacked on #496 (`fix/493-index-file-head-advance`) so the CHANGELOG entries do not conflict. The base retargets to `main` automatically when that merges; review only the second commit.

## What was wrong

Fast path 1 matched on `source_root` containment alone, so a path inside an **independent git repository nested in an indexed parent** came back as the parent index with `indexed: true` and `match_path: source_root_containment`. Nothing in that branch consulted git identity. The caller was bound to a corpus built from a different checkout with a different history.

**Whether it looks wrong depends on something irrelevant to the defect** — your case 1 versus case 2 is the cleanest statement of it. Gitignored, the read fails and returns `absent`, correct for the corpus that was searched and indistinguishable from a normal empty result. Absorbed into the parent walk, the same wrong repository is returned and the read *succeeds* with `state: ok`. Both change here.

## The fix

A `.git` stat between the requested path and the matched `source_root` — the guard you proposed.

- **No subprocess.** Fast path 1 exists to avoid the `resolve_index_identity` walk that can hang (#303), so a correctness guard on it must not reintroduce a process spawn. A test monkeypatches `subprocess.run` to raise and asserts the ordinary containment path still resolves.
- **Classify by where `.git` points, not by whether it is a file.** `.git/worktrees/<name>` versus `.git/modules/<name>` is #372's distinction. **Submodules still resolve to the parent** (criterion 4), since their content is indexed into it. Linked worktrees are also left alone — fast path 2 already answers for them via `canonical_candidates`, and diverting them here would change #303's answer. `git clone --separate-git-dir` leaves a `.git` file pointing at neither and counts as independent; a file/directory test would have read it as a submodule.
- **A file outside the parent's corpus still resolves to the parent** (criterion 5). Gitignored, oversize or skipped is not the same condition as belonging to another repository.

## Verification

Your three-case reproduction against this branch:

```text
--- Case 1  nested repo gitignored by the parent ---
  repo returned          : local/nested-repo-d1a166da
  indexed / loadable     : False / None
  match_path             : not_indexed

--- Case 2  nested repo NOT gitignored (parent absorbs its files) ---
  repo returned          : local/nested-repo-d81734b0
  indexed / loadable     : False / None
  match_path             : not_indexed

--- Case 3  CONTROL: nested repo has its own index ---
  repo returned          : local/nested-repo-5f04d30e
  indexed / loadable     : True / True
  match_path             : exact_source_root
```

Both failing cases now identify the nested repository and report it unindexed, rather than returning a different one as indexed. Case 3 is unchanged.

`tests/test_resolve_repo_nested_repo_boundary.py`, 11 tests. **Seven red against `b85ef61`.** The remaining four are criteria 4–6 and pass on both sides by design. Submodules and linked worktrees are tested against real git layouts, not fabricated `.git` markers.

Suite: **7923 passed, 17 skipped, 0 failed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

