### PR TITLE
fix(security): thread repo= through both exclusion resolvers (#491)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 ## [Unreleased]
 
+### The two exclusion opt-outs never read the project config that documents them (#491, @rknighton)
+
+`security.py`'s `exclude_skip_directories` and `exclude_secret_patterns`
+resolvers called `_config.get()` without `repo=`, which skips the project
+overlay entirely. A project declaring either key in its own `.jcodemunch.jsonc`
+got **no effect, no warning, and a successful index** — the files were simply
+absent from the corpus.
+
+⚠⚠ **The comment above the skip list is what makes this a defect rather than a
+missing feature.** It says in as many words that these are ordinary English
+words that can name a real package, "which is why `exclude_skip_directories`
+exists — a project that ships an `archive/` module removes it there
+per-project." `is_secret_file`'s own docstring claims it applies "the project's
+`exclude_secret_patterns` overrides" one line above the global-only read. **Both
+were describing an intent the code did not implement.**
+
+⚠ **Nothing surfaces it.** `discovery_skip_counts` reports `skip_dir: 2` with no
+directory name and no rule name, and the pruned path goes to `logger.debug`. The
+user sets the documented opt-out, sees a green index, and gets a corpus quietly
+missing a module.
+
+The keys themselves were sound — the same values in **global** config worked
+throughout, which isolates the defect to the missing keyword rather than to the
+key, the walk or the parser. `repo=` is now threaded through
+`_excluded_skip_directories`, `get_skip_directories`, `get_skip_patterns` and
+`is_secret_file`, and through every local call site: the three
+`_build_skip_dirs_regex()` sites in `index_folder.py`, both `is_secret_file`
+sites there, the one in `index_file.py`, and the one in `security.py` itself.
+
+⚠ **`index_repo` is exempt BY NAME, not by omission.** A project's
+`.jcodemunch.jsonc` is found by walking up from a local path, and a GitHub tree
+has no local checkout — there is nothing to walk up to. Passing the owner/repo
+identifier would imply a lookup that cannot succeed. Global config still applies
+there, and the exemption is asserted by name in the test rather than left as a
+gap the ratchet happens not to cover.
+
+⚠ **The parameter is optional and defaults to today's behaviour**, so a caller
+with no path to offer resolves global-only exactly as before.
+
+⚠ **This is the fourth report of one bug shape**, after #300
+(`extra_ignore_patterns`), #187 (`languages`) and #304 (`summarizer_model`).
+**#301 audited about forty call sites for exactly this and lists
+`get_extra_ignore_patterns` as fixed while neither exclusion resolver appears in
+it**; v1.108.197 then fixed the three `max_*` resolvers and did not touch them
+either. So the ratchet is the point: `tests/test_security_exclusions_are_project_overridable.py`
+fails on any unthreaded read of either key and on any local call site that drops
+`repo=`. **A third audit would find the fifth instance; a test finds it on the
+commit that introduces it.**
+
+⚠ **Signature-only would have been a false green** — adding the parameter and
+leaving the callers bare changes nothing observable. The call-site check walks
+the AST rather than the signature for that reason.
+
+⚠ `tests/test_security_exclusions_are_project_overridable.py` (13), all red
+against `b85ef61`. Three of those are constraints rather than evidence: they are
+red only because `repo=` is not a parameter there, so each also asserts the
+no-argument form, which runs identically on both sides.
+
+
 ### `resolve_repo` no longer answers a repository question with a filesystem fact (#492, @rknighton)
 
 Fast path 1 matched on `source_root` containment alone, so a path inside an

--- a/src/jcodemunch_mcp/security.py
+++ b/src/jcodemunch_mcp/security.py
@@ -131,7 +131,7 @@ def _resolve_secret_overrides(excluded: list[str]) -> tuple[set[str], list[str]]
     return disabled, allow
 
 
-def is_secret_file(file_path: str) -> bool:
+def is_secret_file(file_path: str, repo: Optional[str] = None) -> bool:
     """Return True if a path is judged to be a secret/credential file.
 
     Thin boolean wrapper over :func:`secret_classifier.classify_secret_file`,
@@ -145,7 +145,11 @@ def is_secret_file(file_path: str) -> bool:
     flagged; an actual credential file (``.env``, ``*.pem``, ``secrets/db.yaml``,
     ``.aws/credentials``) is.
     """
-    excluded = list(_config.get("exclude_secret_patterns", []) or [])
+    # ⚠ `repo=` is what makes the docstring above true. Without it this reads
+    # global config only, and the project's documented opt-out never applies
+    # (#491). Its sibling `get_respect_cachedir_tag` has threaded it since
+    # v1.108.270; these two were left behind by the #301 audit.
+    excluded = list(_config.get("exclude_secret_patterns", [], repo=repo) or [])
     disabled, allow = _resolve_secret_overrides(excluded)
     return classify_secret_file(
         file_path,
@@ -255,23 +259,40 @@ def get_respect_cachedir_tag(repo: Optional[str] = None) -> bool:
     return False if value is False else True
 
 
-def _excluded_skip_directories() -> set[str]:
-    """Return the set of directory names the user wants to un-skip."""
-    raw = _config.get("exclude_skip_directories", [])
+def _excluded_skip_directories(repo: Optional[str] = None) -> set[str]:
+    """Return the set of directory names the user wants to un-skip.
+
+    ⚠ ``repo`` is not optional in practice, only in signature. The skip list
+    holds ordinary English words that CAN name a real package, which is the
+    whole reason ``exclude_skip_directories`` exists — and a project that ships
+    a ``fixtures/`` or ``archive/`` module declares that in its own
+    ``.jcodemunch.jsonc``, not in global config. Reading without ``repo`` skips
+    the project overlay entirely, so the documented per-project opt-out silently
+    did nothing (#491).
+    """
+    raw = _config.get("exclude_skip_directories", [], repo=repo)
     return set(raw) if isinstance(raw, list) else set()
 
 
-def get_skip_directories() -> list[str]:
-    """Return SKIP_DIRECTORIES with user-excluded entries removed."""
-    excluded = _excluded_skip_directories()
+def get_skip_directories(repo: Optional[str] = None) -> list[str]:
+    """Return SKIP_DIRECTORIES with user-excluded entries removed.
+
+    Pass ``repo`` (a filesystem path) to honour the project's
+    ``exclude_skip_directories``. Omitting it resolves global config only.
+    """
+    excluded = _excluded_skip_directories(repo=repo)
     if not excluded:
         return SKIP_DIRECTORIES
     return [d for d in SKIP_DIRECTORIES if d not in excluded]
 
 
-def get_skip_patterns() -> frozenset[str]:
-    """Return SKIP_PATTERNS with user-excluded directory entries removed."""
-    excluded = _excluded_skip_directories()
+def get_skip_patterns(repo: Optional[str] = None) -> frozenset[str]:
+    """Return SKIP_PATTERNS with user-excluded directory entries removed.
+
+    Pass ``repo`` (a filesystem path) to honour the project's
+    ``exclude_skip_directories``. Omitting it resolves global config only.
+    """
+    excluded = _excluded_skip_directories(repo=repo)
     if not excluded:
         return SKIP_PATTERNS
     excluded_with_slash = {d + "/" for d in excluded}
@@ -605,7 +626,7 @@ def should_exclude_file(
         return "outside_root"
 
     # Secret detection
-    if check_secrets and is_secret_file(rel_path):
+    if check_secrets and is_secret_file(rel_path, repo=str(root)):
         return "secret_file"
 
     # File size

--- a/src/jcodemunch_mcp/tools/index_file.py
+++ b/src/jcodemunch_mcp/tools/index_file.py
@@ -222,7 +222,7 @@ def index_file(
     # skip and then prune — the flip-flop in #351. is_secret_file already exempts
     # source modules (e.g. secret_redaction.py) after the same-issue fix, so this
     # only refuses actual credential files (.env, *.pem, secrets/db.yaml, …).
-    if is_secret_file(rel_path):
+    if is_secret_file(rel_path, repo=str(source_root)):
         return {
             "success": False,
             "error": (

--- a/src/jcodemunch_mcp/tools/index_folder.py
+++ b/src/jcodemunch_mcp/tools/index_folder.py
@@ -212,9 +212,13 @@ def _record_coverage(
         )
 
 
-def _build_skip_dirs_regex() -> re.Pattern:
-    """Build regex from config-filtered skip directories (called per-index)."""
-    dirs = get_skip_directories()
+def _build_skip_dirs_regex(repo: Optional[str] = None) -> re.Pattern:
+    """Build regex from config-filtered skip directories (called per-index).
+
+    ``repo`` is the walk root, threaded so a project's
+    ``exclude_skip_directories`` applies (#491).
+    """
+    dirs = get_skip_directories(repo=repo)
     return re.compile("^(" + "|".join(dirs) + ")$")
 
 
@@ -234,7 +238,7 @@ def _maybe_apply_adaptive(folder_path: str, result: dict) -> None:
 
 def get_filtered_files(path: str) -> Generator[str, None, None]:
     """Generator function to filter directories and files"""
-    skip_dirs_regex = _build_skip_dirs_regex()
+    skip_dirs_regex = _build_skip_dirs_regex(repo=path)
     # Use os.walk with followlinks=False to avoid infinite loops caused by
     # NTFS junctions or symlinks pointing back to ancestor directories.
     for dirpath, dirnames, filenames in os.walk(path, followlinks=False):
@@ -576,7 +580,7 @@ def _should_index_file(
         return False, "extra_ignore", rel_path, None
 
     # 10. Secret-file detection
-    if is_secret_file(rel_path):
+    if is_secret_file(rel_path, repo=str(cfg.root)):
         return False, "secret", rel_path, f"Skipped secret file: {rel_path}"
 
     # 11. Extension filter
@@ -1102,7 +1106,7 @@ def resolve_explicit_paths(
         # The explicit-paths branch must apply the same secret filter the walk
         # does; it intentionally still opts past gitignore/skip-dir so callers
         # can name generated/ignored source files on purpose.
-        if is_secret_file(_rel):
+        if is_secret_file(_rel, repo=str(walk_root)):
             warnings.append(f"Skipped secret file: {_rel}")
             skip_counts["secret"] = skip_counts.get("secret", 0) + 1
             continue
@@ -1241,7 +1245,7 @@ def discover_local_files(
         respect_cachedir_tag=respect_cachedir_tag,
     )
 
-    skip_dirs_regex = _build_skip_dirs_regex()
+    skip_dirs_regex = _build_skip_dirs_regex(repo=str(root))
     for dirpath, dirnames, filenames in os.walk(str(root), followlinks=False):
         dpath = Path(dirpath)
         # Prune directories that should always be skipped before descending.
@@ -1740,7 +1744,9 @@ def index_folder(
                 max_size=_fast_max_size,
                 extra_spec=_fast_extra_spec,
                 forced_paths=_fast_forced_paths(),
-                skip_dirs_regex=_build_skip_dirs_regex(),
+                skip_dirs_regex=_build_skip_dirs_regex(
+                    repo=str(Path(walk_root).resolve())
+                ),
                 check_binary=False,
                 check_filename=True,
                 respect_cachedir_tag=get_respect_cachedir_tag(

--- a/src/jcodemunch_mcp/tools/index_repo.py
+++ b/src/jcodemunch_mcp/tools/index_repo.py
@@ -159,6 +159,10 @@ async def fetch_repo_tree(owner: str, repo: str, token: Optional[str] = None) ->
 def should_skip_file(path: str) -> bool:
     """Check if file should be skipped based on path patterns."""
     normalized = path.replace("\\", "/")
+    # ⚠ No `repo=` here, deliberately (#491). A project's `.jcodemunch.jsonc`
+    # is found by walking up from a LOCAL path, and a GitHub tree has none —
+    # there is no local checkout to read it from. Passing the owner/repo id
+    # would imply a lookup that cannot succeed. Global config still applies.
     for pattern in get_skip_patterns():
         if pattern.endswith("/"):
             # Directory pattern: match only complete path segments to avoid
@@ -253,7 +257,7 @@ def discover_source_files(
             continue
 
         # Secret detection
-        if is_secret_file(path):
+        if is_secret_file(path):  # no local project config; see above
             continue
 
         # Binary extension check

--- a/tests/test_security_exclusions_are_project_overridable.py
+++ b/tests/test_security_exclusions_are_project_overridable.py
@@ -1,0 +1,208 @@
+"""#491: the two exclusion resolvers read global config only.
+
+``security.py``'s ``exclude_skip_directories`` and ``exclude_secret_patterns``
+called ``_config.get()`` without ``repo=``, which skips the project overlay
+entirely. A project declaring either key in its own ``.jcodemunch.jsonc`` got no
+effect, no warning and a successful index - the files were simply absent.
+
+The keys themselves were sound: the same values in global config worked. That is
+what isolates the defect to the missing keyword rather than to the key, the walk
+or the parser.
+
+Antecedents: #300, #187 and #304 are this shape on other keys; #301 audited about
+40 call sites and lists ``get_extra_ignore_patterns`` as fixed without either of
+these two; v1.108.197 fixed the three ``max_*`` resolvers and did not touch them.
+"""
+
+import ast
+import json
+import pathlib
+import re
+import subprocess
+
+import pytest
+
+from jcodemunch_mcp import config as cfg
+from jcodemunch_mcp import security as sec
+from jcodemunch_mcp.tools.get_file_content import get_file_content
+from jcodemunch_mcp.tools.index_folder import index_folder
+
+FIXTURE_REL = "tests/fixtures/fake_server.py"
+
+
+@pytest.fixture
+def project(tmp_path):
+    """A project shipping a real ``tests/fixtures/`` module, plus a store."""
+    proj = tmp_path / "proj"
+    (proj / "tests" / "fixtures").mkdir(parents=True)
+    store = tmp_path / "store"
+    store.mkdir()
+    (proj / "main.py").write_text("def main():\n    return 1\n")
+    (proj / FIXTURE_REL).write_text(
+        "class FakeServer:\n    def serve(self):\n        return 3\n"
+    )
+    for args in (
+        ("init", "-q"),
+        ("config", "user.email", "repro@example.invalid"),
+        ("config", "user.name", "repro"),
+        ("add", "-A"),
+        ("commit", "-q", "-m", "A"),
+    ):
+        subprocess.run(["git", *args], cwd=str(proj), check=True, capture_output=True)
+
+    class Project:
+        path = proj
+        store_path = str(store)
+
+        @staticmethod
+        def declare(**keys):
+            (proj / ".jcodemunch.jsonc").write_text(json.dumps(keys, indent=2))
+            cfg.load_project_config(str(proj))
+
+        @staticmethod
+        def index():
+            return index_folder(
+                path=str(proj), identity_mode="local", use_ai_summaries=False,
+                storage_path=str(store),
+            )
+
+    return Project
+
+
+class TestTheProjectOptOutApplies:
+    """The two acceptance criteria that describe the reported failure."""
+
+    def test_exclude_skip_directories_un_skips_the_directory(self, project):
+        project.declare(exclude_skip_directories=["fixtures"])
+
+        result = project.index()
+        got = get_file_content(
+            repo=result["repo"], file_path=FIXTURE_REL,
+            storage_path=project.store_path,
+        )
+
+        assert got.get("content"), (
+            "the project's documented opt-out did not un-skip tests/fixtures/; "
+            f"skip counts were {result.get('discovery_skip_counts')}"
+        )
+
+    def test_exclude_secret_patterns_applies_from_project_config(self, project):
+        project.declare(exclude_secret_patterns=["tests/fixtures/*"])
+
+        assert sec.is_secret_file(
+            "tests/fixtures/credentials.json", repo=str(project.path)
+        ) is False
+
+    def test_the_same_path_is_still_secret_without_the_opt_out(self, project):
+        """Non-vacuity for the test above: the path must be judged secret when
+        nothing excludes it, or the assertion proves nothing about the key."""
+        assert sec.is_secret_file(
+            "tests/fixtures/credentials.json", repo=str(project.path)
+        ) is True
+
+
+class TestWhatMustNotChange:
+    """Constraints on the fix.
+
+    ⚠ Unlike the usual both-sides controls, these are red against the pre-fix
+    tree too - but only because ``repo=`` is not a parameter there, so they
+    raise ``TypeError`` before asserting anything. They are constraints, not
+    evidence of the defect. Each therefore also asserts the no-argument form,
+    which runs identically on both sides and is the half that carries meaning.
+    """
+
+    def test_the_default_skip_list_is_unchanged(self, project):
+        """With neither key set anywhere, `fixtures` stays skipped."""
+        assert "fixtures" in sec.get_skip_directories()
+        assert "fixtures/" in sec.get_skip_patterns()
+        assert "fixtures" in sec.get_skip_directories(repo=str(project.path))
+        assert "fixtures/" in sec.get_skip_patterns(repo=str(project.path))
+
+    def test_a_global_value_still_applies(self, project, tmp_path):
+        """The path the key SHIPPED with (#209) must not regress. A fix that
+        moved the read from global to project would satisfy the class above and
+        break every existing user."""
+        store = tmp_path / "gstore"
+        store.mkdir()
+        (store / "config.jsonc").write_text(
+            json.dumps({"exclude_skip_directories": ["fixtures"]}, indent=2)
+        )
+        cfg.load_config(storage_path=str(store))
+
+        assert "fixtures" not in sec.get_skip_directories()
+        assert "fixtures" not in sec.get_skip_directories(repo=str(project.path))
+
+    def test_omitting_repo_still_resolves_global_only(self, project):
+        """The parameter is optional and defaults to today's behaviour, so a
+        caller with no path to offer is not broken."""
+        project.declare(exclude_skip_directories=["fixtures"])
+        assert "fixtures" in sec.get_skip_directories()
+        assert "fixtures" not in sec.get_skip_directories(repo=str(project.path))
+
+
+class TestEveryReadIsThreaded:
+    """#301 enumerated ~40 call sites for this bug shape and these two were
+    missed. A ratchet is cheaper than a second audit."""
+
+    @pytest.mark.parametrize(
+        "key", ["exclude_skip_directories", "exclude_secret_patterns"]
+    )
+    def test_no_unthreaded_read_of_either_key(self, key):
+        root = pathlib.Path(sec.__file__).resolve().parent
+        pattern = re.compile(
+            r"_config\.get\(\s*[\"']" + key + r"[\"'][^)]*\)", re.DOTALL
+        )
+        offenders = []
+        for path in sorted(root.rglob("*.py")):
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for match in pattern.finditer(text):
+                if "repo=" not in match.group(0):
+                    line = text[: match.start()].count("\n") + 1
+                    offenders.append(f"{path.relative_to(root)}:{line}")
+        assert not offenders, (
+            f"{key} read without repo=, so the project overlay is skipped: "
+            + ", ".join(offenders)
+        )
+
+    @pytest.mark.parametrize(
+        "func", ["is_secret_file", "get_skip_directories", "get_skip_patterns",
+                 "_excluded_skip_directories"],
+    )
+    def test_the_resolver_accepts_repo(self, func):
+        import inspect
+
+        assert "repo" in inspect.signature(getattr(sec, func)).parameters, (
+            f"security.{func} cannot honour a project value it is never given"
+        )
+
+    def test_every_local_walk_call_site_passes_repo(self):
+        """⚠ Signature-only would be a false green: adding the parameter and
+        leaving the callers bare changes nothing observable.
+
+        ``index_repo`` is exempt BY NAME rather than by omission - a GitHub tree
+        has no local checkout, so there is no ``.jcodemunch.jsonc`` to walk up
+        to and no path to pass.
+        """
+        root = pathlib.Path(sec.__file__).resolve().parent / "tools"
+        watched = {"is_secret_file", "get_skip_directories", "get_skip_patterns",
+                   "_build_skip_dirs_regex"}
+        exempt = {"index_repo.py"}
+        offenders = []
+        for path in sorted(root.rglob("*.py")):
+            if path.name in exempt:
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                name = getattr(node.func, "id", None) or getattr(
+                    node.func, "attr", None
+                )
+                if name not in watched:
+                    continue
+                if not any(kw.arg == "repo" for kw in node.keywords):
+                    offenders.append(f"{path.relative_to(root)}:{node.lineno} {name}")
+        assert not offenders, (
+            "these call a project-overridable resolver without repo=: "
+            + ", ".join(offenders)
+        )


### PR DESCRIPTION
Closes #491.

## What was wrong

`security.py`'s `exclude_skip_directories` and `exclude_secret_patterns` resolvers called `_config.get()` without `repo=`, which skips the project overlay entirely. A project declaring either key in its own `.jcodemunch.jsonc` got no effect, no warning, and a successful index.

**The comments are what make this a defect rather than a missing feature.** The note above the skip list says these are ordinary English words that can name a real package, "which is why `exclude_skip_directories` exists — a project that ships an `archive/` module removes it there per-project." `is_secret_file`'s docstring claims it applies "the project's `exclude_secret_patterns` overrides" one line above the global-only read. Both described an intent the code did not implement.

And nothing surfaces it: `discovery_skip_counts` reports `skip_dir: 2` with no directory name and no rule name, and the pruned path goes to `logger.debug`.

Your global-config control is what makes this a one-line diagnosis rather than an investigation — the key, the walk and the parser are all exonerated by it.

## The fix

`repo=` threaded through `_excluded_skip_directories`, `get_skip_directories`, `get_skip_patterns` and `is_secret_file`, and through every local call site: the three `_build_skip_dirs_regex()` sites in `index_folder.py`, both `is_secret_file` sites there, the one in `index_file.py`, and the one inside `security.py` itself. The parameter is optional and defaults to today's behaviour.

**One deviation from your acceptance criteria, stated plainly.** Criterion 5 lists the `get_skip_patterns()` site in `index_repo.py:162`. It does not pass `repo=`, deliberately: a project config is found by walking up from a *local* path, and a GitHub tree has no local checkout to walk up from. Passing the owner/repo identifier would imply a lookup that cannot succeed. Global config still applies there, and `index_repo.py` is exempted **by name** in the ratchet rather than left as a gap it happens not to cover. Say the word if you read that differently.

## Verification

Your reproduction against this branch — the end-to-end line is the one that moved:

```text
discovery_skip_counts.skip_dir        -> 1     (was 2)
tests/fixtures/fake_server.py readable-> True  (was False)
```

The bare `_excluded_skip_directories()` / `get_skip_directories()` lines in your harness still print the old values, correctly: those are no-argument calls, which resolve global-only by design and are now covered by a test.

`tests/test_security_exclusions_are_project_overridable.py`, 13 tests, **all red against `b85ef61`**. Three of those are constraints rather than evidence — they are red only because `repo=` is not a parameter there, so each also asserts the no-argument form, which runs identically on both sides.

**The ratchet is the point.** This is the fourth report of one shape after #300, #187 and #304, and #301 audited ~40 call sites for exactly it while listing `get_extra_ignore_patterns` as fixed and naming neither of these two. v1.108.197 then fixed the three `max_*` resolvers and left them as well. A fifth audit would find a fifth instance; the test fails on the commit that introduces one. It walks the AST rather than the signature, because adding the parameter and leaving callers bare changes nothing observable.

Suite: **7936 passed, 17 skipped, 0 failed**, ruff clean. Total 7953 against main's 7940 is exactly the 13 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
