### PR TITLE
fix(embed): detect a model change instead of mixing vector widths (#500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,73 @@
 
 ## [Unreleased]
 
+### A model change left the embedding store holding two vector widths (#500)
+
+`embed_repo` carried this comment for four releases:
+
+```python
+# Detect dimension mismatch — if the stored model differs, force a rebuild.
+stored_dim = emb_store.get_dimension()
+```
+
+**It implemented no such detection.** `stored_dim` was read only to seed `dim`,
+nothing compared the stored model against the active one, and `set_dimension`
+fired exclusively when `dim is None` — a first-ever embed. Only `task_type`
+forced a rebuild. So changing the embedding model wrote new-width vectors
+alongside the old ones behind a meta row still naming the first.
+
+⚠⚠ **The consequence is a recall failure that reads as a finding, and it
+compounds.** `EmbeddingMatrix` infers its dimension from the FIRST row and drops
+every row that disagrees. The inferred width follows the majority of
+pre-existing rows, so **every symbol embedded after the change is silently
+excluded from semantic search, and the gap grows with every new file.** Measured
+on a 7-symbol repo: store `{384: 6, 768: 1}`, meta reporting 384, one symbol
+excluded — and nothing anywhere said so.
+
+⚠ **No unusual configuration reaches it.** Installing `[local-embed]` on an
+install that used `embed_model`, uninstalling it, deleting the ONNX model
+directory, changing `embed_model`, or rotating a cloud key with a different
+`*_EMBED_MODEL` all swap the active provider on an existing store.
+
+⚠⚠ **The read path is NOT the defect and was left alone.** Excluding a
+mismatched row reaches the same answer `_cosine_similarity` gave before the
+matrix existed — `embedding_matrix._build` says so in a comment and is right.
+The defect is that a mixed store could come into existence at all. **Fixing the
+consumer would have hidden the producer.**
+
+`EmbeddingStore.get_model()` is added and compared against the active model; a
+difference forces the rebuild, and the result carries `model_changed_from` +
+`rebuild_reason` rather than performing an expensive re-embed silently.
+
+⚠ **Unknown is not a change.** A store written before the model name was
+persisted has no row, and forcing a rebuild on it would bill every existing user
+a full re-embed for a model that may be identical.
+
+⚠ **`stored_dim` is now cleared inside the `force` branch**, which also repairs
+the pre-existing `task_type` rebuild path: it cleared the store and then left
+`dim` seeded from the old value, so the `dim is None` gate never re-fired and
+the meta kept advertising the previous dimension and model against freshly
+written vectors.
+
+⚠ **`skipped_dim_mismatch` was computed, stored on the object and read NOWHERE**
+— `grep -rn skipped_dim_mismatch src/` returned only the three lines defining
+it. Stores already mixed stay mixed until the next model change or a forced
+re-embed, so `search_symbols` now reports `_meta.semantic_partial` and grades
+the semantic channel `partial`. **A count that exists and is discarded is the
+same defect as not counting.**
+
+⚠ **`evidence/capability.py` has called `get_model()` since v1.108.221 behind a
+`type: ignore` and a bare `except`**, so the capability certificate reported
+`model: "unknown"` for every repository. It resolves now — found by adding the
+method, not by reading the call site.
+
+⚠ `tests/test_embedding_model_change.py` (9), 8 red against the pre-fix tree.
+Two of those eight are constraints rather than evidence, red only because
+`get_model()` does not exist there; `test_re_embedding_the_same_model_does_not_rebuild`
+passes on both sides and is the control against turning the common path into a
+full re-embed on every call.
+
+
 ### `resolve_repo` no longer answers a repository question with a filesystem fact (#492, @rknighton)
 
 Fast path 1 matched on `source_root` containment alone, so a path inside an

--- a/src/jcodemunch_mcp/storage/embedding_store.py
+++ b/src/jcodemunch_mcp/storage/embedding_store.py
@@ -100,6 +100,31 @@ class EmbeddingStore:
         finally:
             conn.close()
 
+    def get_model(self) -> Optional[str]:
+        """Return the model name these embeddings were built with, or None.
+
+        ⚠ None means UNKNOWN, never "a different model". Stores written before
+        this key was populated have no row, and `set_dimension` only writes it
+        when given a non-empty name. Callers comparing models must treat None
+        as "cannot tell" and NOT force a rebuild on it (#500).
+
+        ⚠ `evidence/capability.py` has called this since v1.108.221 behind a
+        `type: ignore` and a bare except, so the capability certificate reported
+        `model: "unknown"` for every repo. It resolves now.
+        """
+        try:
+            conn = self._connect()
+            try:
+                row = conn.execute(
+                    "SELECT value FROM meta WHERE key = ?", (_EMBED_MODEL_KEY,)
+                ).fetchone()
+                return str(row[0]) if row and row[0] else None
+            finally:
+                conn.close()
+        except Exception:
+            logger.debug("EmbeddingStore.get_model failed", exc_info=True)
+            return None
+
     def get_task_type(self) -> Optional[str]:
         """Return stored embedding task type, or None if not set."""
         try:

--- a/src/jcodemunch_mcp/tools/embed_repo.py
+++ b/src/jcodemunch_mcp/tools/embed_repo.py
@@ -315,8 +315,27 @@ def embed_repo(
     db_path = store._sqlite._db_path(owner, name)
     emb_store = EmbeddingStore(db_path)
 
-    # Detect dimension mismatch — if the stored model differs, force a rebuild.
+    # Detect a model change and force a rebuild.
+    #
+    # ⚠⚠ This comment described the behaviour for four releases and the code did
+    # not implement it (#500). `stored_dim` was read and only ever used to seed
+    # `dim`, nothing compared the stored model against the active one, and a
+    # store therefore accumulated vectors of two widths behind a meta row that
+    # still named the first. `EmbeddingMatrix` then infers its dimension from
+    # the FIRST row and drops every row that disagrees, so the symbols embedded
+    # after the change stopped being searchable — silently, and cumulatively.
     stored_dim = emb_store.get_dimension()
+    stored_model = emb_store.get_model()
+    # ⚠ Unknown is NOT a change. A store written before `embed_model` was
+    # persisted has no name, and forcing a re-embed on that would bill every
+    # existing user a full rebuild for a model that may well be identical.
+    model_changed = bool(stored_model) and bool(model) and stored_model != model
+    if not force and model_changed and emb_store.count() > 0:
+        logger.info(
+            "embed_repo: model changed (%r → %r); forcing re-embed",
+            stored_model, model,
+        )
+        force = True
 
     # If the task type changed (e.g. Gemini task-awareness toggled), existing
     # embeddings were built with a different task type and must be regenerated.
@@ -332,6 +351,12 @@ def embed_repo(
     if force:
         emb_store.clear()
         symbols_to_embed = list(index.symbols)
+        # ⚠ The meta row must be re-derived with the vectors. `dim` is seeded
+        # from `stored_dim` below, so leaving it set means the `dim is None`
+        # gate never re-fires and the store keeps advertising the OLD dimension
+        # and model against freshly written vectors. This also repairs the
+        # pre-existing `task_type` force path, which had the same hole.
+        stored_dim = None
     else:
         existing_ids = emb_store.get_all_ids()
         symbols_to_embed = [s for s in index.symbols if s["id"] not in existing_ids]
@@ -389,4 +414,9 @@ def embed_repo(
     }
     if doc_task_type:
         result["task_type"] = doc_task_type
+    if model_changed:
+        # Disclosed, not silent: a forced re-embed is expensive on a large
+        # corpus and the caller did not ask for one.
+        result["model_changed_from"] = stored_model
+        result["rebuild_reason"] = "embedding_model_changed"
     return result

--- a/src/jcodemunch_mcp/tools/search_symbols.py
+++ b/src/jcodemunch_mcp/tools/search_symbols.py
@@ -1795,6 +1795,19 @@ def _search_symbols_semantic(
     # The semantic channel really ran, and the verdict should say so rather than
     # inherit the `off` default from `semantic_requested=False` above.
     meta["verdict"]["channels"]["semantic"] = "ok"
+    # #500: a store written across a model change holds two vector widths, and
+    # the matrix silently excludes whichever width is not the first row's. The
+    # producer is fixed, but stores already in that state stay that way until
+    # the next model change or a forced re-embed — so say so, or a partial
+    # corpus reads as a complete one and short results read as a finding.
+    _skipped_dim = getattr(matrix, "skipped_dim_mismatch", 0) if matrix else 0
+    if _skipped_dim:
+        meta["semantic_partial"] = {
+            "symbols_excluded": _skipped_dim,
+            "reason": "embedding_dimension_mismatch",
+            "remedy": "embed_repo(force=True) rebuilds the store at one width",
+        }
+        meta["verdict"]["channels"]["semantic"] = "partial"
     negative_evidence = _vres["negative_evidence"]
     if negative_evidence is not None:
         result["negative_evidence"] = negative_evidence

--- a/tests/test_embedding_model_change.py
+++ b/tests/test_embedding_model_change.py
@@ -1,0 +1,219 @@
+"""#500: a model change must not leave a store holding two vector widths.
+
+`embed_repo` carried the comment "Detect dimension mismatch - if the stored
+model differs, force a rebuild" while implementing no such detection.
+`stored_dim` was read only to seed `dim`, nothing compared the stored model
+against the active one, and `set_dimension` fired exclusively on a first-ever
+embed. A store therefore accumulated vectors of two widths behind a meta row
+still naming the first.
+
+`EmbeddingMatrix` infers its dimension from the FIRST row and drops every row
+that disagrees, so symbols embedded after the change stopped being searchable -
+silently, and cumulatively, since the gap grows with every new file.
+
+⚠ The read path is NOT the defect. Excluding a mismatched row reaches the same
+answer `_cosine_similarity` gave before the matrix existed. The defect is that a
+mixed store could come into existence, plus that the exclusion count was
+computed and thrown away.
+"""
+
+import pytest
+
+from jcodemunch_mcp.storage import IndexStore
+from jcodemunch_mcp.storage import embedding_matrix as em
+from jcodemunch_mcp.storage.embedding_store import EmbeddingStore
+from jcodemunch_mcp.tools import embed_repo as er
+from jcodemunch_mcp.tools.index_folder import index_folder
+
+
+def _fixed_width(width, value=0.1):
+    def _embed(texts, provider, model, task_type=None):
+        return [[value] * width for _ in texts]
+    return _embed
+
+
+@pytest.fixture
+def embedded(tmp_path, monkeypatch):
+    """An indexed repo plus helpers to embed it under a named fake provider."""
+    src = tmp_path / "src"
+    src.mkdir()
+    store_dir = tmp_path / "store"
+    store_dir.mkdir()
+    for i in range(5):
+        (src / f"m{i}.py").write_text(f"def handler_{i}():\n    return {i}\n")
+    result = index_folder(
+        str(src), use_ai_summaries=False, storage_path=str(store_dir),
+    )
+    assert result["success"] is True
+    repo_id = result["repo"]
+    owner, name = repo_id.split("/", 1)
+    index_store = IndexStore(base_path=str(store_dir))
+    db_path = index_store._sqlite._db_path(owner, name)
+
+    class Harness:
+        repo = repo_id
+        path = src
+        store_path = str(store_dir)
+        db = db_path
+
+        @staticmethod
+        def embed(model, width, **kwargs):
+            monkeypatch.setattr(
+                er, "_detect_provider", lambda: ("fake_provider", model)
+            )
+            monkeypatch.setattr(er, "embed_texts", _fixed_width(width))
+            return er.embed_repo(
+                repo=repo_id, storage_path=str(store_dir), **kwargs
+            )
+
+        @staticmethod
+        def store():
+            return EmbeddingStore(db_path)
+
+        @staticmethod
+        def widths():
+            counts = {}
+            for _sid, blob in EmbeddingStore(db_path).iter_raw():
+                w = len(blob) // 4
+                counts[w] = counts.get(w, 0) + 1
+            return counts
+
+        @staticmethod
+        def add_symbol(n):
+            (src / f"extra{n}.py").write_text(f"def extra_{n}():\n    return {n}\n")
+            index_folder(
+                str(src), use_ai_summaries=False, storage_path=str(store_dir),
+            )
+
+    return Harness
+
+
+class TestAModelChangeForcesOneWidth:
+    """The reported defect."""
+
+    def test_the_store_holds_exactly_one_vector_width(self, embedded):
+        embedded.embed("model-a", 384)
+        assert embedded.widths() == {384: 5}
+
+        embedded.add_symbol(1)
+        embedded.embed("model-b", 768)
+
+        widths = embedded.widths()
+        assert len(widths) == 1, (
+            f"store holds two vector widths after a model change: {widths}"
+        )
+        assert 768 in widths
+
+    def test_the_meta_row_agrees_with_the_vectors(self, embedded):
+        embedded.embed("model-a", 384)
+        embedded.add_symbol(1)
+        embedded.embed("model-b", 768)
+
+        store = embedded.store()
+        assert store.get_dimension() == 768
+        assert store.get_model() == "model-b"
+
+    def test_the_rebuild_is_disclosed_not_silent(self, embedded):
+        """A forced re-embed is expensive on a large corpus and the caller did
+        not ask for one."""
+        embedded.embed("model-a", 384)
+        embedded.add_symbol(1)
+        result = embedded.embed("model-b", 768)
+
+        assert result.get("model_changed_from") == "model-a"
+        assert result.get("rebuild_reason") == "embedding_model_changed"
+
+    def test_every_symbol_survives_into_the_matrix(self, embedded):
+        embedded.embed("model-a", 384)
+        embedded.add_symbol(1)
+        embedded.embed("model-b", 768)
+
+        matrix = em.get_matrix(str(embedded.db))
+        assert matrix is not None
+        assert matrix.skipped_dim_mismatch == 0
+        assert len(matrix.ids) == embedded.store().count()
+
+
+class TestWhatMustNotChange:
+    """The two criteria that constrain the fix, plus the disclosure boundary."""
+
+    def test_re_embedding_the_same_model_does_not_rebuild(self, embedded):
+        """Otherwise the common path becomes a full re-embed on every call."""
+        embedded.embed("model-a", 384)
+        embedded.add_symbol(1)
+        result = embedded.embed("model-a", 384)
+
+        assert "model_changed_from" not in result
+        assert result.get("rebuild_reason") is None
+
+    def test_an_unknown_stored_model_is_not_treated_as_a_change(self, embedded):
+        """⚠ Unknown is not a change. A store written before the model name was
+        persisted has no row, and forcing a rebuild on that would bill every
+        existing user a full re-embed for a model that may be identical."""
+        embedded.embed("model-a", 384)
+        store = embedded.store()
+        conn = store._connect()
+        try:
+            conn.execute("DELETE FROM meta WHERE key = 'embed_model'")
+            conn.commit()
+        finally:
+            conn.close()
+        assert embedded.store().get_model() is None
+
+        embedded.add_symbol(1)
+        result = embedded.embed("model-b", 384)
+
+        assert "model_changed_from" not in result, (
+            "an absent stored model name was read as a mismatch"
+        )
+
+    def test_a_first_ever_embed_records_dimension_and_model(self, embedded):
+        result = embedded.embed("model-a", 384)
+        store = embedded.store()
+
+        assert store.get_dimension() == 384
+        assert store.get_model() == "model-a"
+        assert "model_changed_from" not in result
+
+
+class TestTheCountIsNoLongerThrownAway:
+    """`skipped_dim_mismatch` was computed, stored on the object, and read
+    nowhere. The producer is fixed, but stores already mixed stay mixed until
+    the next model change or a forced re-embed."""
+
+    def test_get_model_exists_and_is_readable(self, embedded):
+        """⚠ `evidence/capability.py` has called `get_model()` behind a
+        `type: ignore` and a bare except since v1.108.221, so the capability
+        certificate reported `model: "unknown"` for every repo."""
+        embedded.embed("model-a", 384)
+        assert embedded.store().get_model() == "model-a"
+
+    def test_a_pre_existing_mixed_store_is_disclosed_by_search(self, embedded):
+        """Build the mixed state directly, since the producer can no longer
+        create it, and assert a search says so rather than returning a short
+        result that reads as a finding."""
+        from jcodemunch_mcp.tools.search_symbols import search_symbols
+
+        embedded.embed("model-a", 384)
+        store = embedded.store()
+        ids = [sid for sid, _ in store.iter_raw()]
+        assert len(ids) >= 2
+        # One row at the wrong width: exactly what a pre-fix model change left.
+        store.set_many({ids[-1]: [0.2] * 768})
+        em.invalidate(str(embedded.db)) if hasattr(em, "invalidate") else None
+
+        response = search_symbols(
+            repo=embedded.repo, query="handler", semantic=True,
+            storage_path=embedded.store_path, max_results=10,
+        )
+        meta = response.get("_meta") or {}
+        partial = meta.get("semantic_partial")
+        assert partial, (
+            "a store excluding rows from semantic search reported nothing; "
+            f"_meta was {sorted(meta)}"
+        )
+        assert partial["symbols_excluded"] >= 1
+        assert partial["reason"] == "embedding_dimension_mismatch"
+        assert (meta.get("verdict") or {}).get("channels", {}).get(
+            "semantic"
+        ) == "partial"


### PR DESCRIPTION
Closes #500.

## What was wrong

`embed_repo` carried this comment for four releases and implemented no such detection:

```python
# Detect dimension mismatch — if the stored model differs, force a rebuild.
stored_dim = emb_store.get_dimension()
```

`stored_dim` was read only to seed `dim`, nothing compared the stored model against the active one, and `set_dimension` fired exclusively when `dim is None` — a first-ever embed. Only `task_type` forced a rebuild.

**The consequence compounds.** `EmbeddingMatrix` infers its dimension from the *first* row and drops every row that disagrees. The inferred width follows the majority of pre-existing rows, so every symbol embedded after a model change is silently excluded from semantic search and the gap grows with every new file. Measured on a 7-symbol repo: store `{384: 6, 768: 1}`, meta reporting 384, one symbol excluded, nothing anywhere saying so.

No unusual configuration reaches it — installing `[local-embed]` on an install that used `embed_model`, uninstalling it, deleting the ONNX model directory, changing `embed_model`, or rotating a cloud key with a different `*_EMBED_MODEL` all swap the active provider on an existing store.

## The fix

`EmbeddingStore.get_model()` is added and compared against the active model. A difference forces the rebuild, and the result carries `model_changed_from` + `rebuild_reason` rather than performing an expensive re-embed silently.

- **Unknown is not a change.** A store written before the model name was persisted has no row; forcing a rebuild on it would bill every existing user a full re-embed for a model that may be identical.
- **`stored_dim` is cleared inside the `force` branch**, which also repairs the pre-existing `task_type` path — it cleared the store and left `dim` seeded from the old value, so the `dim is None` gate never re-fired and the meta kept advertising the previous dimension against fresh vectors.

**The read path is deliberately unchanged.** Excluding a mismatched row reaches the same answer `_cosine_similarity` gave before the matrix existed; `embedding_matrix._build` says so in a comment and is right. The defect is that a mixed store could come into existence. Fixing the consumer would have hidden the producer.

Two things found while fixing it, both disclosed rather than quietly repaired:

- **`skipped_dim_mismatch` was computed, stored on the object, and read nowhere** — `grep -rn skipped_dim_mismatch src/` returned only the three lines defining it. Stores already mixed stay mixed until the next model change or a forced re-embed, so `search_symbols` now reports `_meta.semantic_partial` and grades the semantic channel `partial`. A count that exists and is discarded is the same defect as not counting.
- **`evidence/capability.py` has called `get_model()` since v1.108.221** behind a `type: ignore` and a bare `except`, so the capability certificate has reported `model: "unknown"` for every repository. It resolves now — found by adding the method, not by reading the call site.

## Verification

The repro from the issue, against this branch:

```text
2. embed with model-b-768 : rows in store = 7
   stored meta dimension  : 768
   actual row widths      : {768: 7}
3. matrix dim inferred    : 768
   rows in matrix         : 7
   skipped_dim_mismatch   : 0
```

Was `{384: 6, 768: 1}`, meta 384, 1 excluded.

`tests/test_embedding_model_change.py`, 9 tests, **8 red against the pre-fix tree**. Two of those eight are constraints rather than evidence — red only because `get_model()` does not exist there. `test_re_embedding_the_same_model_does_not_rebuild` passes on both sides and is the control against turning the common path into a full re-embed on every call.

Suite: **7932 passed, 17 skipped, 0 failed**, ruff clean. Total 7949 against main's 7940 is exactly the 9 new tests.

## Relationship to #488

This is the blocker I'd want cleared before #488 changes provider precedence: making explicit configuration outrank the zero-config ONNX default makes provider changes *more* frequent, and until now each one silently and permanently degraded the index. With this in place, a precedence change becomes a detected, disclosed re-embed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
