### PR TITLE
fix(embeddings): one source for provider advice, bundled encoder first (#489)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 ## [Unreleased]
 
+### The tool schema advertised three paid-ish providers and hid the free one (#489, @pnm-jgb)
+
+Five places tell a caller how to obtain an embedding provider. Exactly one of
+them named the bundled zero-config ONNX encoder — the provider that is
+**priority 0 in `_detect_provider`** and the project's recommended setup. The
+other four listed only `JCODEMUNCH_EMBED_MODEL`, `GOOGLE_API_KEY` and
+`OPENAI_API_KEY`, two of which bill per call.
+
+⚠⚠ **The `semantic` parameter description is the expensive one, and the harm is
+invisible from outside.** It is not documentation a human browses; it is the
+tool schema, and it is the only information an agent has when deciding whether
+to set `semantic: true`. An agent reading "requires one of three env vars"
+against an environment with none of them set correctly concludes semantic search
+is unavailable and never attempts it — **on a machine where it works, for free,
+right now.** There is no error, no warning and no degraded result to notice. The
+capability simply goes unused. It is the inverse of a false positive: the tool
+under-reports its own function.
+
+All five now derive from `embeddings/advice.py`. `_LOCAL_FIRST` leads both
+strings, mirroring `_detect_provider`'s priority order so the advice and the
+resolver cannot disagree about which provider wins.
+
+⚠⚠ **The report named three sites; the ratchet found FIVE.** Two more were only
+visible once a test asserted the property rather than the instances: the
+`embed_repo` TOOL DESCRIPTION (`server.py`) carried the same omission and is
+equally agent-facing, and `retrieval/embed_drift.py` had its own copy that named
+the bundled encoder **last**, behind the two that cost money. A fifth, the
+`semantic` docstring in `search_symbols`, is developer-facing and now points at
+the constant instead of enumerating.
+
+⚠ **`tests/test_embed_drift.py` pinned the literal `"No embedding provider
+configured"`,** which is precisely how that site kept a stale copy: a test keyed
+to one spelling of a sentence guards the spelling, not the behaviour. It now
+asserts the shared message is served. **The first version of this release's own
+ratchet had the same defect** — it matched `"No embedding provider is
+configured"` with the `is`, and caught `embed_drift` only by luck via a
+different clause.
+
+⚠ **No token-budget cost, and that was MEASURED rather than assumed.** The first
+read of this issue assumed the `semantic` description was charged against the
+hard 4,000-token `core_compact` ceiling, which has ten tokens of headroom, and
+would have trimmed a description to make room. `semantic` is in
+`_COMPACT_STRIP_PARAMS`, so it never reaches the compact schema at all: live
+`core_compact` is **3,990 before and after**. A test pins that, so if `semantic`
+ever stops being stripped the budget question comes back visibly.
+
+⚠ `tests/test_embedding_provider_advice.py` (10). Four are red against the
+pre-fix consumers; the rest assert the constants' shape and the budget, and hold
+on both sides. ⚠⚠ **One of the four only became red after it was corrected**:
+`test_the_search_symbols_runtime_error` originally imported the constant and
+asserted the extra was in it, which is true the moment the constant exists,
+whether or not the site uses it. **It checked the fix instead of the site.**
+
+
 ## [1.108.285] - 2026-08-18 - Five answers that were asserted, not established
 
 Five fixes, each one a place that reported a result it had not checked: a cache that said ready, an index that said fresh, a resolver that said this repository, an opt-out that said applied, and an embedding store that said one model. Three of the five were a comment or docstring describing behaviour the code did not implement.

--- a/src/jcodemunch_mcp/embeddings/advice.py
+++ b/src/jcodemunch_mcp/embeddings/advice.py
@@ -1,0 +1,46 @@
+"""The one place that tells a caller how to obtain an embedding provider.
+
+⚠⚠ Three sites carried this advice independently and two of them omitted the
+bundled zero-config ONNX encoder entirely, naming only the three env-var
+providers — two of which bill per call (#489). `embed_repo`'s copy was updated
+when ONNX landed at priority 0; the `semantic` parameter description and
+`search_symbols`' `no_embedding_provider` error were not.
+
+That is expensive in one direction specifically. The parameter description is
+not documentation a human browses — it is the tool schema, and it is the ONLY
+information an agent has when deciding whether to set `semantic: true`. An agent
+reading "requires one of three env vars" against an environment with none of
+them set correctly concludes semantic search is unavailable, and never attempts
+it, on a machine where it works for free. There is no error, no warning and no
+degraded result: the capability simply goes unused.
+
+Keep `_LOCAL_FIRST` first. The ordering mirrors `_detect_provider`'s priority,
+so the advice and the resolver cannot disagree about which one wins.
+"""
+
+# The bundled encoder. Priority 0 in `_detect_provider`, free, local, and the
+# project's recommended setup — so it leads every list.
+_LOCAL_FIRST = "pip install 'jcodemunch-mcp[local-embed]' (zero-config ONNX, recommended)"
+
+_ENV_PROVIDERS = (
+    "JCODEMUNCH_EMBED_MODEL (sentence-transformers, free/local), "
+    "GOOGLE_API_KEY + GOOGLE_EMBED_MODEL (Gemini), or "
+    "OPENAI_API_KEY + OPENAI_EMBED_MODEL (OpenAI)"
+)
+
+#: Full sentence for a runtime error, where the caller has already failed and
+#: needs the remedy.
+NO_PROVIDER_MESSAGE = (
+    f"No embedding provider is configured. Options: {_LOCAL_FIRST}, "
+    f"{_ENV_PROVIDERS}."
+)
+
+#: Clause for a tool schema, where the caller is deciding whether to try at all.
+#: Shorter than the error on purpose — schema text is paid on every request that
+#: carries it, and `search_symbols` is a core-tier tool.
+#:
+#: ⚠ Semicolon, not "or", before the env list: `_ENV_PROVIDERS` already ends in
+#: "or OPENAI…", so joining with "or" yields two of them in one sentence.
+PROVIDER_HINT = (
+    f"Requires an embedding provider: {_LOCAL_FIRST}; otherwise {_ENV_PROVIDERS}."
+)

--- a/src/jcodemunch_mcp/retrieval/embed_drift.py
+++ b/src/jcodemunch_mcp/retrieval/embed_drift.py
@@ -26,6 +26,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from ..embeddings.advice import NO_PROVIDER_MESSAGE
+
 logger = logging.getLogger(__name__)
 
 _CANARY_FILE = "embed_canary.json"
@@ -121,11 +123,7 @@ def capture_canary(base_path: Optional[str] = None, *, force: bool = False) -> d
     if not provider or not model:
         return {
             "captured": False,
-            "error": (
-                "No embedding provider configured. Set GOOGLE_API_KEY + "
-                "GOOGLE_EMBED_MODEL, OPENAI_API_KEY + OPENAI_EMBED_MODEL, "
-                "embed_model in config, or install the bundled ONNX model."
-            ),
+            "error": NO_PROVIDER_MESSAGE,
         }
     try:
         vectors = _embed(list(CANARY_STRINGS), provider, model)

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -21,6 +21,7 @@ from mcp.types import Tool, ToolAnnotations, TextContent, Resource, Prompt, Prom
 
 from . import __version__
 from . import config as config_module
+from .embeddings.advice import PROVIDER_HINT as _PROVIDER_HINT
 from . import runtime_identity
 from .tools import _arg_contract
 # Tool modules are imported lazily inside each call_tool() dispatch branch.
@@ -1839,7 +1840,7 @@ def _build_tools_list() -> list[Tool]:
                     },
                     "semantic": {
                         "type": "boolean",
-                        "description": "Enable semantic (embedding-based) search. Requires an embedding provider: JCODEMUNCH_EMBED_MODEL (sentence-transformers), GOOGLE_API_KEY+GOOGLE_EMBED_MODEL (Gemini), or OPENAI_API_KEY+OPENAI_EMBED_MODEL (OpenAI). When false (default) there is zero performance impact.",
+                        "description": "Enable semantic (embedding-based) search. " + _PROVIDER_HINT + " When false (default) there is zero performance impact.",
                         "default": False
                     },
                     "semantic_weight": {
@@ -3923,8 +3924,7 @@ def _build_tools_list() -> list[Tool]:
                 "Optional warm-up: search_symbols with semantic=true lazily embeds missing "
                 "symbols on first use, but embed_repo warms the cache upfront so the first "
                 "semantic query returns immediately. "
-                "Requires an embedding provider (JCODEMUNCH_EMBED_MODEL, "
-                "GOOGLE_API_KEY+GOOGLE_EMBED_MODEL, or OPENAI_API_KEY+OPENAI_EMBED_MODEL)."
+                + _PROVIDER_HINT
             ),
             inputSchema={
                 "type": "object",

--- a/src/jcodemunch_mcp/tools/embed_repo.py
+++ b/src/jcodemunch_mcp/tools/embed_repo.py
@@ -12,6 +12,7 @@ from typing import Callable, Optional
 
 from .. import config as _config
 from ..storage import IndexStore
+from ..embeddings.advice import NO_PROVIDER_MESSAGE
 from ._utils import index_status_to_tool_error, resolve_repo
 
 logger = logging.getLogger(__name__)
@@ -286,13 +287,7 @@ def embed_repo(
     if provider_info is None:
         return {
             "error": "no_embedding_provider",
-            "message": (
-                "No embedding provider is configured. Options: "
-                "pip install 'jcodemunch-mcp[local-embed]' (zero-config ONNX, recommended), "
-                "JCODEMUNCH_EMBED_MODEL (sentence-transformers, free/local), "
-                "GOOGLE_API_KEY + GOOGLE_EMBED_MODEL (Gemini), or "
-                "OPENAI_API_KEY + OPENAI_EMBED_MODEL (OpenAI)."
-            ),
+            "message": NO_PROVIDER_MESSAGE,
         }
     provider, model = provider_info
 

--- a/src/jcodemunch_mcp/tools/search_symbols.py
+++ b/src/jcodemunch_mcp/tools/search_symbols.py
@@ -743,8 +743,9 @@ def search_symbols(
             "centrality" = filter by query match, rank by PageRank score.
             "combined" = BM25 + PageRank weighted combination.
         semantic: Enable semantic (embedding-based) search. Requires an embedding
-            provider to be configured (JCODEMUNCH_EMBED_MODEL, GOOGLE_API_KEY +
-            GOOGLE_EMBED_MODEL, or OPENAI_API_KEY + OPENAI_EMBED_MODEL).
+            provider; ``embeddings.advice.PROVIDER_HINT`` is the single source for
+            which ones and which wins (#489 — this docstring used to enumerate
+            them and had gone stale).
             When False (default) there is zero performance impact and no new imports.
         semantic_weight: Weight for semantic score in hybrid ranking (0.0–1.0).
             BM25 receives ``1 - semantic_weight``. Default 0.5.
@@ -914,14 +915,12 @@ def search_symbols(
         from .embed_repo import _detect_provider
         _semantic_provider = _detect_provider()
         if _semantic_provider is None:
+            from ..embeddings.advice import (  # noqa: PLC0415
+                NO_PROVIDER_MESSAGE as _NO_PROVIDER_MESSAGE,
+            )
             return {
                 "error": "no_embedding_provider",
-                "message": (
-                    "No embedding provider is configured. Set one of: "
-                    "JCODEMUNCH_EMBED_MODEL (sentence-transformers, free/local), "
-                    "GOOGLE_API_KEY + GOOGLE_EMBED_MODEL (Gemini), or "
-                    "OPENAI_API_KEY + OPENAI_EMBED_MODEL (OpenAI)."
-                ),
+                "message": _NO_PROVIDER_MESSAGE,
             }
 
     # BM25 corpus stats — cached on CodeIndex, computed once per index load

--- a/tests/test_embed_drift.py
+++ b/tests/test_embed_drift.py
@@ -80,7 +80,14 @@ class TestCaptureCanary:
         monkeypatch.setattr(ed, "_resolve_provider", lambda: (None, None))
         out = ed.capture_canary(base_path=str(tmp_path))
         assert out["captured"] is False
-        assert "No embedding provider configured" in out["error"]
+        # #489: asserts the SHARED advice is served, not one spelling of it.
+        # This used to pin the literal "No embedding provider configured", which
+        # is how this site kept its own copy — one that named the bundled ONNX
+        # encoder LAST, behind two providers that bill per call.
+        from jcodemunch_mcp.embeddings.advice import NO_PROVIDER_MESSAGE
+
+        assert out["error"] == NO_PROVIDER_MESSAGE
+        assert "jcodemunch-mcp[local-embed]" in out["error"]
 
 
 class TestCheckDrift:

--- a/tests/test_embedding_provider_advice.py
+++ b/tests/test_embedding_provider_advice.py
@@ -1,0 +1,201 @@
+"""#489: two of three provider-advice sites omitted the bundled ONNX encoder.
+
+Three places tell a caller how to obtain an embedding provider. `embed_repo`'s
+error led with `pip install 'jcodemunch-mcp[local-embed]'` and marked it
+recommended. The `semantic` parameter description and `search_symbols`'
+`no_embedding_provider` error named only the three env-var providers — two of
+which bill per call — and omitted the free, local, already-bundled one that
+outranks all three in `_detect_provider`.
+
+⚠ The parameter description is the expensive one. It is not documentation a
+human browses; it is the tool schema, and it is the only information an agent
+has when deciding whether to set `semantic: true`. An agent reading "requires
+one of three env vars" against an environment with none of them set correctly
+concludes semantic search is unavailable and never attempts it, on a machine
+where it works for free. No error, no warning, no degraded result — the
+capability simply goes unused.
+
+The drift is the point: site 3 was updated when ONNX landed at priority 0 and
+the other two were not, because each carried its own copy.
+"""
+
+import re
+
+import pytest
+
+from jcodemunch_mcp.embeddings.advice import (
+    NO_PROVIDER_MESSAGE,
+    PROVIDER_HINT,
+    _LOCAL_FIRST,
+)
+
+LOCAL_EXTRA = "jcodemunch-mcp[local-embed]"
+
+
+def _semantic_description():
+    """The `semantic` param description as an agent receives it."""
+    from jcodemunch_mcp import config as config_module
+    from jcodemunch_mcp.server import _build_tools_list
+
+    cfg = config_module._GLOBAL_CONFIG
+    original = {k: cfg.get(k) for k in ("tool_profile", "compact_schemas")}
+    try:
+        cfg["tool_profile"] = "full"
+        cfg["compact_schemas"] = False
+        for tool in _build_tools_list():
+            if tool.name == "search_symbols":
+                props = tool.inputSchema.get("properties", {}) or {}
+                return (props.get("semantic") or {}).get("description", "")
+    finally:
+        for k, v in original.items():
+            if v is None:
+                cfg.pop(k, None)
+            else:
+                cfg[k] = v
+    return ""
+
+
+class TestEverySiteNamesTheBundledEncoder:
+    """One assertion per site, so a failure names which one drifted."""
+
+    def test_the_semantic_parameter_description(self):
+        description = _semantic_description()
+        assert description, "search_symbols has no `semantic` param on the full surface"
+        assert LOCAL_EXTRA in description, (
+            "the tool schema an agent reads to decide whether semantic search is "
+            f"available does not mention the bundled encoder: {description!r}"
+        )
+
+    def test_the_search_symbols_runtime_error(self):
+        """⚠ Asserts on search_symbols' SOURCE, not on the constant.
+
+        The first version of this test imported `NO_PROVIDER_MESSAGE` and
+        asserted the extra was in it — which is true the moment the constant
+        exists, whether or not `search_symbols` uses it. It checked the fix
+        instead of the site, and would have passed against a tree where this
+        site still carried its stale copy.
+        """
+        import inspect
+
+        from jcodemunch_mcp.tools import search_symbols
+
+        source = inspect.getsource(search_symbols)
+        assert "NO_PROVIDER_MESSAGE" in source
+        assert "No embedding provider is configured. Set one of:" not in source, (
+            "search_symbols still carries its own copy of the advice"
+        )
+
+    def test_the_embed_repo_runtime_error(self):
+        """Site 3 was already correct; it is now the shared source rather than a
+        third independent copy."""
+        import inspect
+
+        from jcodemunch_mcp.tools import embed_repo
+
+        source = inspect.getsource(embed_repo)
+        assert "NO_PROVIDER_MESSAGE" in source
+        assert "zero-config ONNX, recommended" not in source, (
+            "embed_repo still carries its own copy of the advice"
+        )
+
+
+class TestTheBundledEncoderLeads:
+    """Naming it is not enough — `_detect_provider` returns it at priority 0, so
+    advice that buries it still describes the design backwards."""
+
+    @pytest.mark.parametrize(
+        "text", [NO_PROVIDER_MESSAGE, PROVIDER_HINT],
+        ids=["runtime_error", "schema_hint"],
+    )
+    def test_it_is_named_before_any_key_requiring_provider(self, text):
+        local_at = text.index(LOCAL_EXTRA)
+        for env_var in ("JCODEMUNCH_EMBED_MODEL", "GOOGLE_API_KEY", "OPENAI_API_KEY"):
+            assert local_at < text.index(env_var), (
+                f"{env_var} is named before the bundled encoder"
+            )
+
+    @pytest.mark.parametrize(
+        "text", [NO_PROVIDER_MESSAGE, PROVIDER_HINT],
+        ids=["runtime_error", "schema_hint"],
+    )
+    def test_no_doubled_conjunction(self, text):
+        """⚠ `_ENV_PROVIDERS` already ends in "or OPENAI…", so joining it with
+        "or" produced two in one sentence. Caught by reading the rendered string,
+        not the template."""
+        assert not re.search(r"\bor\b[^.]*\bor\b[^.]*\bor\b", text), (
+            f"more than two 'or's in one sentence: {text!r}"
+        )
+
+
+class TestTheSitesCannotDriftApartAgain:
+    """The defect was three independent copies, one of which was maintained."""
+
+    def test_no_module_hardcodes_the_provider_list(self):
+        """A second copy of the advice is what created this issue."""
+        import pathlib
+
+        from jcodemunch_mcp import embeddings
+
+        root = pathlib.Path(embeddings.__file__).resolve().parent.parent
+        advice = (root / "embeddings" / "advice.py").resolve()
+        offenders = []
+        for path in sorted(root.rglob("*.py")):
+            if path.resolve() == advice:
+                continue  # the one legitimate home
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for lineno, line in enumerate(text.splitlines(), 1):
+                # An ENUMERATION is the thing that drifts. A line naming two of
+                # the env providers is a copy of the list regardless of wording.
+                if "GOOGLE_EMBED_MODEL" in line and "OPENAI_EMBED_MODEL" in line:
+                    offenders.append(f"{path.relative_to(root)}:{lineno}")
+                # ⚠ Phrasing-agnostic on purpose. The first version of this
+                # matched the literal "No embedding provider is configured" and
+                # missed `embed_drift.py`, which said "No embedding provider
+                # configured" without the "is" — caught only by the clause
+                # above, i.e. by luck. A ratchet keyed to one spelling of a
+                # sentence guards that spelling, not the defect.
+                elif re.search(r"No embedding provider (is )?configured\.", line):
+                    offenders.append(f"{path.relative_to(root)}:{lineno}")
+        assert not offenders, (
+            "these carry their own copy of the provider advice instead of "
+            "importing it, which is how two of three fell out of date: "
+            + ", ".join(offenders)
+        )
+
+    def test_the_shared_constants_share_one_source(self):
+        """Both strings must derive from `_LOCAL_FIRST`, or "lead with the
+        bundled encoder" can be true of one and false of the other."""
+        assert _LOCAL_FIRST in NO_PROVIDER_MESSAGE
+        assert _LOCAL_FIRST in PROVIDER_HINT
+
+
+class TestTheBudgetIsUnchanged:
+    """⚠ `semantic` is in `_COMPACT_STRIP_PARAMS`, so this description never
+    reaches the compact schema and costs the core budget nothing. That was
+    measured, not assumed - the initial read of this issue assumed the opposite
+    and would have trimmed a description for no reason."""
+
+    def test_semantic_is_absent_from_the_compact_schema(self):
+        from jcodemunch_mcp import config as config_module
+        from jcodemunch_mcp.server import _build_tools_list
+
+        cfg = config_module._GLOBAL_CONFIG
+        original = {k: cfg.get(k) for k in ("tool_profile", "compact_schemas")}
+        try:
+            cfg["tool_profile"] = "core"
+            cfg["compact_schemas"] = True
+            props = {}
+            for tool in _build_tools_list():
+                if tool.name == "search_symbols":
+                    props = tool.inputSchema.get("properties", {}) or {}
+                    break
+        finally:
+            for k, v in original.items():
+                if v is None:
+                    cfg.pop(k, None)
+                else:
+                    cfg[k] = v
+        assert "semantic" not in props, (
+            "`semantic` now reaches the compact schema, so this description is "
+            "charged against the hard 4000-token core_compact ceiling"
+        )


### PR DESCRIPTION
Closes #489.

## What was wrong

Five places tell a caller how to obtain an embedding provider. Exactly one named the bundled zero-config ONNX encoder — the provider that is **priority 0 in `_detect_provider`** and the project's recommended setup. The other four listed only `JCODEMUNCH_EMBED_MODEL`, `GOOGLE_API_KEY` and `OPENAI_API_KEY`, two of which bill per call.

Your framing of *why the schema string specifically matters* is the part that set the priority here, and it's right: it isn't documentation a human browses, it's the only information an agent has when deciding whether to set `semantic: true`. An agent reading "requires one of three env vars" against an environment with none of them set correctly concludes semantic search is unavailable and never attempts it — on a machine where it works, for free, right now. No error, no warning, nothing degraded to notice.

## The fix

Your options (1) and (2) together: all five sites now derive from `embeddings/advice.py`, with `_LOCAL_FIRST` leading both strings so the advice mirrors `_detect_provider`'s priority order and the two cannot disagree about which provider wins.

**Your report named three sites. The ratchet found five.** Two were only visible once a test asserted the property instead of the instances:

- **`server.py` — the `embed_repo` tool description.** Same omission, equally agent-facing. This is your site 1's twin and it was missed by both of us.
- **`retrieval/embed_drift.py`** — its own copy, which *did* mention the bundled encoder but **last**, behind the two that cost money. Worse than omission in one sense: it's ordered to suggest ONNX is the fallback.

The fifth is the `semantic` docstring in `search_symbols`, developer-facing, now pointing at the constant rather than enumerating.

Option (3) — a schema that reports the *runtime* fact rather than setup instructions — isn't shipped here. It's a genuinely better idea and a bigger change; noted rather than quietly dropped.

## Two things worth flagging

**`tests/test_embed_drift.py` pinned the literal `"No embedding provider configured"`** — which is exactly how that site kept a stale copy. A test keyed to one spelling of a sentence guards the spelling, not the behaviour. It now asserts the shared message is served. My own ratchet had the identical defect on its first pass: it matched `"No embedding provider is configured"` *with* the `is`, and caught `embed_drift` only by luck via a different clause.

**There is no token-budget cost, and that was measured rather than assumed.** My first read of this issue assumed the `semantic` description was charged against the hard 4,000-token `core_compact` ceiling — which has ten tokens of headroom — and I was ready to trim a description to make room. `semantic` is in `_COMPACT_STRIP_PARAMS`, so it never reaches the compact schema at all. Live `core_compact` is **3,990 before and after**. A test pins that, so if `semantic` ever stops being stripped the budget question resurfaces visibly instead of silently breaching.

## Verification

```text
SCHEMA: Requires an embedding provider: pip install 'jcodemunch-mcp[local-embed]'
        (zero-config ONNX, recommended); otherwise JCODEMUNCH_EMBED_MODEL
        (sentence-transformers, free/local), GOOGLE_API_KEY + GOOGLE_EMBED_MODEL
        (Gemini), or OPENAI_API_KEY + OPENAI_EMBED_MODEL (OpenAI).
```

`tests/test_embedding_provider_advice.py`, 10 tests. Four red against the pre-fix consumers (with `advice.py` present, so the failures are about the sites and not about a missing import); the rest assert the constants' shape and the budget and hold on both sides.

⚠ One of those four only became red **after it was corrected**. `test_the_search_symbols_runtime_error` originally imported the constant and asserted the extra was in it — true the moment the constant exists, whether or not the site uses it. It checked the fix instead of the site, and would have passed against a tree where that site still carried its stale copy.

Suite: **7955 passed, 17 skipped, 0 failed**, ruff clean. Total 7972 against main's 7962 is exactly the 10 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
