### PR TITLE
fix(guide): filter jcodemunch_guide by disabled_tools and profile (#495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## [Unreleased]
 
+### The guide advertised a tool the same process refuses to run (#495, @rknighton)
+
+`jcodemunch_guide` built its `### All tools` list from a static constant without
+consulting `disabled_tools`. That key ships as `["test_summarizer"]`, so **at
+shipped defaults — no config file, no environment overrides —** the guide named a
+tool `call_tool` then rejected before the handler ran. An agent reads the name,
+calls it, and gets an error.
+
+⚠⚠ **The filtering already existed and a SECOND generator walked around it.**
+Commit `e086e9a` ("claude-md respects tool_profile and disabled_tools", #242)
+added exactly this to `cli/init.py`, which is why the CLI policy path filters
+correctly today. `server.py`'s generator never received it. **The fix reuses
+`_get_active_tools` rather than adding a third copy** — a copy is precisely how
+the two drifted apart, and a third would drift again.
+
+⚠ **Profile is honoured too, not only `disabled_tools`.** The reporter scoped
+their claim to `disabled_tools` deliberately and correctly: a profile-hidden tool
+stays dispatchable by name, so naming it costs context (#397) rather than
+producing a failure. But the tool's own registered description promises the guide
+"Matches the active tool surface, tier and disabled_tools", and `tier` is the
+profile — so filtering by one and not the other leaves the description making a
+claim the code does not keep, which is the defect class this release is full of.
+
+⚠ A category emptied by filtering is dropped whole. A bare `**Search:**` with
+nothing after it reads as a surface with no tools in it.
+
+⚠⚠ **`tests/test_config.py::test_generate_full_snippet` asserted that EVERY
+canonical tool name appears in the snippet, which encoded the defect instead of
+catching it.** `test_summarizer` is canonical and disabled by default, so the
+test could only pass while the bug existed. It now asserts the property actually
+wanted — advertises what it will dispatch — and pins the absence. **That is the
+third test this release found asserting the behaviour it should have prevented.**
+
+⚠ `tests/test_guide_respects_disabled_tools.py` (9), 5 red against the pre-fix
+generator. The other four are constraints: the nothing-disabled control, snippet
+shape, the empty-category rule, and a pin on `DEFAULTS["disabled_tools"]` so the
+issue's premise cannot silently change out from under the case.
+
+
 ### The tool schema advertised three paid-ish providers and hid the free one (#489, @pnm-jgb)
 
 Five places tell a caller how to obtain an embedding provider. Exactly one of

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -7822,6 +7822,41 @@ def _generate_claude_md_snippet(missing_only: bool = False) -> str:
             logger.debug("front-door snippet unavailable; using the full one", exc_info=True)
 
     categories = _SNIPPET_TOOL_CATEGORIES
+
+    # #495: filter to what this process will actually dispatch.
+    #
+    # ⚠⚠ `disabled_tools` ships as `["test_summarizer"]`, so at SHIPPED DEFAULTS
+    # this guide advertised a tool `call_tool` then refuses — an agent reads the
+    # name here, calls it, and gets an error before the handler runs. Nothing
+    # about that is configuration-dependent; it was the out-of-the-box state.
+    #
+    # ⚠⚠ The filtering already existed and a SECOND generator walked around it.
+    # Commit e086e9a ("claude-md respects tool_profile and disabled_tools", #242)
+    # added exactly this to `cli/init.py`, which is why the CLI policy path
+    # filters correctly today. This function is the other generator and never
+    # received it. **Reuse `_get_active_tools` rather than writing a third
+    # filter** — a copy is how these two drifted apart in the first place.
+    #
+    # ⚠ Profile is honoured too, not just `disabled_tools`. The registered
+    # description promises the guide "Matches the active tool surface, tier and
+    # disabled_tools", and `tier` is the profile. A profile-hidden tool stays
+    # dispatchable by name, so naming it costs context rather than erroring
+    # (#397) — a weaker harm than the reported one, and the same promise.
+    try:
+        from .cli.init import _get_active_tools
+        _active = _get_active_tools()
+    except Exception:
+        logger.debug("active-tool filter unavailable; listing all", exc_info=True)
+        _active = None
+    if _active is not None:
+        categories = [
+            (cat, [t for t in tools if t in _active])
+            for cat, tools in categories
+        ]
+        # A category emptied by filtering is dropped whole; a bare "**Search:**"
+        # with nothing after it reads as a surface with no tools in it.
+        categories = [(cat, tools) for cat, tools in categories if tools]
+
     from . import __version__ as _ver
     lines = [
         f"## jcodemunch-mcp (v{_ver})",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1699,12 +1699,23 @@ class TestClaudeMdGenerate:
     """claude-md --generate subcommand."""
 
     def test_generate_full_snippet(self, capsys, monkeypatch):
-        """--generate outputs all canonical tool names."""
-        from jcodemunch_mcp.server import _run_claude_md, _CANONICAL_TOOL_NAMES
+        """--generate outputs every tool this process will actually dispatch.
+
+        ⚠ #495: this asserted every CANONICAL name appeared, which encoded the
+        defect rather than catching it. `disabled_tools` ships as
+        `["test_summarizer"]`, so a snippet naming every canonical tool names one
+        that `call_tool` rejects before the handler runs. The property wanted is
+        "advertises what it will dispatch", not "advertises everything".
+        """
+        from jcodemunch_mcp.server import _run_claude_md, _build_tools_list
         _run_claude_md(generate=True, fmt="full")
         out = capsys.readouterr().out
-        for tool in _CANONICAL_TOOL_NAMES:
-            assert tool in out, f"Expected tool {tool!r} in snippet"
+        mounted = {t.name for t in _build_tools_list()}
+        for tool in mounted:
+            assert tool in out, f"Expected mounted tool {tool!r} in snippet"
+        assert "test_summarizer" not in out, (
+            "snippet names a tool disabled by default"
+        )
 
     def test_generate_append_reports_missing(self, monkeypatch, tmp_path, capsys):
         """--format=append outputs only tools absent from the existing CLAUDE.md."""

--- a/tests/test_guide_respects_disabled_tools.py
+++ b/tests/test_guide_respects_disabled_tools.py
@@ -1,0 +1,159 @@
+"""#495: the guide advertised a tool the same process refuses to run.
+
+`_generate_claude_md_snippet` built its `### All tools` list from a static
+constant without consulting `disabled_tools`. `disabled_tools` ships as
+`["test_summarizer"]`, so **at shipped defaults** — no config file, no env
+overrides — the guide named a tool `call_tool` then rejected before the handler
+ran. An agent reads the name, calls it, gets an error.
+
+⚠⚠ The filtering already existed and a SECOND generator walked around it.
+Commit `e086e9a` ("claude-md respects tool_profile and disabled_tools", #242)
+added it to `cli/init.py`, which is why the CLI policy path filters correctly.
+This function is the other generator and never received it. The fix reuses
+`_get_active_tools` rather than adding a third copy — a copy is how the two
+drifted apart.
+"""
+
+import re
+
+import pytest
+
+from jcodemunch_mcp import config as config_module
+from jcodemunch_mcp import server
+
+
+def _advertised(snippet):
+    """Tool names the guide's `### All tools` block presents as callable."""
+    if "### All tools" not in snippet:
+        return set()
+    block = snippet.split("### All tools", 1)[1]
+    return set(re.findall(r"`([a-z_0-9]+)`", block))
+
+
+def _mounted():
+    return {t.name for t in server._build_tools_list()}
+
+
+@pytest.fixture
+def cfg():
+    """Direct access to the global config, restored after each test."""
+    c = config_module._GLOBAL_CONFIG
+    keys = ("disabled_tools", "tool_profile", "tool_surface")
+    original = {k: c.get(k) for k in keys}
+    yield c
+    for k, v in original.items():
+        if v is None:
+            c.pop(k, None)
+        else:
+            c[k] = v
+
+
+class TestTheGuideMatchesWhatDispatchAccepts:
+    def test_a_disabled_tool_is_not_advertised(self, cfg):
+        cfg["disabled_tools"] = ["test_summarizer"]
+        cfg["tool_profile"] = "full"
+
+        advertised = _advertised(server._generate_claude_md_snippet())
+
+        assert "test_summarizer" not in advertised, (
+            "the guide advertises a tool call_tool rejects before the handler runs"
+        )
+
+    def test_this_is_the_shipped_default_not_a_configuration(self):
+        """⚠ The defect needed no configuration to reach. If this default ever
+        changes the issue's premise changes with it, so pin it here rather than
+        leaving the test above looking like a contrived case."""
+        from jcodemunch_mcp.config import DEFAULTS
+
+        assert DEFAULTS["disabled_tools"] == ["test_summarizer"]
+
+    def test_no_advertised_tool_is_unmounted(self, cfg):
+        """The general property, not the one instance."""
+        cfg["disabled_tools"] = ["test_summarizer", "find_dead_code"]
+        cfg["tool_profile"] = "full"
+
+        ghosts = _advertised(server._generate_claude_md_snippet()) - _mounted()
+
+        assert not ghosts, f"guide advertises unmounted tools: {sorted(ghosts)}"
+
+    def test_an_ordinary_tool_is_filtered_too(self, cfg):
+        """`test_summarizer` is disabled by default, so fixing only that name
+        would pass the first test. A second, ordinary tool proves the filter is
+        general."""
+        cfg["disabled_tools"] = ["find_dead_code"]
+        cfg["tool_profile"] = "full"
+
+        advertised = _advertised(server._generate_claude_md_snippet())
+
+        assert "find_dead_code" not in advertised
+        assert "search_symbols" in advertised, "the filter removed too much"
+
+
+class TestWhatMustNotChange:
+    def test_nothing_disabled_lists_everything(self, cfg):
+        """Control: with the filter satisfied, the guide is unchanged."""
+        cfg["disabled_tools"] = []
+        cfg["tool_profile"] = "full"
+
+        advertised = _advertised(server._generate_claude_md_snippet())
+
+        assert "test_summarizer" in advertised
+        assert not (advertised - _mounted())
+
+    def test_the_snippet_keeps_its_shape(self, cfg):
+        cfg["disabled_tools"] = ["test_summarizer"]
+        cfg["tool_profile"] = "full"
+
+        snippet = server._generate_claude_md_snippet()
+
+        assert snippet.startswith("## jcodemunch-mcp (v")
+        assert "### Quick start" in snippet
+        assert "### All tools" in snippet
+        assert "Never fall back to Grep, Read, or Glob" in snippet
+
+    def test_no_category_is_left_empty(self, cfg):
+        """A bare `**Search:**` with nothing after it reads as a surface with no
+        tools in it. Emptied categories are dropped whole."""
+        cfg["disabled_tools"] = list(server._CANONICAL_TOOL_NAMES)
+        cfg["tool_profile"] = "full"
+
+        snippet = server._generate_claude_md_snippet()
+
+        for line in snippet.splitlines():
+            if line.startswith("**") and line.endswith(":**"):
+                pytest.fail(f"category header with no tools: {line!r}")
+            if re.match(r"^\*\*[^*]+:\*\*\s*$", line):
+                pytest.fail(f"category header with no tools: {line!r}")
+
+
+class TestOneFilterNotThree:
+    """The defect was two generators and one filter. A third copy would be the
+    same bug again."""
+
+    def test_the_guide_uses_the_cli_helper(self):
+        import inspect
+
+        source = inspect.getsource(server._generate_claude_md_snippet)
+        assert "_get_active_tools" in source, (
+            "the guide should reuse cli.init._get_active_tools, not re-derive "
+            "the active set — a second copy is how #242's fix was missed here"
+        )
+
+    def test_the_two_generators_agree(self, cfg):
+        """⚠ The reporter's diagnostic, as a test: one process, one config, and
+        the two paths must not disagree about a tool's availability."""
+        from jcodemunch_mcp.cli.init import active_policy
+
+        cfg["disabled_tools"] = ["test_summarizer", "find_dead_code"]
+        cfg["tool_profile"] = "full"
+
+        advertised = _advertised(server._generate_claude_md_snippet())
+        cli_text = active_policy()
+
+        for name in ("test_summarizer", "find_dead_code"):
+            in_guide = name in advertised
+            in_cli = f"`{name}`" in cli_text
+            assert in_guide == in_cli is False, (
+                f"{name}: guide={in_guide} cli_policy={in_cli} — the two "
+                "generators disagree on one config in one process"
+            )


### PR DESCRIPTION
Closes #495.

## What was wrong

`_generate_claude_md_snippet` built its `### All tools` list from a static constant without consulting `disabled_tools`. That key ships as `["test_summarizer"]`, so **at shipped defaults** — no config file, no environment overrides — the guide named a tool `call_tool` then rejected before the handler ran.

Your framing is the useful part and it's what set the fix: **the filtering already existed and a second generator walked around it.** `e086e9a` added exactly this to `cli/init.py` for #242, which is why your `find_dead_code` contrast line shows the CLI path filtering correctly on the same config in the same process. `server.py`'s generator never received it.

So the fix reuses `_get_active_tools` rather than adding a third copy. A copy is how these two drifted apart, and a third would drift again.

## One deliberate widening beyond your scope

You scoped the claim to `disabled_tools` and were right to: a profile-hidden tool stays dispatchable by name, so naming it costs context (#397) rather than producing a failure. Different severity, different case.

I filtered by profile too, for the reason you raised yourself — the registered description promises the guide "Matches the active tool surface, tier and disabled_tools", and `tier` is the profile. Filtering one and not the other leaves the description making a claim the code doesn't keep, which is the same defect class one layer up. Happy to narrow it if you'd rather the two cases stay separate.

## Verification

Your harness, all three states, on this branch:

```text
  disabled_tools      : ['test_summarizer']          <- shipped default
  tools/list          : 90
  guide advertises    : 90
  advertised, unmounted: []

  disabled_tools      : []
  tools/list          : 91
  guide advertises    : 91
  advertised, unmounted: []

  disabled_tools      : ['test_summarizer', 'find_dead_code']
  tools/list          : 89
  guide advertises    : 89
  advertised, unmounted: []
  [find_dead_code] mounted=False guide=False cli_policy=False
```

That last line is the one worth reading: `guide` now agrees with `cli_policy` instead of contradicting it.

**`tests/test_config.py::test_generate_full_snippet` asserted that every canonical tool name appears in the snippet**, so it could only pass while the bug existed — `test_summarizer` is canonical and disabled by default. It now asserts the property actually wanted (advertises what it will dispatch) and pins the absence. That's the third test this release found asserting the behaviour it should have prevented.

`tests/test_guide_respects_disabled_tools.py`, 9 tests, **5 red against the pre-fix generator**. The other four are constraints: the nothing-disabled control, snippet shape, the empty-category rule, and a pin on `DEFAULTS["disabled_tools"]` so the issue's premise can't silently change out from under the case.

Suite: **7964 passed, 17 skipped, 0 failed**, ruff clean. Total 7981 against main's 7972 is exactly the 9 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
