### PR TITLE
fix(embed): explicit local model outranks the bundled default (#488)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,66 @@
 
 ## [Unreleased]
 
+### An explicit local embedding model now outranks the zero-config default (#488, @pnm-jgb)
+
+`_detect_provider` returned the bundled ONNX encoder at priority 0, so once
+`[local-embed]` was installed every lower branch became unreachable **by
+configuration**. `embed_model` / `JCODEMUNCH_EMBED_MODEL` was read after the
+early return and changed nothing — no warning, no log line, no field in any
+response. **Absence of a setting and an explicit setting are different intents,
+and only the first should get the default.**
+
+The reporter's case is the ordinary one: they run jdocmunch on
+`BAAI/bge-base-en-v1.5` and wanted code and docs on the same model. `embed_model`
+is exactly the knob that appears to offer it. They set it, saw no change, and
+learned why only by reading the resolver.
+
+⚠⚠ **ONLY THE FREE, ON-MACHINE OPTION WAS PROMOTED. Gemini and OpenAI still sit
+BELOW the bundled encoder, and that is the load-bearing half of this change.**
+`tests/test_paid_embeddings_optin.py` exists because jdocmunch's resolver
+auto-selected OpenAI from an ambient key and began **billing a remote account and
+shipping the indexed corpus off the machine**; jcm's second line of defence is
+precisely that ONNX wins before any cloud branch is reached. **`embed_model` is
+free and local, so promoting it costs a re-embed; promoting a cloud provider
+costs money and exfiltrates the corpus.** Those are not the same decision and
+they do not get the same answer. A machine with an ambient `OPENAI_API_KEY` and
+`OPENAI_EMBED_MODEL` still embeds locally.
+
+⚠ **The usability probe decides PRECEDENCE, never selection.**
+`_embed_sentence_transformers` raises `ImportError` without its package, so
+promoting an uninstalled backend over a working ONNX install would trade a
+silently-ignored setting for a hard failure at embed time — the same defect,
+louder. When ONNX is unavailable there is nothing to protect and the setting is
+selected as before, which is what hands the caller the actionable
+`pip install 'jcodemunch-mcp[semantic]'` message rather than a bare `None`.
+**Probing unconditionally broke that on every machine without the package**, and
+33 tests said so.
+
+⚠ `embed_repo` now reports `provider_reason` (`embed_model` / `bundled_default`
+/ `google_api_key` / `openai_api_key` / `none_configured`) and, when an explicit
+setting could not be honoured, `provider_skipped` naming it and the remedy. **An
+explicit setting we cannot use is disclosed, never dropped** — silently ignoring
+it is the reported defect, and silently failing on it is that defect with a
+louder symptom.
+
+⚠ **The config comment is corrected**, which matters because it was the only
+place `embed_model` was documented and it described the opposite precedence:
+"takes priority over GOOGLE_API_KEY and OPENAI_API_KEY embeddings" was true of
+the two it named and silent about the one that outranked it.
+
+⚠ **MIGRATION, stated.** If you have `[local-embed]` installed AND `embed_model`
+set, your next `embed_repo` switches provider — and v1.108.285's #500 fix
+detects that, forces the rebuild, and reports `model_changed_from`. Before .285
+it would have left the store holding two vector widths with the newer half
+silently excluded from search, which is why this change waited for that one.
+
+⚠ `tests/test_explicit_embed_model_wins.py` (12). Six are red against the
+pre-fix resolver, **but only two of those are behavioural** — the other four
+fail because `_detect_provider_detailed` does not exist there. The six that pass
+on both sides are the money-safety class and the wrapper-shape controls, which
+pin what must NOT move.
+
+
 ### The guide advertised a tool the same process refuses to run (#495, @rknighton)
 
 `jcodemunch_guide` built its `### All tools` list from a static constant without

--- a/src/jcodemunch_mcp/config.py
+++ b/src/jcodemunch_mcp/config.py
@@ -2573,8 +2573,14 @@ def generate_template() -> str:
   // "summarizer_model": "",
   // "embed_model": "",
   //   Sentence-transformers model name for local (free) semantic embeddings.
-  //   Example: "all-MiniLM-L6-v2". Requires sentence-transformers package.
-  //   When set, takes priority over GOOGLE_API_KEY and OPENAI_API_KEY embeddings.
+  //   Example: "all-MiniLM-L6-v2". Requires the sentence-transformers package
+  //   (pip install 'jcodemunch-mcp[semantic]').
+  //   When set, takes priority over GOOGLE_API_KEY and OPENAI_API_KEY
+  //   embeddings AND over the bundled zero-config ONNX encoder. Setting it is
+  //   an explicit choice, so it outranks the default (v1.108.286, #488).
+  //   Leave it empty to use the bundled encoder.
+  //   If the package is not installed the setting is SKIPPED rather than
+  //   honoured into an error, and embed_repo reports it in provider_skipped.
   // "allow_remote_summarizer": false,
   //   Allow remote LLM endpoints for summarization (security risk).
   //   Default false blocks non-local summarization.

--- a/src/jcodemunch_mcp/tools/embed_repo.py
+++ b/src/jcodemunch_mcp/tools/embed_repo.py
@@ -23,41 +23,136 @@ EMBED_BATCH_SIZE = 50
 # ── Provider detection ──────────────────────────────────────────────────────
 
 
+_PROVIDER_BACKENDS: dict[str, tuple[str, str]] = {
+    # provider -> (import name, the extra that installs it)
+    "sentence_transformers": ("sentence_transformers", "jcodemunch-mcp[semantic]"),
+    "gemini": ("google.generativeai", "jcodemunch-mcp[gemini]"),
+    "openai": ("openai", "openai"),
+}
+
+
+def _backend_available(provider: str) -> bool:
+    """Is the package this provider needs importable?
+
+    ⚠ Import-checked, not merely configured. Every explicit provider's embed
+    function raises ``ImportError`` when its package is missing, so selecting
+    one we cannot run turns a silently-ignored setting (#488's complaint) into a
+    hard failure at embed time — the same defect with a louder symptom.
+    """
+    spec = _PROVIDER_BACKENDS.get(provider)
+    if spec is None:
+        return True
+    try:
+        import importlib.util  # noqa: PLC0415
+
+        return importlib.util.find_spec(spec[0]) is not None
+    except Exception:
+        logger.debug("backend probe failed for %s", provider, exc_info=True)
+        return False
+
+
+def _detect_provider_detailed() -> tuple[Optional[tuple[str, str]], str, list[str]]:
+    """Return ((provider, model) or None, reason, skipped).
+
+    ⚠⚠ **An explicit LOCAL choice outranks the local default (#488); a PAID
+    REMOTE provider never does.** Until v1.108.286 the bundled ONNX encoder
+    returned at priority 0, so once ``[local-embed]`` was installed
+    ``embed_model`` / ``JCODEMUNCH_EMBED_MODEL`` was read after the early return
+    and changed nothing — no warning, no field in any response. Absence of a
+    setting and an explicit setting are different intents, and only the first
+    should get the default.
+
+    ⚠⚠ **The cloud branches are DELIBERATELY still below ONNX, and this is not
+    an oversight.** ``tests/test_paid_embeddings_optin.py`` exists because
+    jdocmunch's resolver auto-selected OpenAI from an ambient key and began
+    billing a remote account *and shipping the indexed corpus off the machine*.
+    jcm's second line of defence against that is precisely that ONNX wins before
+    any cloud branch is reached. **`embed_model` is free and on-machine, so
+    promoting it costs a re-embed; promoting Gemini or OpenAI costs money and
+    exfiltrates the corpus.** Those are not the same decision and they do not
+    get the same answer.
+
+    ⚠ **The local promotion applies only when it is USABLE.**
+    ``_embed_sentence_transformers`` raises ``ImportError`` without the package,
+    so selecting it over a working ONNX install would turn a silently-ignored
+    setting into a hard failure at embed time — the same defect with a louder
+    symptom. An unusable explicit setting is skipped and NAMED, never silently
+    dropped.
+    """
+    skipped: list[str] = []
+
+    from ..embeddings.local_encoder import (
+        is_onnxruntime_available, is_model_available, MODEL_NAME,
+    )
+    onnx_ready = is_onnxruntime_available() and is_model_available()
+
+    # 1. sentence-transformers, named explicitly. Free, local, and therefore
+    #    safe to rank above the bundled default.
+    #
+    #    Global-only by design (#301): per-project embedding models would break
+    #    cross-project semantic search consistency. If per-repo selection ever
+    #    becomes a feature, this needs a repo arg threaded from embed_repo().
+    st_model = (
+        _config.get("embed_model", "") or os.environ.get("JCODEMUNCH_EMBED_MODEL", "")
+    ).strip()
+    if st_model:
+        # ⚠⚠ The usability probe decides PRECEDENCE ONLY, never selection.
+        # Promoting an uninstalled sentence-transformers OVER a working ONNX
+        # install would trade a silently-ignored setting for a hard
+        # `ImportError` at embed time — the same defect, louder. But when ONNX
+        # is not available there is nothing to protect, and returning this
+        # provider is what hands the caller the actionable "pip install
+        # 'jcodemunch-mcp[semantic]'" message instead of a bare None. Probing
+        # unconditionally broke exactly that, on every machine without the
+        # package.
+        if not onnx_ready or _backend_available("sentence_transformers"):
+            return ("sentence_transformers", st_model), "embed_model", skipped
+        skipped.append(
+            f"embed_model={st_model!r} (sentence-transformers not installed; "
+            f"pip install '{_PROVIDER_BACKENDS['sentence_transformers'][1]}') — "
+            f"using the bundled encoder instead"
+        )
+
+    # 2. The zero-config bundled encoder. Above the cloud branches, so a machine
+    #    with an ambient API key never silently starts billing.
+    if onnx_ready:
+        return ("local_onnx", MODEL_NAME), "bundled_default", skipped
+
+    # 3. Gemini. Requires TWO signals — the key AND an explicit model. Naming
+    #    the model is the opt-in; a bare key must never select a paid provider.
+    google_key = os.environ.get("GOOGLE_API_KEY", "").strip()
+    google_model = os.environ.get("GOOGLE_EMBED_MODEL", "").strip()
+    if google_key and google_model:
+        return ("gemini", google_model), "google_api_key", skipped
+
+    # 4. OpenAI. OPENAI_API_KEY alone is used for the local-LLM summariser, so
+    #    OPENAI_EMBED_MODEL must be set explicitly to avoid conflation.
+    openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    openai_model = os.environ.get("OPENAI_EMBED_MODEL", "").strip()
+    if openai_key and openai_model:
+        return ("openai", openai_model), "openai_api_key", skipped
+
+    return None, "none_configured", skipped
+
+
 def _detect_provider() -> Optional[tuple[str, str]]:
     """Return (provider_name, model_name) or None when nothing is configured.
 
     Priority order (first match wins):
-    0. local_onnx             — ``onnxruntime`` installed + ONNX model present
-    1. sentence-transformers  — ``embed_model`` config key or ``JCODEMUNCH_EMBED_MODEL`` env var
+    0. sentence-transformers  — ``embed_model`` config key or ``JCODEMUNCH_EMBED_MODEL`` env var
+    1. local_onnx             — ``onnxruntime`` installed + ONNX model present (zero-config default)
     2. Gemini                 — ``GOOGLE_API_KEY`` + ``GOOGLE_EMBED_MODEL``
     3. OpenAI                 — ``OPENAI_API_KEY`` + ``OPENAI_EMBED_MODEL``
+
+    ⚠ Only the FREE, on-machine option was promoted above the default. The paid
+    remote providers stay below it — see :func:`_detect_provider_detailed`.
+
+    Thin wrapper over :func:`_detect_provider_detailed`, kept at a two-tuple so
+    every existing caller is unchanged. Use the detailed form when the caller
+    can surface *why* a provider was chosen or what was skipped.
     """
-    # Priority 0: bundled ONNX local encoder (zero-config)
-    from ..embeddings.local_encoder import is_onnxruntime_available, is_model_available, MODEL_NAME
-    if is_onnxruntime_available() and is_model_available():
-        return ("local_onnx", MODEL_NAME)
-
-    # Global-only by design (#301): per-project embedding models would
-    # break cross-project semantic search consistency. Audit decision: if
-    # per-repo embedding model selection ever becomes a feature, _detect_provider
-    # needs a repo arg threaded from embed_repo().
-    st_model = (_config.get("embed_model", "") or os.environ.get("JCODEMUNCH_EMBED_MODEL", "")).strip()
-    if st_model:
-        return ("sentence_transformers", st_model)
-
-    google_key = os.environ.get("GOOGLE_API_KEY", "").strip()
-    google_model = os.environ.get("GOOGLE_EMBED_MODEL", "").strip()
-    if google_key and google_model:
-        return ("gemini", google_model)
-
-    openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
-    openai_model = os.environ.get("OPENAI_EMBED_MODEL", "").strip()
-    # OPENAI_API_KEY alone is used for the local-LLM summariser; require
-    # OPENAI_EMBED_MODEL to be set explicitly to avoid conflation.
-    if openai_key and openai_model:
-        return ("openai", openai_model)
-
-    return None
+    selected, _reason, _skipped = _detect_provider_detailed()
+    return selected
 
 
 # ── Eager backend warm-up (Windows loader-lock guard) ──────────────────────
@@ -283,7 +378,7 @@ def embed_repo(
     """
     start = time.perf_counter()
 
-    provider_info = _detect_provider()
+    provider_info, _provider_reason, _provider_skipped = _detect_provider_detailed()
     if provider_info is None:
         return {
             "error": "no_embedding_provider",
@@ -409,6 +504,14 @@ def embed_repo(
     }
     if doc_task_type:
         result["task_type"] = doc_task_type
+    # #488: name WHY this provider was chosen, so an index is reproducible from
+    # the record rather than by re-deriving the resolver's precedence.
+    result["provider_reason"] = _provider_reason
+    if _provider_skipped:
+        # An explicit setting we could not honour is disclosed, never dropped.
+        # Silently ignoring it is the defect #488 reported; silently failing on
+        # it at embed time would be the same defect with a louder symptom.
+        result["provider_skipped"] = _provider_skipped
     if model_changed:
         # Disclosed, not silent: a forced re-embed is expensive on a large
         # corpus and the caller did not ask for one.

--- a/tests/test_embedding_model_change.py
+++ b/tests/test_embedding_model_change.py
@@ -58,6 +58,14 @@ def embedded(tmp_path, monkeypatch):
 
         @staticmethod
         def embed(model, width, **kwargs):
+            # ⚠ Patch the DETAILED resolver: `embed_repo` calls that one, and
+            # `_detect_provider` is now a thin wrapper over it (#488). Patching
+            # the wrapper leaves the real resolver in play and the fake provider
+            # never reaches the code under test.
+            monkeypatch.setattr(
+                er, "_detect_provider_detailed",
+                lambda: (("fake_provider", model), "test_fixture", []),
+            )
             monkeypatch.setattr(
                 er, "_detect_provider", lambda: ("fake_provider", model)
             )

--- a/tests/test_explicit_embed_model_wins.py
+++ b/tests/test_explicit_embed_model_wins.py
@@ -1,0 +1,201 @@
+"""#488: an explicit local model outranks the zero-config default.
+
+`_detect_provider` returned the bundled ONNX encoder at priority 0, so once
+`[local-embed]` was installed every lower branch became unreachable *by
+configuration*. `embed_model` / `JCODEMUNCH_EMBED_MODEL` was read after the
+early return and changed nothing — no warning, no log line, no field in any
+response. The config comment documented the opposite precedence, which is how it
+stayed invisible.
+
+⚠⚠ Only the FREE, on-machine option was promoted. Gemini and OpenAI stay below
+the bundled encoder, and that is the load-bearing half of this change: see
+`tests/test_paid_embeddings_optin.py`, which exists because jdocmunch's resolver
+auto-selected OpenAI from an ambient key and began billing a remote account and
+shipping the indexed corpus off the machine. `embed_model` is free and local, so
+promoting it costs a re-embed; promoting a cloud provider costs money and
+exfiltrates the corpus. Not the same decision, not the same answer.
+"""
+
+from unittest import mock
+
+import pytest
+
+# ⚠ Module reference, not a from-import of `_detect_provider_detailed`. That
+# symbol does not exist pre-fix, so importing it by name turns the non-vacuity
+# pass into a COLLECTION ERROR — which proves the function is new and nothing
+# about the behaviour. Referencing through the module lets each test fail on its
+# own terms.
+from jcodemunch_mcp.tools import embed_repo as er
+from jcodemunch_mcp.tools.embed_repo import _detect_provider
+
+
+def _detect_provider_detailed():
+    return er._detect_provider_detailed()
+
+_ENV = (
+    "JCODEMUNCH_EMBED_MODEL",
+    "GOOGLE_API_KEY", "GOOGLE_EMBED_MODEL",
+    "OPENAI_API_KEY", "OPENAI_EMBED_MODEL",
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    for name in _ENV:
+        monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+def _with_onnx(available=True):
+    return (
+        mock.patch(
+            "jcodemunch_mcp.embeddings.local_encoder.is_onnxruntime_available",
+            return_value=available,
+        ),
+        mock.patch(
+            "jcodemunch_mcp.embeddings.local_encoder.is_model_available",
+            return_value=available,
+        ),
+    )
+
+
+def _backend(available):
+    return mock.patch(
+        "jcodemunch_mcp.tools.embed_repo._backend_available", return_value=available
+    )
+
+
+class TestAnExplicitLocalModelWins:
+    def test_embed_model_outranks_the_bundled_encoder(self, clean_env):
+        clean_env.setenv("JCODEMUNCH_EMBED_MODEL", "BAAI/bge-base-en-v1.5")
+        onnx_rt, onnx_model = _with_onnx(True)
+        with onnx_rt, onnx_model, _backend(True):
+            provider, model = _detect_provider()
+        assert provider == "sentence_transformers"
+        assert model == "BAAI/bge-base-en-v1.5"
+
+    def test_the_reason_names_why(self, clean_env):
+        clean_env.setenv("JCODEMUNCH_EMBED_MODEL", "BAAI/bge-base-en-v1.5")
+        onnx_rt, onnx_model = _with_onnx(True)
+        with onnx_rt, onnx_model, _backend(True):
+            selected, reason, skipped = _detect_provider_detailed()
+        assert selected[0] == "sentence_transformers"
+        assert reason == "embed_model"
+        assert skipped == []
+
+    def test_nothing_configured_still_gets_the_default(self, clean_env):
+        """A zero-config install must behave exactly as before."""
+        onnx_rt, onnx_model = _with_onnx(True)
+        with onnx_rt, onnx_model:
+            selected, reason, _ = _detect_provider_detailed()
+        assert selected == ("local_onnx", "all-MiniLM-L6-v2")
+        assert reason == "bundled_default"
+
+
+class TestPaidRemoteProvidersStayBelowTheDefault:
+    """⚠⚠ The half that must not move. Reversing these bills the user and sends
+    their corpus off the machine."""
+
+    @pytest.mark.parametrize(
+        "key,model_var,value",
+        [
+            ("GOOGLE_API_KEY", "GOOGLE_EMBED_MODEL", "models/embedding-001"),
+            ("OPENAI_API_KEY", "OPENAI_EMBED_MODEL", "text-embedding-3-small"),
+        ],
+    )
+    def test_a_cloud_provider_does_not_outrank_onnx(
+        self, clean_env, key, model_var, value
+    ):
+        clean_env.setenv(key, "not-a-real-key")
+        clean_env.setenv(model_var, value)
+        onnx_rt, onnx_model = _with_onnx(True)
+        with onnx_rt, onnx_model:
+            provider, _ = _detect_provider()
+        assert provider == "local_onnx", (
+            "a configured cloud provider was selected over the free on-machine "
+            "encoder — this bills the user and ships the corpus off the box"
+        )
+
+    def test_a_cloud_provider_is_still_reachable_without_onnx(self, clean_env):
+        """Below the default is not the same as removed."""
+        clean_env.setenv("OPENAI_API_KEY", "not-a-real-key")
+        clean_env.setenv("OPENAI_EMBED_MODEL", "text-embedding-3-small")
+        onnx_rt, onnx_model = _with_onnx(False)
+        with onnx_rt, onnx_model:
+            provider, model = _detect_provider()
+        assert provider == "openai"
+        assert model == "text-embedding-3-small"
+
+    def test_embed_model_still_beats_a_cloud_provider(self, clean_env):
+        """The pre-existing ordering among the explicit providers is unchanged."""
+        clean_env.setenv("JCODEMUNCH_EMBED_MODEL", "all-MiniLM-L6-v2")
+        clean_env.setenv("GOOGLE_API_KEY", "fake-key")
+        clean_env.setenv("GOOGLE_EMBED_MODEL", "models/embedding-001")
+        onnx_rt, onnx_model = _with_onnx(False)
+        with onnx_rt, onnx_model:
+            provider, _ = _detect_provider()
+        assert provider == "sentence_transformers"
+
+
+class TestAnUnusableSettingIsSkippedNotHonoured:
+    """⚠ The probe decides PRECEDENCE, never selection."""
+
+    def test_an_uninstalled_backend_does_not_displace_a_working_onnx(self, clean_env):
+        """Promoting it would trade a silently-ignored setting for an
+        ImportError at embed time — the same defect, louder."""
+        clean_env.setenv("JCODEMUNCH_EMBED_MODEL", "BAAI/bge-base-en-v1.5")
+        onnx_rt, onnx_model = _with_onnx(True)
+        with onnx_rt, onnx_model, _backend(False):
+            selected, reason, skipped = _detect_provider_detailed()
+        assert selected == ("local_onnx", "all-MiniLM-L6-v2")
+        assert reason == "bundled_default"
+        assert len(skipped) == 1
+        assert "BAAI/bge-base-en-v1.5" in skipped[0]
+        assert "jcodemunch-mcp[semantic]" in skipped[0], (
+            "the skip must name the remedy, or it is the original silent "
+            "discard with extra steps"
+        )
+
+    def test_without_onnx_the_setting_is_still_selected(self, clean_env):
+        """⚠ Probing unconditionally broke this on every machine without the
+        package. With no ONNX there is nothing to protect, and returning the
+        provider is what hands the caller the actionable pip-install error
+        instead of a bare None."""
+        clean_env.setenv("JCODEMUNCH_EMBED_MODEL", "BAAI/bge-base-en-v1.5")
+        onnx_rt, onnx_model = _with_onnx(False)
+        with onnx_rt, onnx_model, _backend(False):
+            selected, reason, skipped = _detect_provider_detailed()
+        assert selected == ("sentence_transformers", "BAAI/bge-base-en-v1.5")
+        assert reason == "embed_model"
+        assert skipped == []
+
+
+class TestTheWrapperIsUnchangedForCallers:
+    def test_detect_provider_still_returns_a_two_tuple(self, clean_env):
+        clean_env.setenv("JCODEMUNCH_EMBED_MODEL", "all-MiniLM-L6-v2")
+        onnx_rt, onnx_model = _with_onnx(False)
+        with onnx_rt, onnx_model:
+            result = _detect_provider()
+        assert isinstance(result, tuple) and len(result) == 2
+
+    def test_none_when_nothing_is_available(self, clean_env):
+        onnx_rt, onnx_model = _with_onnx(False)
+        with onnx_rt, onnx_model:
+            assert _detect_provider() is None
+
+
+class TestTheConfigCommentMatchesTheCode:
+    """The comment documenting the OPPOSITE precedence is why this stayed
+    invisible: it was the only place `embed_model` was documented."""
+
+    def test_the_comment_states_the_shipped_precedence(self):
+        import pathlib
+
+        from jcodemunch_mcp import config as config_module
+
+        text = pathlib.Path(config_module.__file__).read_text(encoding="utf-8")
+        block = text.split('// "embed_model": ""', 1)[1][:800]
+        assert "ONNX" in block, (
+            "the embed_model comment does not mention the encoder it now "
+            "outranks, which is the omission #488 reported"
+        )


### PR DESCRIPTION
Closes #488.

> ⚠ **This is narrower than the decided option A, deliberately. Read the second section before merging.**

## What was wrong

`_detect_provider` returned the bundled ONNX encoder at priority 0, so once `[local-embed]` was installed every lower branch became unreachable *by configuration*. `embed_model` / `JCODEMUNCH_EMBED_MODEL` was read after the early return and changed nothing — no warning, no log line, no field in any response. The config comment documented the opposite precedence, which is how it stayed invisible.

## Why this ships narrower than "explicit wins"

Implementing full option A turned `tests/test_paid_embeddings_optin.py` red, and that file is not incidental. Its docstring:

> A bare cloud API key must never select a paid embedding provider. […] jdoc's `get_provider_name()` auto-selected OpenAI from an ambient `OPENAI_API_KEY`, so `index_local`'s default began **billing a remote account and shipping the indexed corpus off the machine**. […] The bundled local ONNX encoder also wins at priority 0, so the common path never reaches a cloud branch at all.

That last sentence is the protection full option A removes. A developer with `[local-embed]` installed and an ambient `OPENAI_API_KEY` + `OPENAI_EMBED_MODEL` — a normal thing to have exported — would silently start paying per call and sending their source off the box.

**`embed_model` is free and on-machine; Gemini and OpenAI are paid and remote. Promoting the first costs a re-embed. Promoting the others costs money and exfiltrates the corpus.** Not the same decision.

So: `embed_model` promoted above the default, cloud providers left below it. That resolves the reporter's case completely — they want sentence-transformers to match jdocmunch, and never asked for cloud precedence. Widening it to the cloud branches is a one-line move if you want it, but I'd want that to be a deliberate reversal of the money-safety guard rather than a side effect.

## The other correction the tests forced

My first version probed backend availability unconditionally — select sentence-transformers only if the package imports. **33 tests went red**, and they were right: on any machine without the package, `JCODEMUNCH_EMBED_MODEL` stopped selecting sentence-transformers, so the caller got a bare `None` instead of the actionable `pip install 'jcodemunch-mcp[semantic]'` error.

The probe now decides **precedence only**. An uninstalled backend does not displace a *working* ONNX install; with no ONNX there is nothing to protect and the setting is selected as before.

## Disclosure

`embed_repo` now reports `provider_reason` (`embed_model` / `bundled_default` / `google_api_key` / `openai_api_key` / `none_configured`) and, when an explicit setting could not be honoured, `provider_skipped` naming it and the remedy. An explicit setting we cannot use is disclosed, never dropped — silently ignoring it is the reported defect; silently failing on it is the same defect louder.

The config comment is corrected too. It was the only place `embed_model` was documented, and "takes priority over GOOGLE_API_KEY and OPENAI_API_KEY embeddings" was true of the two it named and silent about the one that outranked it.

## Migration

If you have `[local-embed]` **and** `embed_model` set, your next `embed_repo` switches provider. v1.108.285's #500 fix detects that, forces the rebuild, and reports `model_changed_from`. Before .285 it would have left the store holding two vector widths with the newer half silently excluded from search — which is exactly why this change waited for that one.

## Verification

`tests/test_explicit_embed_model_wins.py`, 12 tests. Six red against the pre-fix resolver, **but only two of those are behavioural** — the other four fail because `_detect_provider_detailed` doesn't exist there, which is a signature fact, not evidence. The six that pass on both sides are the money-safety class and the wrapper-shape controls, pinning what must not move.

Suite: **7976 passed, 17 skipped, 0 failed**, ruff clean. Total 7993 against main's 7981 is exactly the 12 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
