### PR TITLE
fix(guide): filter `### Quick start` too (#506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 ## [Unreleased]
 
+### `### Quick start` could still recommend a disabled tool (#506, @rknighton)
+
+v1.108.286 filtered the guide's `### All tools` list by `disabled_tools` and
+profile. **`### Quick start` was six fixed strings assembled afterwards, which no
+filter reached**, so with `search_text` disabled the guide still said, as a
+numbered instruction, to call it — and `call_tool` rejected it before the handler
+ran.
+
+⚠⚠ **This is the previous fix being scoped to the section that was reported
+rather than to the property.** #495's own diagnosis was "the filtering existed
+and a second generator walked around it"; #506 is the same sentence one level
+down — the filter existed and a second *section* was not behind it. **Fixing the
+reported instance and leaving an adjacent one with the identical defect is the
+failure mode this project keeps hitting, and it has now happened inside the fix
+for it.**
+
+Quick-start steps are data now, not literal lines. A step naming a tool that will
+not dispatch is dropped whole and the remainder **renumbered**, so the list never
+shows a gap. `index_folder` and `index_repo` share one continuation line and are
+filtered individually: disabling one keeps the other, disabling both drops the
+line rather than leaving a bare "If not:" with nothing to offer.
+
+⚠⚠ **The test helper was scoped the same way and that is the durable half.**
+`_advertised()` split the content at `### All tools` and inspected only what
+followed, so it could not observe this section and would not observe the next one
+either. It now scans the whole document, which satisfies the reporter's fourth
+criterion: **a section added outside that block is covered on the commit that
+adds it.**
+
+⚠ All six names Quick Start uses are parametrized, not just the reported
+`search_text` — none of them is in `_UNDISABLEABLE_TOOLS`, so any can be
+disabled.
+
+⚠ `tests/test_guide_respects_disabled_tools.py` grows to 19; the 8 new
+quick-start cases are red against v1.108.286 with #495's fix still in place, so
+they pin this gap specifically rather than the original defect.
+
+
 ## [1.108.286] - 2026-08-18 - Three surfaces that advertised a product we were not running
 
 A config comment describing a precedence the resolver did not use, a tool schema naming three key-requiring embedding providers while hiding the free bundled one, and a guide listing a tool the same process refuses to dispatch. In each case the code was fine and the thing describing it was not.

--- a/src/jcodemunch_mcp/server.py
+++ b/src/jcodemunch_mcp/server.py
@@ -7785,6 +7785,64 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
+# Quick-start steps as DATA, not literal lines (#506).
+#
+# ⚠⚠ #495 filtered `### All tools` and left this section as six fixed strings
+# that no filter reached, so the guide could still instruct a caller to run a
+# tool `call_tool` rejects. **Fixing the reported section and leaving an
+# adjacent one with the identical defect is the failure mode this project keeps
+# hitting** — the same shape as #495's own "the filtering existed and a second
+# generator walked around it".
+#
+# Each entry is (tools named, text, alternatives). A step whose tool will not
+# dispatch is dropped whole and the remainder RENUMBERED, so the list never
+# shows a gap or an orphaned continuation line.
+_QUICK_START_STEPS: tuple[tuple[tuple[str, ...], str, tuple[tuple[str, str], ...]], ...] = (
+    (
+        ("list_repos",),
+        "`list_repos` — check if the project is indexed.",
+        (("index_folder", "local"), ("index_repo", "GitHub URL")),
+    ),
+    (
+        ("search_symbols",),
+        "`search_symbols` — find functions/classes by name or description.",
+        (),
+    ),
+    (
+        ("get_context_bundle",),
+        "`get_context_bundle` — symbol source + imports in one call.",
+        (),
+    ),
+    (
+        ("search_text",),
+        "`search_text` — full-text/regex search for literals and comments.",
+        (),
+    ),
+)
+
+
+def _quick_start_lines(active: Optional[set]) -> list[str]:
+    """Numbered quick-start steps, restricted to tools that will dispatch.
+
+    ``active`` of ``None`` means no filtering is needed and the output is
+    byte-identical to the pre-#506 literal.
+    """
+    def _ok(name: str) -> bool:
+        return active is None or name in active
+
+    out: list[str] = []
+    step = 0
+    for tools, text, alternatives in _QUICK_START_STEPS:
+        if not all(_ok(t) for t in tools):
+            continue
+        step += 1
+        out.append(f"{step}. {text}")
+        available = [f"`{t}` ({label})" for t, label in alternatives if _ok(t)]
+        if available:
+            out.append("   If not: " + " or ".join(available) + ".")
+    return out
+
+
 def _generate_claude_md_snippet(missing_only: bool = False) -> str:
     """Return the recommended CLAUDE.md prompt-policy snippet.
 
@@ -7864,11 +7922,7 @@ def _generate_claude_md_snippet(missing_only: bool = False) -> str:
         "Use jcodemunch-mcp tools instead of Grep/Read/Glob for any indexed repository.",
         "",
         "### Quick start",
-        "1. `list_repos` — check if the project is indexed.",
-        "   If not: `index_folder` (local) or `index_repo` (GitHub URL).",
-        "2. `search_symbols` — find functions/classes by name or description.",
-        "3. `get_context_bundle` — symbol source + imports in one call.",
-        "4. `search_text` — full-text/regex search for literals and comments.",
+        *_quick_start_lines(_active),
         "",
         "### All tools",
     ]

--- a/tests/test_guide_respects_disabled_tools.py
+++ b/tests/test_guide_respects_disabled_tools.py
@@ -23,11 +23,25 @@ from jcodemunch_mcp import server
 
 
 def _advertised(snippet):
-    """Tool names the guide's `### All tools` block presents as callable."""
-    if "### All tools" not in snippet:
-        return set()
-    block = snippet.split("### All tools", 1)[1]
-    return set(re.findall(r"`([a-z_0-9]+)`", block))
+    """Every tool name the guide presents as callable, ANYWHERE in it.
+
+    ⚠⚠ #506: this used to split on `### All tools` and inspect only what
+    followed, so it could not see `### Quick start` — which #495's fix left
+    unfiltered, and which went on recommending a disabled tool. **A helper
+    scoped to the section the report happened to name cannot catch the section
+    it did not.** Scanning the whole document means a section added later is
+    covered on the commit that adds it.
+    """
+    return set(re.findall(r"`([a-z_0-9]+)`", snippet))
+
+
+def _quick_start(snippet):
+    """Just the `### Quick start` block, for assertions specific to it."""
+    if "### Quick start" not in snippet:
+        return ""
+    body = snippet.split("### Quick start", 1)[1]
+    nxt = re.search(r"\n### ", body)
+    return body[: nxt.start()] if nxt else body
 
 
 def _mounted():
@@ -157,3 +171,73 @@ class TestOneFilterNotThree:
                 f"{name}: guide={in_guide} cli_policy={in_cli} — the two "
                 "generators disagree on one config in one process"
             )
+
+
+class TestQuickStartIsFilteredToo:
+    """#506: `### Quick start` was six fixed strings that no filter reached.
+
+    ⚠ Reported by @rknighton against his own #495 — that report's reproduction
+    and acceptance criteria addressed `### All tools`, the fix landed there, and
+    this is the section it did not test.
+    """
+
+    QUICK_START_TOOLS = (
+        "list_repos", "index_folder", "index_repo",
+        "search_symbols", "get_context_bundle", "search_text",
+    )
+
+    @pytest.mark.parametrize("tool", QUICK_START_TOOLS)
+    def test_a_disabled_quick_start_tool_is_not_recommended(self, cfg, tool):
+        """Every name Quick Start uses, not just the reported one — none of the
+        six is in `_UNDISABLEABLE_TOOLS`, so any can be disabled."""
+        cfg["disabled_tools"] = [tool]
+        cfg["tool_profile"] = "full"
+
+        assert f"`{tool}`" not in _quick_start(
+            server._generate_claude_md_snippet()
+        ), f"Quick start still instructs the caller to run {tool!r}"
+
+    def test_nothing_disabled_leaves_quick_start_intact(self, cfg):
+        cfg["disabled_tools"] = []
+        cfg["tool_profile"] = "full"
+
+        block = _quick_start(server._generate_claude_md_snippet())
+
+        for tool in self.QUICK_START_TOOLS:
+            assert f"`{tool}`" in block
+        assert "1. " in block and "4. " in block
+
+    def test_the_remaining_steps_are_renumbered(self, cfg):
+        """Dropping a step must not leave a gap in the numbering."""
+        cfg["disabled_tools"] = ["search_symbols"]
+        cfg["tool_profile"] = "full"
+
+        block = _quick_start(server._generate_claude_md_snippet())
+        numbers = [int(m) for m in re.findall(r"^(\d+)\. ", block, re.M)]
+
+        assert numbers == list(range(1, len(numbers) + 1)), (
+            f"quick-start numbering has a gap: {numbers}"
+        )
+
+    def test_the_continuation_line_drops_only_what_is_disabled(self, cfg):
+        """`index_folder` and `index_repo` share one continuation line; losing
+        one must not orphan the line or take the other with it."""
+        cfg["disabled_tools"] = ["index_repo"]
+        cfg["tool_profile"] = "full"
+
+        block = _quick_start(server._generate_claude_md_snippet())
+
+        assert "`index_folder`" in block
+        assert "`index_repo`" not in block
+        assert "If not:" in block, "the continuation line was dropped entirely"
+
+    def test_the_continuation_line_goes_when_both_are_disabled(self, cfg):
+        cfg["disabled_tools"] = ["index_folder", "index_repo"]
+        cfg["tool_profile"] = "full"
+
+        block = _quick_start(server._generate_claude_md_snippet())
+
+        assert "If not:" not in block, (
+            "an empty 'If not:' line survived with nothing to offer"
+        )
+        assert "`list_repos`" in block, "the step itself should remain"


### PR DESCRIPTION
Closes #506.

## What was wrong, and whose fault it is

v1.108.286 filtered the guide's `### All tools` list. **`### Quick start` was six fixed strings assembled afterwards, which no filter reached** — so with `search_text` disabled the guide still said, as a numbered instruction, to call it, and `call_tool` rejected it before the handler ran.

You're generous in framing this as "the section that report did not test." It's more precisely that **I scoped the fix to the section you reported rather than to the property.** #495's own diagnosis was *"the filtering existed and a second generator walked around it."* This is that sentence one level down: the filter existed and a second *section* was not behind it. The failure mode landed inside the fix for the failure mode.

## The fix

Quick-start steps are data now rather than literal lines. A step naming a tool that won't dispatch is dropped whole and the remainder **renumbered**, so the list never shows a gap.

`index_folder` and `index_repo` share one continuation line and are filtered individually — disabling one keeps the other, disabling both drops the line rather than leaving a bare `If not:` with nothing to offer:

```text
disabled_tools: ["test_summarizer", "search_text", "index_repo"]

1. `list_repos` — check if the project is indexed.
   If not: `index_folder` (local).
2. `search_symbols` — find functions/classes by name or description.
3. `get_context_bundle` — symbol source + imports in one call.
```

## Your fourth criterion is the durable half

`_advertised()` split the content at `### All tools` and inspected only what followed — so it couldn't observe this section, and wouldn't have observed the next one either. It now scans the whole document, which is what makes a section added later covered on the commit that adds it rather than by another round-trip through you.

All six names Quick Start uses are parametrized, not just `search_text`, since none of them is in `_UNDISABLEABLE_TOOLS`.

## Verification

Your reproduction on this branch, up to the point where it crashes — and the crash is the result:

```text
  disabled_tools            : ['test_summarizer', 'search_text']
  search_text in tools/list : False
  named in '### All tools'  : False
  named in '### Quick start': False
```

The final line of your harness does `[l for l in content.splitlines() if "`search_text`" in l][0]` and raises `IndexError`, because there is no longer any line to print.

`tests/test_guide_respects_disabled_tools.py` grows to 19. The 8 new quick-start cases are red against v1.108.286 **with #495's fix still in place**, so they pin this gap specifically rather than re-testing the original defect.

Suite: **7986 passed, 17 skipped, 0 failed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
