### PR TITLE
fix(index_file): establish repo identity and load the project overlay (#509, #508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 ## [Unreleased]
 
+### `index_file` could write a file into another repository's index (#509, #508, @rknighton)
+
+Two defects on one path, both of them the *previous* fix stopping at the call
+site that was reported.
+
+**#509 — containment is not identity.** `index_file` picked the deepest indexed
+`source_root` containing the requested file and never established that the file
+and that index were the same repository. `resolve_repo` stopped doing this in
+#492/v1.108.285; this path still did — and here the consequence is a **write**
+into an index built from a different repository with a different history, not
+merely a wrong read.
+
+⚠ The check is **imported** from `resolve_repo`, not reimplemented. Copying it is
+exactly how the two call sites diverged, and importing it also inherits #492's
+boundary for free: **a path inside a submodule still resolves to the parent**,
+because submodule content is indexed into the parent.
+
+⚠ The refusal names the repository. Falling through to "no indexed folder found
+that contains this path" would have been wrong on the facts — the parent index
+*does* contain it — and would send the caller to `index_folder` on the parent,
+which is the wrong remedy.
+
+**#508 — a keyword that was present and did nothing.** `index_file` passes
+`repo=` to `is_secret_file`, the context-provider gate and the language gate, but
+nothing on that path ever called `load_project_config`. `config.get(..., repo=)`
+reads an overlay only that function populates, so every one of those resolved to
+**global** config and the project's `.jcodemunch.jsonc` was inert.
+
+⚠⚠ **v1.108.286 threaded that keyword through six sites (#491) without checking
+anything loads the overlay it reads.** A parameter that is present and does
+nothing is indistinguishable from the defect it was added to fix.
+
+⚠ Fixed at the entry point rather than by lazy-loading inside `config.get()`.
+`load_project_config` does not cache a *miss*, so a lazy load would re-stat on
+every read for any repo without a project file — on the hottest function in the
+codebase. The entry point loads it once, and the ratchet below guards the rest.
+
+⚠⚠ **`tests/test_path_entry_point_invariants.py` is the point of this entry.**
+Both defects are the same shape reported twice, so the tests are written over
+the *entry points* rather than over the two reported functions: a path in a
+nested independent repository must not be attributed to the enclosing parent by
+**any** entry point, and a project-only setting must apply at **any** entry point
+that accepts a path. `resolve_repo` and `index_folder` are the passing controls
+in each pair, which is what proves the invariant achievable rather than
+aspirational. **A third instance now fails on the commit that introduces it.**
+
+
 ## [1.108.286] - 2026-08-18 - Three surfaces that advertised a product we were not running
 
 A config comment describing a precedence the resolver did not use, a tool schema naming three key-requiring embedding providers while hiding the free bundled one, and a guide listing a tool the same process refuses to dispatch. In each case the code was fine and the thing describing it was not.

--- a/src/jcodemunch_mcp/tools/index_file.py
+++ b/src/jcodemunch_mcp/tools/index_file.py
@@ -14,6 +14,7 @@ from ..security import validate_path, is_secret_file
 from ..storage import IndexStore
 from ..storage.index_store import _file_hash, _get_git_head, _get_git_branch
 from ._indexing_pipeline import parse_and_prepare_incremental
+from .resolve_repo import _independent_repo_between
 
 logger = logging.getLogger(__name__)
 
@@ -178,6 +179,9 @@ def index_file(
     repos = store.list_repos()
     best_match: Optional[dict] = None
     best_root_len = -1
+    # Candidates rejected for belonging to a different repository, kept so the
+    # refusal can say WHICH repository rather than "no index contains this".
+    _blocked_by_boundary: list[tuple[str, Path]] = []
 
     for repo_entry in repos:
         source_root = repo_entry.get("source_root", "")
@@ -185,11 +189,24 @@ def index_file(
             continue
         try:
             root_path = Path(source_root).resolve()
-            if file_path.is_relative_to(root_path) and len(str(root_path)) > best_root_len:
-                best_match = repo_entry
-                best_root_len = len(str(root_path))
+            if not file_path.is_relative_to(root_path):
+                continue
         except (ValueError, OSError):
             continue
+        # #509: containment is a FILESYSTEM fact; attribution needs a REPOSITORY
+        # one. `resolve_repo` stopped matching on containment alone in #492 and
+        # this path still did — where the consequence is a WRITE into an index
+        # built from a different repository, not merely a wrong read.
+        #
+        # ⚠ Imported, not reimplemented. Copying the check is exactly how these
+        # two call sites diverged in the first place.
+        _boundary = _independent_repo_between(file_path, root_path)
+        if _boundary is not None:
+            _blocked_by_boundary.append((repo_entry.get("repo", ""), _boundary))
+            continue
+        if len(str(root_path)) > best_root_len:
+            best_match = repo_entry
+            best_root_len = len(str(root_path))
 
     if best_match is None:
         sibling_error = _sibling_checkout_error(file_path, store)
@@ -198,6 +215,20 @@ def index_file(
                 "success": False,
                 "error": sibling_error,
                 "skipped": "different_working_tree",
+            }
+        if _blocked_by_boundary:
+            _enclosing, _repo_root = _blocked_by_boundary[0]
+            return {
+                "success": False,
+                "error": (
+                    f"{path} belongs to the git repository at {_repo_root}, which "
+                    f"has no index of its own. It is inside the indexed folder "
+                    f"for '{_enclosing}', but that is a different repository with "
+                    f"a different history — writing this file into it would "
+                    f"attribute one repository's source to another. Run "
+                    f"index_folder on {_repo_root} first."
+                ),
+                "skipped": "different_repository",
             }
         return {
             "success": False,
@@ -209,6 +240,17 @@ def index_file(
 
     owner, name = best_match["repo"].split("/", 1)
     source_root = Path(best_match["source_root"]).resolve()
+
+    # #508: `config.get(key, repo=...)` reads an overlay that only
+    # `load_project_config` populates, and nothing on this path called it — so
+    # every `repo=` below (is_secret_file, context_providers, language gating)
+    # silently resolved to GLOBAL config and the project's settings were inert.
+    # `index_folder` loads it for the same reason at its own walk root.
+    #
+    # ⚠ A parameter that is present and does nothing is indistinguishable from
+    # the defect it was added to fix (#491 threaded the keyword; this is the
+    # path where it never reached anything).
+    _config.load_project_config(str(source_root))
 
     # Security validation
     if not validate_path(source_root, file_path):

--- a/tests/test_path_entry_point_invariants.py
+++ b/tests/test_path_entry_point_invariants.py
@@ -1,0 +1,175 @@
+"""Two invariants every entry point that takes a filesystem path must hold.
+
+Written as a ratchet because both have now been reported twice, each time
+against a different call site of the same mechanism:
+
+**Containment is not identity.** #492 fixed `resolve_repo`, which matched on
+`source_root` containment and returned the enclosing parent index for a path
+belonging to a nested independent repository. #509 is the same logic still
+present in `index_file` — where the consequence is a *write* into the wrong
+repository's index rather than a read.
+
+**`repo=` only works if the overlay is loaded.** #491 threaded `repo=` through
+`security.py`'s exclusion resolvers. #508 is that keyword arriving on a path
+where nothing ever called `load_project_config`, so it resolves to global config
+and the project's opt-out is inert. **The parameter is present and does
+nothing**, which is indistinguishable from the defect it was added to fix.
+
+⚠ The lesson these share is the one this project keeps re-learning: fixing the
+reported call site leaves the mechanism. A ratchet over the entry points costs
+less than a third report.
+"""
+
+import json
+import subprocess
+
+import pytest
+
+from jcodemunch_mcp.tools.index_file import index_file
+from jcodemunch_mcp.tools.index_folder import index_folder
+from jcodemunch_mcp.tools.resolve_repo import resolve_repo
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", *args], cwd=str(cwd), check=True, capture_output=True, text=True
+    )
+
+
+def _make_repo(path, files):
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "repro@example.invalid")
+    _git(path, "config", "user.name", "repro")
+    for name, text in files.items():
+        (path / name).write_text(text)
+    _git(path, "add", "-A")
+    _git(path, "commit", "-q", "-m", "init")
+    return path
+
+
+class TestContainmentIsNotIdentity:
+    """A path inside a nested INDEPENDENT repository must never be attributed to
+    the enclosing indexed parent, by any entry point."""
+
+    @pytest.fixture
+    def nested(self, tmp_path):
+        store = tmp_path / "store"
+        store.mkdir()
+        parent = _make_repo(
+            tmp_path / "parent", {"marker.py": "def marker():\n    return 1\n"}
+        )
+        (parent / ".gitignore").write_text("nested-repo/\n")
+        _git(parent, "add", "-A")
+        _git(parent, "commit", "-q", "-m", "ignore nested")
+        nested = _make_repo(
+            parent / "nested-repo", {"alpha.py": "def alpha():\n    return 1\n"}
+        )
+        result = index_folder(
+            path=str(parent), identity_mode="local", use_ai_summaries=False,
+            storage_path=str(store),
+        )
+        assert result["success"] is True
+
+        class Fixture:
+            parent_repo = result["repo"]
+            parent_path = parent
+            nested_path = nested
+            store_path = str(store)
+            target = nested / "alpha.py"
+
+        return Fixture
+
+    def test_resolve_repo_does_not_claim_it(self, nested):
+        """#492, fixed in v1.108.285. The control for the entry point below."""
+        got = resolve_repo(path=str(nested.target), storage_path=nested.store_path)
+        assert got.get("repo") != nested.parent_repo or got.get("indexed") is not True
+
+    def test_index_file_does_not_write_it_into_the_parent(self, nested):
+        """#509. A read returning the wrong repo is a wrong answer; a WRITE into
+        the wrong repo corrupts an index the caller never named."""
+        result = index_file(
+            path=str(nested.target), use_ai_summaries=False,
+            storage_path=nested.store_path,
+        )
+        wrote_to = result.get("repo")
+        assert wrote_to != nested.parent_repo, (
+            f"index_file wrote {nested.target.name!r} into {wrote_to!r}, an index "
+            "built from a different repository with a different history"
+        )
+
+    def test_the_refusal_names_the_repository(self, nested):
+        """A refusal that says 'no index contains this' is wrong here — the
+        parent index does contain the path. Saying so sends the caller to
+        `index_folder` on the parent, which is the wrong remedy."""
+        result = index_file(
+            path=str(nested.target), use_ai_summaries=False,
+            storage_path=nested.store_path,
+        )
+        assert result.get("success") is False
+        assert result.get("skipped") == "different_repository"
+        assert "nested-repo" in (result.get("error") or ""), (
+            "the refusal does not name the repository the file actually "
+            f"belongs to: {result.get('error')!r}"
+        )
+
+
+class TestProjectConfigReachesEveryPathEntryPoint:
+    """`config.get(key, repo=path)` reads an overlay only
+    `load_project_config()` populates. An entry point that passes `repo=`
+    without ensuring the overlay is loaded has a parameter that does nothing."""
+
+    @pytest.fixture
+    def project(self, tmp_path):
+        store = tmp_path / "store"
+        store.mkdir()
+        proj = _make_repo(tmp_path / "proj", {"main.py": "def main():\n    return 1\n"})
+        # Matches a built-in secret rule AND has a supported extension, so it is
+        # refused unless the project's opt-out applies.
+        (proj / "settings.env.py").write_text("TOKEN = 'x'\n")
+        (proj / ".jcodemunch.jsonc").write_text(
+            json.dumps({"exclude_secret_patterns": ["settings.env.py"]}, indent=2)
+        )
+        _git(proj, "add", "-A")
+        _git(proj, "commit", "-q", "-m", "add settings")
+
+        class Fixture:
+            path = proj
+            store_path = str(store)
+            secret_file = proj / "settings.env.py"
+
+        return Fixture
+
+    def test_index_folder_honours_it(self, project):
+        """The control: this entry point calls `load_project_config` itself."""
+        result = index_folder(
+            path=str(project.path), identity_mode="local", use_ai_summaries=False,
+            storage_path=project.store_path,
+        )
+        skipped = (result.get("discovery_skip_counts") or {}).get("secret", 0)
+        assert skipped == 0, (
+            "the project's exclude_secret_patterns did not apply to index_folder"
+        )
+
+    def test_index_file_honours_it(self, project):
+        """#508. `index_file` passes `repo=` to `is_secret_file` and nothing on
+        that path ever loads the overlay the keyword reads."""
+        index_folder(
+            path=str(project.path), identity_mode="local", use_ai_summaries=False,
+            storage_path=project.store_path,
+        )
+        # Fresh overlay state: exactly what a hook-driven single-file refresh
+        # sees in a process that never walked the folder.
+        from jcodemunch_mcp import config as cfg
+
+        cfg._PROJECT_CONFIGS.clear()
+
+        result = index_file(
+            path=str(project.secret_file), use_ai_summaries=False,
+            storage_path=project.store_path,
+        )
+
+        assert result.get("success") is True, (
+            f"index_file refused a file the project's opt-out permits: "
+            f"{result.get('error')!r}"
+        )


### PR DESCRIPTION
Closes #509. Closes #508.

Two defects on one path, and both are the *previous* fix stopping at the call site that was reported. You filed them separately and they resolve together, so the ratchet is the substance of this PR.

## #509 — containment is not identity

`index_file` picked the deepest indexed `source_root` containing the file and never established that the file and that index were the same repository. `resolve_repo` stopped doing this in #492; this path still did — and here it's a **write** into an index built from a different repository, not a wrong read.

**The check is imported from `resolve_repo`, not reimplemented.** Copying it is how the two call sites diverged, and importing it inherits #492's boundary for free — your Case 3 confirms a submodule path still resolves to the parent, which it must.

The refusal names the repository rather than falling through to "no indexed folder found that contains this path". That message would be wrong on the facts — the parent index *does* contain it — and would send the caller to `index_folder` on the parent, which is the wrong remedy.

## #508 — a keyword that was present and did nothing

`index_file` passes `repo=` to `is_secret_file`, the context-provider gate and the language gate. Nothing on that path ever called `load_project_config`, and `config.get(..., repo=)` reads an overlay only that function populates — so all three resolved to global config.

**v1.108.286 threaded that keyword through six sites for #491 without checking anything loads the overlay it reads.** A parameter that is present and does nothing is indistinguishable from the defect it was added to fix.

Fixed at the entry point rather than by lazy-loading inside `config.get()`: `load_project_config` doesn't cache a *miss*, so a lazy load would re-stat on every read for any repo without a project file, on the hottest function in the codebase.

## The ratchet, which is why these are one PR

`tests/test_path_entry_point_invariants.py` is written over the **entry points**, not over the two functions you reported:

- a path inside a nested independent repository must not be attributed to the enclosing parent by *any* entry point;
- a project-only setting must apply at *any* entry point that accepts a path.

`resolve_repo` and `index_folder` are the passing controls in each pair — which is what makes the invariant demonstrably achievable rather than aspirational, and what makes the two failures specific rather than a claim that the whole area is broken. Against the pre-fix tree it reads:

```text
FAILED ...TestContainmentIsNotIdentity::test_index_file_does_not_write_it_into_the_parent
FAILED ...TestProjectConfigReachesEveryPathEntryPoint::test_index_file_honours_it
2 failed, 2 passed
```

A third instance of either now fails on the commit that introduces it, rather than arriving as your next issue.

## Verification

Your reproductions on this branch:

**#509** — Case 1 refuses (`skipped: different_repository`, nested symbol absent from the parent index); Case 2 writes into the nested repo's own index; Case 3 still writes a submodule file into the parent.

**#508** — step 3, `index_file` with a cold project cache, now returns `success=True` with no error.

Suite: **7981 passed, 17 skipped, 0 failed**, ruff clean.

## Still open from your set

#507 is not addressed here — `_get_active_tools` reconstructing the active set from `tool_profile` and baked `_PROFILE_TIERS` while `tools/list` reads three inputs it doesn't. That's a different mechanism and wants its own change. #506 is in #510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
