### PR TITLE
fix(policy): resolve the active tool set from the builder, not the tier table (#507)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 ## [Unreleased]
 
+### Both generated policies reconstructed the tool list instead of asking for it (#507, @rknighton)
+
+`_get_active_tools` rebuilt the active set from `tool_profile` and the baked
+`_PROFILE_TIERS`. `tools/list` is built by `_build_tools_list()` from three
+further inputs it never read:
+
+1. **the session tier override** — `set_tool_tier`, and also `announce_model`
+   via `resolve_model_to_tier`;
+2. **`tool_tier_bundles`**, which lets a user redefine what a tier contains;
+3. **the `languages` gate**, which drops `search_columns` when SQL is off.
+
+Two generators depend on it, so `jcodemunch_guide` and the CLAUDE.md that `init`
+writes could both name tools the server does not carry. Measured on one process:
+**70, 15 and 1** unmounted names for the three cases; all are 0 now.
+
+⚠⚠ **The first case needs no configuration at all.** `announce_model` writes the
+session tier, so an agent that announces a small model and then reads the guide
+arrives there without calling `set_tool_tier` — and `jcodemunch_guide` is in
+`_ALWAYS_PRESENT_TOOLS`, so it stays reachable at every tier. The other two are
+config-only and therefore reach `init`, whose output **is written into the
+user's CLAUDE.md and stays there.**
+
+The helper now asks `_build_tools_list()` rather than reproducing its logic.
+**This is the third instance of that shape in three days** — #495 was a second
+generator carrying its own copy of the filter, #509 a second call site with its
+own containment check, and this a second derivation of the tool set.
+
+⚠ **Filtering is a subtraction, so a wrong answer here removes guidance.** An
+empty or failed build returns `None`, meaning "do not filter": a policy naming a
+few unavailable tools is a smaller harm than a policy with no workflow left in
+it. Same shape as v1.108.209's rule that an unmeasurable comparison never
+answers `fresh`.
+
+⚠⚠ **`test_full_surface_still_honours_profile` asserted
+`active == set(_PROFILE_TIERS["core"])`** — the baked tier table, which was never
+what the server advertises, since `_ALWAYS_PRESENT_TOOLS` survives every tier.
+**It encoded the premise of the defect and could only pass while the helper
+reconstructed the answer.** It now compares against `_build_tools_list()`, and
+sets the config rather than monkeypatching `cfg.get` with a signature the real
+resolver does not have. **Fourth test this cycle found asserting the behaviour it
+should have prevented.**
+
+⚠ `tests/test_generated_policy_matches_tools_list.py` (8), 6 red against the
+pre-fix helper. ⚠ Its source-level guard walks the **AST**: the first version
+matched the literal string `_PROFILE_TIERS` and failed on the comment explaining
+why the helper must not use it — a guard that could not tell prose from code,
+the same fix the `src.` twin-import guard needed.
+
+
 ### `index_file` could write a file into another repository's index (#509, #508, @rknighton)
 
 Two defects on one path, both of them the *previous* fix stopping at the call

--- a/src/jcodemunch_mcp/cli/init.py
+++ b/src/jcodemunch_mcp/cli/init.py
@@ -733,23 +733,39 @@ def _get_active_tools() -> set[str] | None:
     through the tool list.
     """
     try:
-        from ..config import get as cfg_get
-        from ..server import _PROFILE_TIERS, _CANONICAL_TOOL_NAMES
+        from ..server import _build_tools_list
     except Exception:
+        logger.debug("could not import the tool-list builder", exc_info=True)
         return None
 
     if _effective_tool_surface() == "counter":
         return set(_front_door_tool_names())
 
-    profile = cfg_get("tool_profile", "full")
-    tier = _PROFILE_TIERS.get(profile)
-    disabled = set(cfg_get("disabled_tools", []))
+    # ⚠⚠ ASK the builder; do not reconstruct its answer (#507). This used to
+    # rebuild the active set from `tool_profile` + the baked `_PROFILE_TIERS`,
+    # which omits three inputs `tools/list` actually reads:
+    #   1. the SESSION tier override — `set_tool_tier`, and also `announce_model`
+    #      via `resolve_model_to_tier`, so an agent that announces a small model
+    #      and then reads the guide diverges without configuring anything;
+    #   2. `tool_tier_bundles`, which lets a user redefine what a tier contains;
+    #   3. the `languages` gate, which drops `search_columns` when SQL is off.
+    # Measured on one process: 70, 15 and 1 unmounted names respectively, and
+    # the `init` half of the last two is written into the user's CLAUDE.md and
+    # stays there.
+    try:
+        active = {t.name for t in _build_tools_list()}
+    except Exception:
+        logger.debug("tool-list build failed; not filtering", exc_info=True)
+        return None
 
-    if tier is None and not disabled:
-        return None  # full profile, nothing disabled
-
-    active = set(_CANONICAL_TOOL_NAMES) if tier is None else set(tier)
-    active -= disabled
+    # ⚠ An empty answer must not filter the policy down to nothing. `None` means
+    # "no filtering", which is the safe direction: a policy naming a few
+    # unavailable tools is a smaller harm than a policy with no workflow left in
+    # it. Same shape as v1.108.209's rule that an unmeasurable comparison never
+    # answers `fresh`.
+    if not active:
+        logger.debug("tool-list build returned nothing; not filtering")
+        return None
     return active
 
 

--- a/tests/test_generated_policy_matches_tools_list.py
+++ b/tests/test_generated_policy_matches_tools_list.py
@@ -1,0 +1,172 @@
+"""#507: the generated policies reconstructed the active tool set instead of asking.
+
+`_get_active_tools` rebuilt the answer from `tool_profile` and the baked
+`_PROFILE_TIERS`, while `tools/list` is built by `_build_tools_list()` from three
+further inputs it never read:
+
+1. the **session tier override** — `set_tool_tier`, and also `announce_model` via
+   `resolve_model_to_tier`, so an agent that announces a small model and then
+   reads the guide diverges without configuring anything;
+2. `tool_tier_bundles`, which lets a user redefine what a tier contains;
+3. the `languages` gate, which drops `search_columns` when SQL is off.
+
+Two generators depend on it — `jcodemunch_guide` and the CLAUDE.md `init` writes
+— so both could name tools `tools/list` does not carry. The `init` half is
+written into the user's file and stays there.
+
+⚠ The fix is to ask the builder rather than reproduce its logic. This is the
+third instance of that shape in as many days: #495 (a second generator with its
+own copy of the filter), #509 (a second call site with its own containment
+check), and now a second *derivation* of the tool set.
+"""
+
+import re
+
+import pytest
+
+from jcodemunch_mcp import config as config_module
+from jcodemunch_mcp import server
+from jcodemunch_mcp.cli.init import _get_active_tools, active_policy
+
+
+def _mounted():
+    return {t.name for t in server._build_tools_list()}
+
+
+def _guide_catalogue():
+    snippet = server._generate_claude_md_snippet()
+    if "### All tools" not in snippet:
+        return set()
+    return set(re.findall(r"`([a-z_0-9]+)`", snippet.split("### All tools", 1)[1]))
+
+
+def _policy_names():
+    policy = active_policy()
+    return {n for n in server._CANONICAL_TOOL_NAMES if f"`{n}`" in policy}
+
+
+@pytest.fixture
+def cfg():
+    c = config_module._GLOBAL_CONFIG
+    keys = ("tool_profile", "tool_surface", "disabled_tools",
+            "tool_tier_bundles", "languages")
+    original = {k: c.get(k) for k in keys}
+    yield c
+    for k, v in original.items():
+        if v is None:
+            c.pop(k, None)
+        else:
+            c[k] = v
+    server._reset_session_tiers()
+
+
+class TestNeitherGeneratorNamesAnUnmountedTool:
+    """One property, four states. The generators must agree with `tools/list`
+    in each, whatever decided it."""
+
+    def test_a_baseline_is_the_control(self, cfg):
+        cfg["tool_profile"] = "full"
+        assert not (_guide_catalogue() - _mounted())
+        assert not (_policy_names() - _mounted())
+
+    def test_b_a_session_tier_override(self, cfg):
+        """⚠ Needs no configuration at all. `announce_model` writes the session
+        tier through `resolve_model_to_tier`, so an agent that announces a small
+        model and then reads the guide arrives here without ever calling
+        `set_tool_tier`. `jcodemunch_guide` is in `_ALWAYS_PRESENT_TOOLS`, so it
+        stays reachable at every tier."""
+        cfg["tool_profile"] = "full"
+        server._set_session_tier("core")
+
+        ghosts = _guide_catalogue() - _mounted()
+
+        assert not ghosts, (
+            f"the guide names {len(ghosts)} tools tools/list does not carry "
+            f"under a session tier override: {sorted(ghosts)[:4]}"
+        )
+
+    def test_c_a_custom_tool_tier_bundle(self, cfg):
+        """A user may redefine what a tier contains; the baked `_PROFILE_TIERS`
+        does not know that."""
+        cfg["tool_profile"] = "core"
+        cfg["tool_tier_bundles"] = {"core": ["list_repos", "search_symbols"]}
+
+        assert not (_guide_catalogue() - _mounted())
+        assert not (_policy_names() - _mounted()), (
+            "the CLAUDE.md written into the user's project names unmounted tools"
+        )
+
+    def test_d_the_languages_gate(self, cfg):
+        """`search_columns` leaves the tool list when SQL is gated off, and no
+        tier or disabled_tools entry says so."""
+        cfg["tool_profile"] = "full"
+        cfg["languages"] = ["python"]
+
+        mounted = _mounted()
+        assert "search_columns" not in mounted, "precondition: the gate applies"
+        assert "search_columns" not in _guide_catalogue()
+        assert "search_columns" not in _policy_names()
+
+
+class TestTheSafeDirection:
+    """⚠ Filtering is a subtraction, so a wrong answer here removes guidance.
+    An unanswerable question must not empty the policy."""
+
+    def test_an_empty_build_does_not_filter_everything(self, cfg, monkeypatch):
+        monkeypatch.setattr(server, "_build_tools_list", lambda: [])
+        assert _get_active_tools() is None, (
+            "an empty tool list filtered the policy instead of leaving it alone"
+        )
+
+    def test_a_failing_build_does_not_filter_everything(self, cfg, monkeypatch):
+        def boom():
+            raise RuntimeError("no")
+
+        monkeypatch.setattr(server, "_build_tools_list", boom)
+        assert _get_active_tools() is None
+
+    def test_the_policy_still_has_a_workflow_when_the_build_fails(
+        self, cfg, monkeypatch
+    ):
+        """`None` means 'do not filter', so the policy survives whole."""
+        monkeypatch.setattr(server, "_build_tools_list", lambda: [])
+        assert "`search_symbols`" in active_policy()
+
+
+class TestItAsksRatherThanReconstructs:
+    def test_the_helper_reads_the_builder(self):
+        """⚠ Checked over the AST, not the source text.
+
+        The first version of this test matched the literal string
+        `_PROFILE_TIERS` and failed on the COMMENT that explains why the helper
+        must not use it — a guard that cannot tell prose from code. The same
+        mistake the `src.` twin-import guard had to fix. `ast` does not see
+        comments at all, so the question it answers is the intended one:
+        does this function REFERENCE that table?
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        from jcodemunch_mcp.cli import init as init_mod
+
+        tree = ast.parse(
+            textwrap.dedent(inspect.getsource(init_mod._get_active_tools))
+        )
+        referenced = {
+            node.id for node in ast.walk(tree) if isinstance(node, ast.Name)
+        } | {
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+            for alias in node.names
+        }
+
+        assert "_build_tools_list" in referenced, (
+            "the active set is being reconstructed rather than read from the "
+            "function that builds tools/list"
+        )
+        assert "_PROFILE_TIERS" not in referenced, (
+            "reconstructing from the baked tier table is what #507 was: it "
+            "cannot see session overrides, custom bundles or the language gate"
+        )

--- a/tests/test_init_policy_matches_surface.py
+++ b/tests/test_init_policy_matches_surface.py
@@ -22,6 +22,7 @@ import re
 import pytest
 
 from jcodemunch_mcp.cli import init as I
+import jcodemunch_mcp.server as server_module
 
 # Matches the ways the policies name a tool: `name`, `name {`, `name(`.
 _NAMED = re.compile(r"`([a-z_][a-z0-9_]*)[`(\s{]")
@@ -104,16 +105,31 @@ def test_active_tools_ignores_profile_when_the_surface_is_the_front_door(surface
 
 
 def test_full_surface_still_honours_profile(surface, monkeypatch):
+    """A non-full profile must still filter, and to what `tools/list` carries.
+
+    ⚠ #507: this asserted ``active == set(_PROFILE_TIERS["core"])`` — the baked
+    tier table. That was never what the server advertises: `_ALWAYS_PRESENT_TOOLS`
+    survives every tier, and `tool_tier_bundles` can redefine a tier outright.
+    **The test encoded the premise of the defect**, so it could only pass while
+    the helper reconstructed the answer instead of asking for it.
+
+    It also monkeypatched `cfg.get` with a two-argument signature, which the real
+    resolver does not have; setting the config exercises the actual path.
+    """
     surface("full")
     from jcodemunch_mcp import config as cfg
-    monkeypatch.setattr(
-        cfg, "get",
-        lambda k, d=None: "core" if k == "tool_profile" else ([] if k == "disabled_tools" else d),
-    )
+    from jcodemunch_mcp.server import _build_tools_list
+
+    monkeypatch.setitem(cfg._GLOBAL_CONFIG, "tool_profile", "core")
+    monkeypatch.setitem(cfg._GLOBAL_CONFIG, "disabled_tools", [])
+
     active = I._get_active_tools()
+
     assert active is not None, "a non-full profile must still filter"
-    from jcodemunch_mcp.server import _PROFILE_TIERS
-    assert active == set(_PROFILE_TIERS["core"])
+    assert active == {t.name for t in _build_tools_list()}
+    assert len(active) < len(server_module._CANONICAL_TOOL_NAMES), (
+        "the profile did not narrow anything"
+    )
 
 
 # ── config is loaded before anything is generated ─────────────────────────


### PR DESCRIPTION
Closes #507.

## What was wrong

`_get_active_tools` rebuilt the active set from `tool_profile` and the baked `_PROFILE_TIERS`. `tools/list` is built by `_build_tools_list()` from three further inputs it never read — the session tier override, `tool_tier_bundles`, and the `languages` gate on `search_columns`.

Your four-state harness is the clearest possible statement of it, and state A being clean is what isolates this to how the active set was decided rather than to either template. All four now report 0:

| State | Before | After |
|---|---|---|
| A. baseline | 0 | 0 |
| B. session tier override | 70 unmounted | 0 |
| C. custom `tool_tier_bundles.core` | 15 (guide) / 9 (`init`) | 0 / 0 |
| D. `languages: ["python"]` | 1 | 0 |

Your note that **B needs no configuration** is the part that raised its priority for me: `announce_model` writes the session tier through `resolve_model_to_tier`, so an agent that announces a small model and then reads the guide arrives there without ever calling `set_tool_tier` — and `jcodemunch_guide` is in `_ALWAYS_PRESENT_TOOLS`, so it stays reachable at every tier. Reporting the `init` column as `n/a` there rather than as a zero was the right call and saved me checking it.

## The fix

Ask `_build_tools_list()` instead of reproducing its logic. **This is the third instance of that shape in three days** — #495 was a second generator with its own copy of the filter, #509 a second call site with its own containment check, and this a second derivation of the tool set.

**Filtering is a subtraction**, so a wrong answer here removes guidance rather than adding noise. An empty or failed build returns `None`, meaning "do not filter": a policy naming a few unavailable tools is a smaller harm than a policy with no workflow left in it. Two tests pin that direction.

## An existing test was asserting the defect

`test_full_surface_still_honours_profile` asserted `active == set(_PROFILE_TIERS["core"])`. That was never what the server advertises — `_ALWAYS_PRESENT_TOOLS` survives every tier and `tool_tier_bundles` can redefine one outright. **It encoded the premise of the defect and could only pass while the helper reconstructed the answer.** It now compares against the built list, and sets the config rather than monkeypatching `cfg.get` with a two-argument signature the real resolver doesn't have.

That's the fourth test in this cycle found asserting the behaviour it should have prevented.

## One note on my own test

Its source-level guard walks the **AST**. The first version matched the literal string `_PROFILE_TIERS` and failed on the comment explaining why the helper must not use it — a guard that couldn't tell prose from code, which is the same fix the `src.` twin-import guard needed. `ast` doesn't see comments, so it answers the intended question.

`tests/test_generated_policy_matches_tools_list.py`, 8 tests, **6 red against the pre-fix helper** — all three of your states plus both safe-direction guards.

Suite: **7989 passed, 17 skipped, 0 failed**, ruff clean.

That closes all four of your reports from last night: #506 (#510), #508 and #509 (#511), and this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
