### PR TITLE
test(index_folder): three #504 cases beyond #513's coverage

### DIFF
--- a/tests/test_repeat_root_walk_additional.py
+++ b/tests/test_repeat_root_walk_additional.py
@@ -1,0 +1,128 @@
+"""Three cases #513 does not reach.
+
+@lsg1103275794's fix and tests for #504 are correct and merged; these are
+additions to that work, written independently while our fallback path was kept
+warm, and kept because each pins something their two cases leave open.
+
+⚠ The first is the control that matters most: a no-change path that is simply
+*always* taken would satisfy every "second run is incremental" assertion and
+index nothing.
+"""
+
+import subprocess
+
+import pytest
+
+from jcodemunch_mcp.tools.index_folder import index_folder
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", *args], cwd=str(cwd), check=True, capture_output=True, text=True
+    )
+
+
+@pytest.fixture
+def repo(tmp_path):
+    work = tmp_path / "demo"
+    work.mkdir()
+    store = tmp_path / "store"
+    store.mkdir()
+    _git(work, "init", "-q")
+    _git(work, "config", "user.email", "repro@example.invalid")
+    _git(work, "config", "user.name", "repro")
+    _git(work, "remote", "add", "origin", "https://github.com/acme/demo.git")
+    (work / "main.py").write_text("def main():\n    return 1\n")
+    (work / "pkg").mkdir()
+    (work / "pkg" / "mod.py").write_text("def mod():\n    return 2\n")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-q", "-m", "A")
+
+    class Repo:
+        path = work
+        store_path = str(store)
+
+        @staticmethod
+        def index(**kwargs):
+            return index_folder(
+                str(work), use_ai_summaries=False, storage_path=str(store),
+                identity_mode="git", **kwargs,
+            )
+
+        @staticmethod
+        def index_subdir(rel, **kwargs):
+            return index_folder(
+                str(work / rel), use_ai_summaries=False, storage_path=str(store),
+                identity_mode="git", **kwargs,
+            )
+
+    return Repo
+
+
+class TestCasesBeyond513:
+    def test_a_real_edit_is_still_picked_up(self, repo):
+        """Control against the obvious wrong fix — taking the no-change path
+        unconditionally would satisfy every assertion above and index nothing."""
+        repo.index()
+        (repo.path / "main.py").write_text("def main_v2():\n    return 99\n")
+
+        result = repo.index()
+
+        assert result["performed_incremental"] is True
+        assert result.get("message") != "No changes detected"
+
+        from jcodemunch_mcp.tools.search_symbols import search_symbols
+
+        found = search_symbols(
+            repo=result["repo"], query="main_v2", storage_path=repo.store_path,
+            detail_level="compact", max_results=5,
+        )
+        names = {r["name"] for r in (found.get("results") or found.get("symbols") or [])}
+        assert "main_v2" in names, "the edit was not indexed"
+
+
+    def test_a_subdir_walk_still_merges(self, repo):
+        """The behaviour the guard was written for must not move: a subdir walk
+        carries over files outside its prefix rather than pruning them."""
+        repo.index()
+        repo.index_subdir("pkg")
+
+        from jcodemunch_mcp.tools.get_file_content import get_file_content
+
+        resolved = repo.index()
+        got = get_file_content(
+            repo=resolved["repo"], file_path="main.py",
+            storage_path=repo.store_path,
+        )
+        assert got.get("content"), (
+            "a subdir walk dropped a file outside its prefix — the carry-over "
+            "the collision guard exists for"
+        )
+
+
+    def test_an_index_without_source_roots_rebuilds_once(self, repo, monkeypatch):
+        """A legacy index carrying no `source_roots` has unknown coverage, and
+        unknown is not full. One rebuild resolves it rather than diffing a full
+        corpus against a marker that says nothing."""
+        from jcodemunch_mcp.storage import IndexStore
+
+        repo.index()
+        store = IndexStore(base_path=repo.store_path)
+        result = repo.index()
+        assert result["performed_incremental"] is True  # precondition
+
+        real_load = store.__class__.load_index
+
+        def load_without_roots(self, owner, name, *a, **kw):
+            index = real_load(self, owner, name, *a, **kw)
+            if index is not None:
+                index.source_roots = []
+            return index
+
+        monkeypatch.setattr(store.__class__, "load_index", load_without_roots)
+
+        degraded = repo.index()
+
+        assert degraded["performed_incremental"] is not True, (
+            "an index with unknown coverage was treated as full coverage"
+        )


### PR DESCRIPTION
Follow-up to #513 (@lsg1103275794), as promised on that review. **Additions to their work, not corrections to it** — all three pass against their implementation unchanged.

Their two tests cover the core case and the subdir→full-root transition, and the second one asserts the `source_roots` marker moving `["packages"]` → `[""]` directly, which is a better test than the behavioural equivalent I'd written. These three pin what those two leave open:

- **`test_a_real_edit_is_still_picked_up`** — the control that matters most. A no-change path that is simply *always* taken would satisfy every "second run is incremental" assertion in the file and index nothing. This one edits a file between runs and asserts the new symbol is searchable.
- **`test_a_subdir_walk_still_merges`** — the behaviour the collision guard exists for. The fix narrows when `_merge_with_existing` is assigned, so it's worth pinning that a subdir walk still carries over files outside its prefix.
- **`test_an_index_without_source_roots_rebuilds_once`** — unknown coverage is not full coverage. A legacy index with no `source_roots` must rebuild rather than be treated as already full-root. Their `!= {""}` set comparison handles this correctly; nothing asserted it.

These were written overnight without sight of their patch, while keeping our own path warm under policy 3. Their PR arrived inside the window so the fix is theirs; this is the part of that parallel work worth keeping.

Suite: **8004 passed, 17 skipped, 0 failed**, ruff clean. +3 over main, exactly these three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
