### PR TITLE
docs(config): the documented `disabled_tools` default was not the shipped one (#515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## [Unreleased]
 
+### `CONFIGURATION.md` gave the wrong default for `disabled_tools` (#515, @rknighton)
+
+The Tools table documented the default as `[]`. The shipped default is
+`["test_summarizer"]`, so a reader following the reference page expected all 91
+canonical tools in the schema and got 90.
+
+Three other surfaces state it correctly — the generated config template writes
+`// Default: test_summarizer disabled` above the key, `config --init` carries the
+same comment, and `test_guide_respects_disabled_tools.py` pins
+`DEFAULTS["disabled_tools"] == ["test_summarizer"]`. The reference table was the
+only one that disagreed, and it is the page a user opens when a tool they
+expected is missing.
+
+The row now spells the value out and names the tool, so the 90-of-91 count is
+explained where it is discovered.
+
+⚠ **`tool_tier_bundles` was wrong the same way and the reporter said so while
+scoping it out**: documented `{}`, ships populated. Nothing observable changed
+because the shipped value is set-identical to the `_TOOL_TIER_CORE` /
+`_TOOL_TIER_STANDARD` fallback the row already described. Fixed here too — a cell
+that is accidentally harmless is still a cell that will be read.
+
+⚠⚠ **The deliverable is `tests/test_configuration_md_defaults.py`, written over
+the TABLE rather than the two reported rows.** It parses every `Default` column
+in the document and compares each cell against `config.DEFAULTS`, so the next key
+someone documents is covered on the commit that documents it. 3 red against the
+pre-fix document, 63 green after.
+
+⚠ **The exemption is load-bearing, not a hole.** `tool_tier_bundles` cannot be
+inlined, so its cell is prose — and the test asserts its repr is genuinely too
+long to fit, which means a small wrong value cannot hide behind the same escape
+hatch, plus it asserts the claim the prose makes (that the bundles carry the
+built-in tier names) rather than trusting it.
+
 ### A full-root re-walk was treated as a subdir merge, so every repeat index rebuilt the corpus (#504, @lsg1103275794)
 
 The v1.96 collision guard assigned `_merge_with_existing` whenever an existing

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -101,10 +101,10 @@ The full list of supported language identifiers matches the values in `LANGUAGE_
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `disabled_tools` | list | `[]` | Tool names to remove from `list_tools()` schema. Project-level disabling also blocks execution via `call_tool()`. |
+| `disabled_tools` | list | `["test_summarizer"]` | Tool names to remove from `list_tools()` schema. Ships with `test_summarizer` disabled — it is a diagnostic that probes the AI summarizer — so out of the box the schema carries 90 of the 91 canonical tools. Delete it from the list to expose it. Project-level disabling also blocks execution via `call_tool()`. |
 | `descriptions` | dict | `{}` | Override tool and parameter descriptions. See [Descriptions](#descriptions) below. |
 | `tool_profile` | string | `"full"` | Which tool tier `list_tools()` exposes: `core`, `standard`, or `full`. New installs are *initialized* to the compact core tier by `init`/`install` writing this key; the in-code fallback stays `"full"` so existing installs are unaffected. `set_tool_tier` switches tiers in-session without editing config; `jcodemunch_guide` is present at every tier. |
-| `tool_tier_bundles` | dict | `{}` | Override the tool lists per tier (`{"core": [...], "standard": [...]}`). Missing or malformed entries fall back to the built-in tier constants. |
+| `tool_tier_bundles` | dict | the built-in tiers (`{"core": [...], "standard": [...]}`, too long to inline) | Override the tool lists per tier. Ships populated with the same names as the built-in `_TOOL_TIER_CORE` / `_TOOL_TIER_STANDARD` constants, so the shipped value and the fallback agree. Missing or malformed entries fall back to those constants. |
 | `adaptive_tiering` | bool | `false` | Let the server recommend tier switches based on observed usage. Off = tiers only change when explicitly switched. |
 | `allow_disabling_tier_controls` | bool | `false` | By default the tier-control tools can't be removed via `disabled_tools` (a config typo could otherwise strand a session in a tier). Set `true` to allow disabling them anyway. |
 | `compact_schemas` | bool | `false` | Emit compacted tool schemas (stripped/demoted params). The core tier enables compaction in practice; its full schema payload is held under a CI-enforced 4,000-token ceiling. |

--- a/tests/test_configuration_md_defaults.py
+++ b/tests/test_configuration_md_defaults.py
@@ -1,0 +1,129 @@
+"""CONFIGURATION.md's `Default` column must agree with `config.DEFAULTS`.
+
+Issue #515: the `disabled_tools` row read `[]` while the shipped default has
+been `["test_summarizer"]` since it was introduced. Three other surfaces state
+that default correctly (the generated config template, the `config --init`
+comment, and `test_guide_respects_disabled_tools.py`'s pin); the reference
+table was the only one that disagreed, and it is the page a user consults when
+a tool they expected is missing from the schema.
+
+This is written over the TABLE, not over the two reported rows: a row-specific
+assertion would have said nothing about the next key someone documents.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from jcodemunch_mcp.config import DEFAULTS
+from jcodemunch_mcp.server import _TOOL_TIER_CORE, _TOOL_TIER_STANDARD
+
+_DOC = Path(__file__).resolve().parents[1] / "CONFIGURATION.md"
+_HEADER = "| Key | Type | Default | Description |"
+
+# Keys whose real default is too large to inline in a table cell. An entry here
+# is NOT a licence to write prose — each one carries a check below that proves
+# the documented cell tells the truth, and `test_non_literal_defaults_are_big`
+# proves the escape hatch cannot be used to hide a small wrong value.
+_NON_LITERAL_DEFAULTS = frozenset({"tool_tier_bundles"})
+
+# A default whose repr is shorter than this fits in a cell, so it must be
+# spelled out rather than described.
+_INLINEABLE_REPR_CHARS = 200
+
+
+def _documented_rows() -> list[tuple[str, str, str]]:
+    """(key, type_cell, default_cell) for every row of every `Default` table."""
+    rows: list[tuple[str, str, str]] = []
+    in_table = False
+    for line in _DOC.read_text(encoding="utf-8").splitlines():
+        if line.startswith(_HEADER):
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if not line.startswith("|"):
+            in_table = False
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) < 4 or set("".join(cells)) <= set("-: "):
+            continue
+        rows.append((cells[0].strip("`"), cells[1], cells[2]))
+    return rows
+
+
+_ROWS = _documented_rows()
+_LITERAL_ROWS = [r for r in _ROWS if r[0] not in _NON_LITERAL_DEFAULTS]
+
+
+def test_the_tables_were_actually_found() -> None:
+    """Guard against a silent parse failure reporting a vacuous pass."""
+    assert len(_ROWS) > 50, f"only {len(_ROWS)} rows parsed from {_DOC.name}"
+    assert any(k == "disabled_tools" for k, _, _ in _ROWS)
+
+
+@pytest.mark.parametrize("key,default_cell", [(k, d) for k, _, d in _LITERAL_ROWS])
+def test_documented_default_matches_the_shipped_default(key: str, default_cell: str) -> None:
+    assert key in DEFAULTS, f"CONFIGURATION.md documents `{key}`, which is not in DEFAULTS"
+    literal = default_cell.strip()
+    assert literal.startswith("`") and literal.endswith("`"), (
+        f"`{key}` documents its default as {default_cell!r} rather than a "
+        "backticked literal; add it to _NON_LITERAL_DEFAULTS with a check if "
+        "the real value cannot be inlined"
+    )
+    try:
+        documented = json.loads(literal.strip("`"))
+    except ValueError:  # pragma: no cover - a malformed cell is the failure
+        pytest.fail(f"`{key}`'s Default cell {literal} is not a JSON literal")
+    assert documented == DEFAULTS[key], (
+        f"CONFIGURATION.md says `{key}` defaults to {documented!r}; "
+        f"config.DEFAULTS says {DEFAULTS[key]!r}"
+    )
+
+
+@pytest.mark.parametrize("key", sorted(_NON_LITERAL_DEFAULTS))
+def test_non_literal_defaults_are_big(key: str) -> None:
+    """The escape hatch only covers values a table cell genuinely cannot hold."""
+    assert len(repr(DEFAULTS[key])) > _INLINEABLE_REPR_CHARS, (
+        f"`{key}` is exempt from the literal check but its default fits in a "
+        "cell — spell it out instead of describing it"
+    )
+
+
+@pytest.mark.parametrize("key", sorted(_NON_LITERAL_DEFAULTS))
+def test_non_literal_defaults_are_documented(key: str) -> None:
+    assert any(k == key for k, _, _ in _ROWS), f"`{key}` is exempt but has no row"
+
+
+def test_tool_tier_bundles_ships_the_built_in_tiers() -> None:
+    """The claim its cell makes, asserted rather than trusted.
+
+    The row says the shipped bundles carry the same names as the built-in
+    constants. If that ever stops being true the cell becomes wrong in the way
+    #515 was wrong, and no literal comparison would catch it.
+    """
+    bundles = DEFAULTS["tool_tier_bundles"]
+    assert sorted(bundles) == ["core", "standard"]
+    assert set(bundles["core"]) == set(_TOOL_TIER_CORE)
+    assert set(bundles["standard"]) == set(_TOOL_TIER_STANDARD)
+
+    row = next(d for k, _, d in _ROWS if k == "tool_tier_bundles")
+    assert row.strip() != "`{}`", "the empty-dict cell is the #515 defect"
+
+
+def test_disabled_tools_row_names_the_tool_it_disables() -> None:
+    """Acceptance criterion 2: a reader can tell why 90 of 91 tools mount."""
+    key, _, default_cell = next(r for r in _ROWS if r[0] == "disabled_tools")
+    assert json.loads(default_cell.strip().strip("`")) == DEFAULTS["disabled_tools"]
+    description = next(
+        line for line in _DOC.read_text(encoding="utf-8").splitlines()
+        if line.startswith("| `disabled_tools` |")
+    )
+    for name in DEFAULTS["disabled_tools"]:
+        assert re.search(rf"\b{re.escape(name)}\b", description), (
+            f"the row does not name `{name}`"
+        )


### PR DESCRIPTION
Closes #515. Reported by @rknighton.

## What was wrong

`CONFIGURATION.md`'s Tools table documented `disabled_tools` as defaulting to
`[]`. The shipped default is `["test_summarizer"]`, so a reader following the
reference page expected all 91 canonical tools in the schema and got 90.

Three other surfaces state it correctly — the generated config template, the
`config --init` comment, and `test_guide_respects_disabled_tools.py`'s pin on
`DEFAULTS["disabled_tools"]`. The reference table was the only one that
disagreed, and it is the page a user opens when a tool they expected is missing.

The row now spells the value out and names the tool, so the 90-of-91 count is
explained where it is discovered.

## `tool_tier_bundles` is fixed too

The report scoped it out on the grounds that nothing observable changes: the
shipped value is set-identical to the `_TOOL_TIER_CORE` / `_TOOL_TIER_STANDARD`
fallback the row already described, so the row still predicts the behaviour. That
is right about the behaviour. A cell that is accidentally harmless is still a
cell that will be read, and the ratchet below would have had to carry it as an
unexplained exception otherwise.

## The deliverable is the ratchet, not the two rows

`tests/test_configuration_md_defaults.py` parses every `| Key | Type | Default |
Description |` table in the document and compares each cell against
`config.DEFAULTS`. Written over the table rather than over the two reported rows,
so the next key someone documents is covered on the commit that documents it.

**3 red against the pre-fix document, 63 green after.** The reds are the
`disabled_tools` literal comparison, the `tool_tier_bundles` empty-dict cell, and
the acceptance-criterion check that the row names the tool it disables.

The one exemption is load-bearing rather than a hole. `tool_tier_bundles` cannot
be inlined, so its cell is prose — and the test asserts its repr is genuinely too
long to fit in a cell, which stops a small wrong value hiding behind the same
escape hatch, and separately asserts the claim the prose makes (that the bundles
carry the built-in tier names) instead of trusting it.

## Verification

- Suite: **8067 passed, 17 skipped, 0 failed** (`uv run pytest tests/ -n 4 --dist loadfile`)
- `uv run ruff check src/` clean
- Same-tree collect: 8084 with the new file, 8021 without = exactly its 63, so nothing else moved

🤖 Generated with [Claude Code](https://claude.com/claude-code)