### PR TITLE
fix(packaging): declare PEP 639 license expression for PyPI allowlisting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ requires-python = ">=3.10"
 authors = [
     { name = "J. Gravelle", email = "j@gravelle.us" },
 ]
-license = { file = "LICENSE" }
+license = "LicenseRef-jCodeMunch-Dual-Use-1.1"
+license-files = ["LICENSE"]
 keywords = [
     "mcp",
     "model-context-protocol",
@@ -23,7 +24,6 @@ keywords = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: Other/Proprietary License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
## Human summary

We have a commercial license, but are currently unable to allowlist the license for this package because `license = { file = "LICENSE" }` makes PyPI put the full LICENSE file text into info.license instead of a license name. I therefore propose adding a PEP 639-compliant license identifier (info.license_expression) instead, which can be allowlisted by package ingestion systems. An alternative I considered was setting info.license to a simple string that would easily identify the license in a way that allows for freeform allowlisting. Let me know if you would prefer that approach.

## Summary
PyPI ingestion was treating `license = { file = "LICENSE" }` as the full LICENSE file text, so the dual-use license could not be allowlisted by identifier.

This switches packaging metadata to PEP 639:
- `license = "LicenseRef-jCodeMunch-Dual-Use-1.1"`
- `license-files = ["LICENSE"]`
- drops the deprecated `License :: Other/Proprietary License` classifier (Hatch/setuptools still want that gone when a license expression is present)

`uv build` emits `License-Expression` / `License-File` as expected. The LICENSE file itself is unchanged.

## Test plan
- [x] Confirm `pyproject.toml` has `license` as the LicenseRef expression and `license-files = ["LICENSE"]`
- [x] `uv build` and check the wheel/sdist metadata for `License-Expression: LicenseRef-jCodeMunch-Dual-Use-1.1` and `License-File: LICENSE`
- [x] Confirm no `License ::` classifier remains
