### PR TITLE
fix(packaging): one license identifier across all three surfaces (#517)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/jgravelle/jcodemunch-mcp#readme",
   "repository": "https://github.com/jgravelle/jcodemunch-mcp",
-  "license": "LicenseRef-Dual-Use",
+  "license": "LicenseRef-jCodeMunch-Dual-Use-1.1",
   "keywords": [
     "code",
     "mcp",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ## [Unreleased]
 
+### PyPI published the whole LICENSE file where an identifier belonged (#517, @marcelruhf)
+
+`license = { file = "LICENSE" }` makes PyPI put the entire licence text into
+`info.license`, so a commercial user could not allowlist us by identifier — there
+was no identifier to allowlist. Packaging metadata is PEP 639 now:
+`license = "LicenseRef-jCodeMunch-Dual-Use-1.1"` plus
+`license-files = ["LICENSE"]`, and the deprecated
+`License :: Other/Proprietary License` classifier is gone, which PEP 639 requires
+beside an expression.
+
+The LICENSE file is unchanged and still ships — `dist-info/licenses/LICENSE` in
+the wheel, repo root in the sdist. Verified on a built artifact, not inferred from
+the diff: `License-Expression` and `License-File` both present at
+`Metadata-Version: 2.5`, `twine check` green on both.
+
+⚠ **PyPI metadata is immutable per version, so this starts at the next release.**
+Every version up to 1.108.287 keeps the full-text `info.license`.
+
+⚠⚠ **The report named one surface and we declared the licence on three.**
+`.claude-plugin/plugin.json` and the mcpb manifest both said
+`LicenseRef-Dual-Use` — no product prefix, no version — so an allowlist keyed on
+the identifier still needed two entries. **That is the reported defect one surface
+over, and fixing only what was reported would have left it.** Both now name the
+same identifier, and the mcpb generator DERIVES it from `pyproject.toml` rather
+than carrying its own copy, which is how the two spellings drifted apart to begin
+with.
+
+⚠ **The version suffix is load-bearing, not decoration.** LICENSE 1.2 must
+produce a new identifier, or an allowlist that approved 1.1's terms keeps matching
+terms nobody read — consent inherited by silence.
+`tests/test_license_identifier_agreement.py` pins the suffix to the `Version X.Y`
+line in the file, so a licence bump that forgets the identifier fails the build
+instead of shipping quietly. 5 red against the pre-#517 tree, 2 red against the
+reported-surface-only fix, 5 green now.
+
 ### `CONFIGURATION.md` gave the wrong default for `disabled_tools` (#515, @rknighton)
 
 The Tools table documented the default as `[]`. The shipped default is

--- a/mcpb/build.py
+++ b/mcpb/build.py
@@ -58,7 +58,7 @@ def build_manifest():
         "homepage": f"https://github.com/jgravelle/{name}",
         "documentation": f"https://github.com/jgravelle/{name}#readme",
         "support": f"https://github.com/jgravelle/{name}/issues",
-        "license": "LicenseRef-Dual-Use",
+        "license": pyproject_field("license"),
         "server": {
             "type": "python",
             "entry_point": "server/main.py",

--- a/tests/test_license_identifier_agreement.py
+++ b/tests/test_license_identifier_agreement.py
@@ -1,0 +1,105 @@
+"""Every surface that declares our license must name the same identifier.
+
+#517 (@marcelruhf) switched packaging metadata to a PEP 639 expression so a
+commercial user could allowlist the license BY IDENTIFIER rather than by the
+full LICENSE text PyPI was publishing as `info.license`. That fixed the surface
+they hit and left two others declaring `LicenseRef-Dual-Use` — no product
+prefix, no version — so an allowlist keyed on the identifier still needed two
+entries. Same defect as the one that was fixed, one surface over.
+
+The version suffix is deliberate: LICENSE 1.2 must produce a NEW identifier, so
+consent to 1.1's terms is not silently inherited by terms nobody read. That only
+holds if the suffix tracks the file, which is the second assertion here.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+PLUGIN_JSON = REPO_ROOT / ".claude-plugin" / "plugin.json"
+LICENSE = REPO_ROOT / "LICENSE"
+
+# SPDX 3.0 §10.1: LicenseRef-[idstring], idstring = [A-Za-z0-9.-]+
+_LICENSE_REF = re.compile(r"^LicenseRef-[A-Za-z0-9.-]+$")
+
+
+def _declared_expression() -> str:
+    """pyproject.toml is the source; every other surface is checked against it."""
+    text = PYPROJECT.read_text(encoding="utf-8")
+    match = re.search(r'^license\s*=\s*"([^"]+)"', text, re.M)
+    assert match, (
+        "pyproject.toml no longer declares `license` as a bare string. If it "
+        "reverted to `license = { file = ... }`, PyPI publishes the whole "
+        "LICENSE text as info.license and the identifier is unallowlistable "
+        "again (#517)."
+    )
+    return match.group(1)
+
+
+def test_the_declared_expression_is_a_well_formed_license_ref() -> None:
+    expression = _declared_expression()
+    assert _LICENSE_REF.match(expression), (
+        f"{expression!r} is not a valid SPDX LicenseRef; PyPI rejects a "
+        "malformed license expression at upload, i.e. after the wheel is built"
+    )
+
+
+def test_plugin_manifest_names_the_same_identifier() -> None:
+    declared = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))["license"]
+    assert declared == _declared_expression(), (
+        f".claude-plugin/plugin.json says {declared!r}; pyproject.toml says "
+        f"{_declared_expression()!r}. Two identifiers for one license means an "
+        "allowlist needs two entries."
+    )
+
+
+def test_mcpb_manifest_derives_the_identifier_rather_than_copying_it() -> None:
+    """`mcpb/manifest.json` is generated, so the check belongs on the generator.
+
+    Asserting the built value (not the source text) is what makes this fail if
+    someone reintroduces a literal, whatever they spell it.
+    """
+    sys.path.insert(0, str(REPO_ROOT / "mcpb"))
+    try:
+        from build import build_manifest  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+    assert build_manifest()["license"] == _declared_expression()
+
+
+def test_the_version_suffix_tracks_the_license_file() -> None:
+    """A LICENSE version bump that forgets the identifier is the failure here.
+
+    Without this, 1.2's terms ship under 1.1's identifier and every allowlist
+    that approved 1.1 keeps matching — consent inherited by terms nobody read.
+    """
+    expression = _declared_expression()
+    suffix = re.search(r"-(\d+\.\d+)$", expression)
+    assert suffix, (
+        f"{expression!r} carries no version suffix. If that is deliberate, "
+        "delete this test and say why on the commit — but see the module "
+        "docstring first; the suffix is what forces re-approval."
+    )
+    header = LICENSE.read_text(encoding="utf-8")[:400]
+    in_file = re.search(r"^Version\s+(\d+\.\d+)", header, re.M)
+    assert in_file, f"{LICENSE.name} no longer states its version in its header"
+    assert suffix.group(1) == in_file.group(1), (
+        f"the identifier claims license version {suffix.group(1)}; "
+        f"{LICENSE.name} says {in_file.group(1)}"
+    )
+
+
+def test_no_license_classifier_survives_beside_the_expression() -> None:
+    """PEP 639: a `License ::` classifier alongside an expression is rejected.
+
+    The build succeeds and the UPLOAD fails, which is the expensive ordering —
+    step 4 of the release checklist exists for the same reason.
+    """
+    text = PYPROJECT.read_text(encoding="utf-8")
+    offenders = re.findall(r'^\s*"(License :: [^"]+)"', text, re.M)
+    assert not offenders, f"remove the classifier(s) {offenders}; the expression supersedes them"


### PR DESCRIPTION
Follow-up to #517 (@marcelruhf), which is merged. Adds the CHANGELOG entry for it and closes the gap it left.

## What #517 left

It fixed the surface the reporter hit — PyPI's `info.license` — and we declare the license on **three**. `.claude-plugin/plugin.json` and the mcpb manifest both said `LicenseRef-Dual-Use`: no product prefix, no version. So an allowlist keyed on the identifier still needed two entries, which is the reported defect one surface over.

Both now name `LicenseRef-jCodeMunch-Dual-Use-1.1`, and `mcpb/build.py` **derives** it via its existing `pyproject_field()` rather than carrying a literal — a third copy is how the first two drifted.

## The version suffix is load-bearing

LICENSE 1.2 must produce a new identifier, or an allowlist that approved 1.1's terms keeps matching terms nobody read. That only holds while the suffix tracks the file, so `test_the_version_suffix_tracks_the_license_file` pins it to the `Version X.Y` line in `LICENSE` itself. A license bump that forgets the identifier now fails the build instead of shipping quietly.

Raised the trade-off with @marcelruhf on #517 — he's the one operating an allowlist, so if version-pinned identifiers are a recurring cost on his side that's a requirement I'd rather hear than guess at.

## Ratchet

`tests/test_license_identifier_agreement.py` (5):

- the pyproject expression is a well-formed SPDX `LicenseRef` (PyPI rejects a malformed one **at upload**, i.e. after the wheel is built)
- plugin.json names the same identifier
- the mcpb generator's **built output** names it — asserted on the value, not the source text, so reintroducing a literal fails however it's spelled
- the version suffix matches LICENSE's header
- no `License ::` classifier survives beside the expression

**5 red against the pre-#517 tree, 2 red against the reported-surface-only fix, 5 green now.**

## Verification

- Suite: **8072 passed, 17 skipped, 0 failed**; 8089 total against main's 8084 = exactly the 5 new tests
- `uv run ruff check` clean
- Built artifacts read directly: `License-Expression: LicenseRef-jCodeMunch-Dual-Use-1.1`, `License-File: LICENSE`, LICENSE present at `dist-info/licenses/LICENSE`, `twine check` green on wheel and sdist

⚠ PyPI metadata is immutable per version, so none of this reaches PyPI until the next release; 1.108.287 and earlier keep the full-text `info.license`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)