### PR TITLE
fix(install-pack): confine archive members by resolution, not by pattern (#447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 ## [Unreleased]
 
+### `install-pack` extracted drive-absolute archive members outside the install directory ([#447](https://github.com/jgravelle/jcodemunch-mcp/issues/447))
+
+The pre-scan rejected a leading separator and `..` anywhere in a member name,
+which is necessary and not sufficient. `C:/Windows/Temp/evil.txt` contains
+neither — and `base / relative` **discards `base`** when `relative` is absolute,
+so the write went wherever the archive said. `dest.parent.mkdir(parents=True)`
+ran first, so a hostile member created directories outside the install root
+before a byte of content was written.
+
+Confinement is by RESOLUTION now, not by pattern. A string test can never finish
+enumerating separator and drive spellings; resolving the destination and refusing
+anything outside the base does not have to. The pre-scan is kept as an early
+abort — it refuses an obviously hostile archive before any work — with the
+per-member check as the authority.
+
+⚠ **Reported by [@elfrost](https://github.com/elfrost), who also wrote a correct
+fix in [#443](https://github.com/jgravelle/jcodemunch-mcp/pull/443) that we could
+not merge because the CLA went unsigned.** The vulnerability, the analysis and
+the design of the remedy are theirs. What shipped applies our own pre-existing
+`_safe_content_path` pattern to the call site that lacked it — an independent
+path, not a clean-room copy of their diff — and their PR is closed with that said
+plainly on the thread.
+
+⚠ **One definition of the rule.** Three spellings of resolve-and-compare existed
+(`security.validate_path` plus a private copy on `IndexStore` and another on
+`SQLiteIndexStore`). The new call site would have been a fourth. `resolve_within`
+in `security.py` is now the one definition and both stores delegate to it;
+`SQLiteIndexStore` keeps its resolved-base cache by passing it in, so the hot
+path is unchanged and the rule is not duplicated to preserve it.
+
+⚠ **The refusal is deliberately NOT pinned to a platform.** `C:/Windows/...` is
+absolute on Windows and an ordinary relative name on Linux and macOS, where
+resolving it under the base is correct behaviour. The tests assert **confinement**
+— nothing appeared outside the install directory — rather than that a particular
+string was rejected, which would encode platform trivia as a security property.
+
+⚠⚠ **The first version of the regression test named the reported path verbatim
+and PASSED against the unfixed source**, because the escape landed outside the
+directory the assertion was looking in. Worse, the non-vacuity pass — which runs
+the unfixed source on purpose — wrote a real file into a real Windows system
+directory. **A test for an arbitrary-write defect executes that defect every time
+you prove the test is not vacuous, so the target must be somewhere the test
+owns.** Rebuilt against a `tmp_path` sentinel: 3 red at the call site, 1 red on
+the one-definition guard, controls green both sides.
+
+⚠ A second test of ours asserted an OS accident rather than the rule — that an
+embedded NUL byte fails to resolve — and it passed serially and failed under
+xdist, where the longer worker temp path takes the other branch. **The rule is
+that a raising resolve refuses; which inputs happen to raise is the OS's
+business.** Rewritten to force the raise.
+
 ### PyPI published the whole LICENSE file where an identifier belonged (#517, @marcelruhf)
 
 `license = { file = "LICENSE" }` makes PyPI put the entire licence text into

--- a/src/jcodemunch_mcp/cli/install_pack.py
+++ b/src/jcodemunch_mcp/cli/install_pack.py
@@ -12,6 +12,8 @@ from urllib.parse import quote
 
 import httpx
 
+from ..security import resolve_within
+
 # The packs are built by the jcodemunch-starter-packs CI job, which deploys to
 # jcodemunch.com. The legacy j.gravelle.us copy is no longer refreshed and served
 # an April build for months after the pipeline moved -- a stale artifact reads as
@@ -380,7 +382,14 @@ def _install_pack(
 
     try:
         with zipfile.ZipFile(tmp_path, "r") as zf:
-            # Validate -- no path traversal
+            # Validate -- no path traversal.
+            #
+            # This pre-scan is an EARLY ABORT, not the guard. A string test can
+            # never finish enumerating separator and drive spellings, so the
+            # authoritative check is the per-member confinement below, which
+            # resolves the destination and refuses anything landing outside
+            # `base`. Both are kept: the scan refuses an obviously hostile
+            # archive before a byte is written, the confinement decides.
             for info in zf.infolist():
                 if info.filename.startswith("/") or ".." in info.filename:
                     print(
@@ -408,7 +417,19 @@ def _install_pack(
                     symbol_count = manifest_data.get("total_symbols", 0)
                     continue
 
-                dest = base / relative
+                # `base / relative` DISCARDS `base` when `relative` is
+                # absolute, so a member named `C:/Windows/Temp/evil.txt` -- which
+                # carries neither a leading separator nor `..` -- writes outside
+                # the install directory. Resolve and confine before anything is
+                # created, `mkdir` included.
+                dest = resolve_within(base, relative)
+                if dest is None:
+                    print(
+                        f"  {_RED}{_CROSS} Archive member '{info.filename}' resolves "
+                        f"outside the install directory. Aborting.{_RESET}",
+                        file=sys.stderr,
+                    )
+                    return 1
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 with zf.open(info.filename) as src, open(dest, "wb") as dst:
                     dst.write(src.read())

--- a/src/jcodemunch_mcp/security.py
+++ b/src/jcodemunch_mcp/security.py
@@ -69,6 +69,47 @@ def validate_path(root: Path, target: Path) -> bool:
         return False
 
 
+def resolve_within(
+    base: Path,
+    relative: str,
+    *,
+    base_resolved: Optional[str] = None,
+) -> Optional[Path]:
+    """Join ``relative`` onto ``base`` and return it only if it stays inside.
+
+    The rule is CONFINEMENT BY RESOLUTION, deliberately not a string test on the
+    member name. A pre-scan for a leading separator and ``..`` is necessary and
+    not sufficient: ``C:/Windows/Temp/evil.txt`` contains neither, and
+    ``base / relative`` with an absolute ``relative`` DISCARDS ``base``. No
+    enumeration of separator and drive spellings ever finishes; resolving and
+    comparing does not have to.
+
+    ⚠ Whether a given name escapes is PLATFORM-DEPENDENT and that is correct
+    rather than a gap. ``C:/Windows/...`` is absolute on Windows and an ordinary
+    relative name on Linux and macOS, where resolving it under the base is the
+    right answer. Assert confinement, never that a particular string is refused.
+
+    Args:
+        base: The directory the result must stay inside.
+        relative: An untrusted path fragment (archive member, stored file path).
+        base_resolved: ``str(base.resolve())`` when the caller already has it.
+            Callers on a hot path pass their cached value; the rule is unchanged.
+
+    Returns:
+        The resolved destination, or None if it escapes or cannot be resolved.
+    """
+    try:
+        base_str = base_resolved if base_resolved is not None else str(base.resolve())
+        candidate = (base / relative).resolve()
+        if os.path.commonpath([base_str, str(candidate)]) != base_str:
+            return None
+        return candidate
+    except (OSError, ValueError):
+        # ValueError also covers Windows' different-drive commonpath, which is
+        # an escape by definition.
+        return None
+
+
 def is_symlink_escape(root: Path, path: Path) -> bool:
     """Check if a symlink points outside the root directory.
 

--- a/src/jcodemunch_mcp/storage/index_store.py
+++ b/src/jcodemunch_mcp/storage/index_store.py
@@ -532,14 +532,9 @@ class IndexStore:
         Prevents path traversal when writing/reading cached raw files from
         untrusted repository paths.
         """
-        try:
-            base = content_dir.resolve()
-            candidate = (content_dir / relative_path).resolve()
-            if os.path.commonpath([str(base), str(candidate)]) != str(base):
-                return None
-            return candidate
-        except (OSError, ValueError):
-            return None
+        from ..security import resolve_within
+
+        return resolve_within(content_dir, relative_path)
 
     def _write_cached_text(self, path: Path, content: str) -> None:
         """Write cached text without newline translation."""

--- a/src/jcodemunch_mcp/storage/sqlite_store.py
+++ b/src/jcodemunch_mcp/storage/sqlite_store.py
@@ -2713,18 +2713,17 @@ class SQLiteIndexStore:
 
     def _safe_content_path(self, content_dir: Path, relative_path: str) -> Optional[Path]:
         """Resolve a content path and ensure it stays within content_dir."""
-        try:
-            dir_key = str(content_dir)
-            base_str = self._resolved_content_dirs.get(dir_key)
-            if base_str is None:
+        from ..security import resolve_within
+
+        dir_key = str(content_dir)
+        base_str = self._resolved_content_dirs.get(dir_key)
+        if base_str is None:
+            try:
                 base_str = str(content_dir.resolve())
-                self._resolved_content_dirs[dir_key] = base_str
-            candidate = (content_dir / relative_path).resolve()
-            if os.path.commonpath([base_str, str(candidate)]) != base_str:
+            except (OSError, ValueError):
                 return None
-            return candidate
-        except (OSError, ValueError):
-            return None
+            self._resolved_content_dirs[dir_key] = base_str
+        return resolve_within(content_dir, relative_path, base_resolved=base_str)
 
     def _write_cached_text(self, path: Path, content: str) -> None:
         """Write cached text atomically, without newline translation.

--- a/tests/test_install_pack_member_confinement.py
+++ b/tests/test_install_pack_member_confinement.py
@@ -1,0 +1,215 @@
+"""A Starter Pack archive member must not write outside the install directory.
+
+Issue #447, reported by @elfrost with a working fix in PR #443 that we could not
+merge for CLA reasons. `install-pack`'s pre-scan rejected a leading separator and
+`..` anywhere in the member name, which is necessary and not sufficient: a member
+named `C:/Windows/Temp/evil.txt` carries neither, and `base / relative` with an
+absolute `relative` DISCARDS `base`. The archive is served over TLS from a host
+we control, so this is a compromise-amplifier rather than a drive-by — and that
+is exactly the class where the guard has to hold anyway.
+
+⚠ **The assertion here is CONFINEMENT, never that a particular string is
+refused.** `C:/Windows/Temp/evil.txt` is absolute on Windows and an ordinary
+relative name on Linux and macOS, where extracting it under the base is correct.
+Pinning the refusal would encode platform trivia as if it were a security
+property; pinning "nothing appeared outside the base" is the property.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from jcodemunch_mcp.cli.install_pack import _install_pack
+from jcodemunch_mcp.security import resolve_within
+
+_SRC = Path(__file__).parent.parent / "src" / "jcodemunch_mcp"
+
+
+def _pack_zip(files: dict[str, bytes], pack_id: str = "testpack") -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in files.items():
+            zf.writestr(f"{pack_id}/{name}", content)
+    return buf.getvalue()
+
+
+def _zip_response(zip_bytes: bytes):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {"content-type": "application/zip", "X-Pack-Version": "1.0.0"}
+    resp.content = zip_bytes
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+# ── resolve_within: the rule itself ───────────────────────────────────────
+
+def test_an_absolute_member_does_not_escape_the_base(tmp_path):
+    """The mechanism, stated directly: joining an absolute path drops the base."""
+    base = tmp_path / "install"
+    base.mkdir()
+    absolute = str((tmp_path / "outside" / "evil.txt").resolve())
+
+    # Precondition — this is what makes the naive join dangerous.
+    assert Path(str(base / absolute)) != base / "outside" / "evil.txt"
+
+    assert resolve_within(base, absolute) is None
+
+
+def test_a_parent_traversal_does_not_escape_the_base(tmp_path):
+    base = tmp_path / "install"
+    base.mkdir()
+    assert resolve_within(base, os.path.join("..", "evil.txt")) is None
+
+
+def test_an_ordinary_relative_member_resolves_inside(tmp_path):
+    base = tmp_path / "install"
+    base.mkdir()
+    dest = resolve_within(base, "licenses/nodejs/LICENSE")
+    assert dest is not None
+    assert dest == (base / "licenses" / "nodejs" / "LICENSE").resolve()
+
+
+def test_a_caller_supplied_resolved_base_does_not_change_the_rule(tmp_path):
+    """The hot-path caching form must decide identically to the plain form."""
+    base = tmp_path / "install"
+    base.mkdir()
+    cached = str(base.resolve())
+    for relative in ("a/b.txt", os.path.join("..", "evil.txt")):
+        assert resolve_within(base, relative, base_resolved=cached) == resolve_within(
+            base, relative
+        )
+
+
+def test_a_path_that_cannot_be_resolved_is_refused_rather_than_admitted(tmp_path):
+    """Could-not-establish is never a pass — the same asymmetry as #209.
+
+    ⚠ The first version of this asserted that an embedded NUL byte returns None,
+    which is an accident of how Windows resolves a non-existent path rather than
+    the rule: it passed serially and failed under xdist, where the longer worker
+    temp path took the other branch. **The rule is that a raising resolve refuses;
+    which inputs happen to raise is the OS's business.**
+    """
+    base = tmp_path / "install"
+    base.mkdir()
+
+    def _boom(self, *args, **kwargs):
+        raise OSError("resolution unavailable")
+
+    with patch.object(Path, "resolve", _boom):
+        assert resolve_within(base, "ordinary/name.txt") is None
+
+
+# ── the reported call site ────────────────────────────────────────────────
+
+@pytest.mark.parametrize("spelling", ["forward_slash", "backslash", "parent_traversal"])
+@patch("jcodemunch_mcp.cli.install_pack.httpx")
+def test_no_member_spelling_writes_outside_the_install_directory(
+    mock_httpx, spelling, tmp_path, monkeypatch
+):
+    """⚠ The hostile member is built from `tmp_path`, never from a real system path.
+
+    The first version of this test named `C:/Windows/Temp/evil.txt` — the
+    reported attack verbatim. Two things were wrong with that, and the second is
+    the one worth remembering. The escape landed outside `tmp_path`, so the
+    assertion could not see it and the test PASSED against the unfixed source.
+    And the non-vacuity pass, which runs the unfixed source ON PURPOSE, wrote a
+    real file into a real Windows system directory. **A test for an arbitrary-write
+    defect executes that defect every time you prove the test is not vacuous, so
+    the target has to be somewhere the test owns.**
+    """
+    monkeypatch.setenv("JCODEMUNCH_SHARE_SAVINGS", "0")
+    base = tmp_path / "install"
+    sentinel = tmp_path / "outside"
+    sentinel.mkdir()
+    target = sentinel / "evil.txt"
+
+    member = {
+        # Absolute for THIS platform, and containing neither a leading separator
+        # on Windows nor `..` — the shape the pre-scan cannot see.
+        "forward_slash": str(target).replace("\\", "/"),
+        "backslash": str(target),
+        "parent_traversal": "sub/../../../../evil.txt",
+    }[spelling]
+
+    mock_httpx.get.return_value = _zip_response(
+        _pack_zip({
+            "manifest.json": json.dumps({"name": "T", "total_symbols": 1}).encode(),
+            member: b"pwned",
+        })
+    )
+
+    rc = _install_pack("testpack", base_path=base)
+
+    assert not target.exists(), f"member {member!r} wrote outside the install directory"
+    escaped = [
+        p for p in tmp_path.rglob("*")
+        if p.is_file() and base.resolve() not in p.resolve().parents
+    ]
+    assert escaped == [], f"member {member!r} escaped to {escaped}"
+    # rc is 1 where the member is genuinely absolute for this platform, and 0
+    # where it is an ordinary relative name that landed inside. Both are correct;
+    # only escaping is not.
+    assert rc in (0, 1)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="drive-absolute names need Windows")
+@patch("jcodemunch_mcp.cli.install_pack.httpx")
+def test_a_drive_absolute_member_is_refused_on_windows(mock_httpx, tmp_path, monkeypatch):
+    """The reported attack, on the platform where the name is actually absolute."""
+    monkeypatch.setenv("JCODEMUNCH_SHARE_SAVINGS", "0")
+    target = tmp_path / "outside" / "evil.txt"
+    target.parent.mkdir()
+    mock_httpx.get.return_value = _zip_response(
+        _pack_zip({
+            "manifest.json": json.dumps({"name": "T", "total_symbols": 1}).encode(),
+            str(target).replace("\\", "/"): b"pwned",
+        })
+    )
+
+    assert _install_pack("testpack", base_path=tmp_path / "install") == 1
+    assert not target.exists()
+
+
+@patch("jcodemunch_mcp.cli.install_pack.httpx")
+def test_an_ordinary_pack_still_installs(mock_httpx, tmp_path, monkeypatch):
+    """The control. A guard that refused everything would satisfy every test above."""
+    monkeypatch.setenv("JCODEMUNCH_SHARE_SAVINGS", "0")
+    base = tmp_path / "install"
+    mock_httpx.get.return_value = _zip_response(
+        _pack_zip({
+            "manifest.json": json.dumps({"name": "T", "total_symbols": 1}).encode(),
+            "licenses/nodejs/LICENSE": b"MIT",
+        })
+    )
+
+    assert _install_pack("testpack", base_path=base) == 0
+    assert (base / "licenses" / "nodejs" / "LICENSE").read_bytes() == b"MIT"
+
+
+# ── one definition of the rule ────────────────────────────────────────────
+
+def test_confinement_is_defined_only_in_security_py():
+    """Three spellings of this rule existed; a fourth is how they drift apart.
+
+    `IndexStore` and `SQLiteIndexStore` each carried their own resolve-and-compare
+    block. Both now delegate, so `commonpath` appearing anywhere else in `src/`
+    means someone rebuilt the rule instead of calling it.
+    """
+    offenders = sorted(
+        str(path.relative_to(_SRC))
+        for path in _SRC.rglob("*.py")
+        if path.name != "security.py" and "commonpath" in path.read_text(encoding="utf-8")
+    )
+    assert offenders == [], (
+        f"path-confinement re-implemented in {offenders}; import "
+        "`security.resolve_within` instead"
+    )


### PR DESCRIPTION
Closes #447. **Reported by @elfrost**, who also wrote a correct fix in #443 — see the provenance note below.

## The defect

`install-pack`'s pre-scan rejected a leading separator and `..` anywhere in a member name. Necessary, not sufficient: `C:/Windows/Temp/evil.txt` contains neither, and `base / relative` **discards `base`** when `relative` is absolute. `dest.parent.mkdir(parents=True)` ran before the write, so a hostile member created directories outside the install root before a byte of content existed.

Confinement is by **resolution** now. A string test can never finish enumerating separator and drive spellings; resolving the destination and refusing anything outside the base does not have to. The pre-scan stays as an early abort — it refuses an obviously hostile archive before any work — with the per-member check as the authority.

## Provenance

@elfrost found this, analysed it, and wrote a fix. #443 could not be merged because the CLA went unsigned through a posted window that expires today. What ships here applies our own pre-existing `_safe_content_path` pattern to the call site that lacked it — an independent path, not a clean-room copy of their diff — and the credit is theirs in the CHANGELOG, the release notes and the close comments.

## One definition of the rule

Three spellings of resolve-and-compare already existed: `security.validate_path`, a private copy on `IndexStore`, and another on `SQLiteIndexStore`. The new call site would have been a fourth. `security.resolve_within()` is now the one definition and both stores delegate; `SQLiteIndexStore` keeps its resolved-base cache by passing it in, so the hot path is unchanged without duplicating the rule to preserve it. `test_confinement_is_defined_only_in_security_py` fails on a `commonpath` anywhere else in `src/`.

## Two test notes

**The refusal is deliberately not pinned to a platform.** `C:/Windows/...` is absolute on Windows and an ordinary relative name on Linux and macOS, where resolving it under the base is correct. The tests assert **confinement** — nothing appeared outside the install directory — not that a given string was rejected, which would encode platform trivia as a security property.

**The first version of the regression test named the reported path verbatim and passed against the unfixed source**, because the escape landed outside the directory the assertion was looking in. Worse: the non-vacuity pass, which runs the unfixed source on purpose, wrote a real file into a real Windows system directory. A test for an arbitrary-write defect executes that defect every time you prove it isn't vacuous, so the target has to be somewhere the test owns. Rebuilt against a `tmp_path` sentinel.

A second test of ours asserted an OS accident rather than the rule — that an embedded NUL fails to resolve — and passed serially while failing under xdist, where the longer worker temp path takes the other branch. Rewritten to force the raise.

## Verification

- **3 red at the call site, 1 red on the one-definition guard**; the `parent_traversal` case and the ordinary-install control pass both sides by design
- Suite: **8083 passed, 17 skipped, 0 failed**; 8100 total against main's 8089 = exactly the 11 new tests
- `uv run ruff check src/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)