### PR TITLE
test(license): the version suffix and the LICENSE version imply each other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### The license-identifier ratchet asserted this repo's accident (@marcelruhf)
+
+`test_the_version_suffix_tracks_the_license_file` required the identifier to
+carry a `-X.Y` suffix unconditionally, which is only correct while this LICENSE
+happens to state a version. @marcelruhf ported the ratchet into jdocmunch-mcp
+and jdatamunch-mcp, whose LICENSE files carry no `Version` line, and wrote the
+general form: **a version line and a suffix imply each other, in both
+directions.** Adopted here.
+
+⚠ The half that only his version catches is the one nobody would think to test —
+an identifier claiming a version the licence text does not state. Both directions
+were proven to fail against a temporarily edited LICENSE.
+
 ## [1.108.288] - 2026-08-20 - The reported surface was never the only one
 
 Four fixes, and in three of them the report named one site while the tree held

--- a/tests/test_license_identifier_agreement.py
+++ b/tests/test_license_identifier_agreement.py
@@ -72,26 +72,37 @@ def test_mcpb_manifest_derives_the_identifier_rather_than_copying_it() -> None:
     assert build_manifest()["license"] == _declared_expression()
 
 
-def test_the_version_suffix_tracks_the_license_file() -> None:
+def test_the_version_suffix_and_the_license_file_imply_each_other() -> None:
     """A LICENSE version bump that forgets the identifier is the failure here.
 
     Without this, 1.2's terms ship under 1.1's identifier and every allowlist
     that approved 1.1 keeps matching — consent inherited by terms nobody read.
+
+    ⚠ The implication runs BOTH WAYS, which is @marcelruhf's improvement on the
+    version I first wrote for this file. Mine asserted a suffix exists, which is
+    only true while this LICENSE happens to carry a `Version` line — jdocmunch's
+    and jdatamunch's do not, and there the same assertion would have demanded a
+    version the file never states. **A version line and a suffix must imply each
+    other; asserting one unconditionally encodes this repo's accident.**
     """
     expression = _declared_expression()
     suffix = re.search(r"-(\d+\.\d+)$", expression)
-    assert suffix, (
-        f"{expression!r} carries no version suffix. If that is deliberate, "
-        "delete this test and say why on the commit — but see the module "
-        "docstring first; the suffix is what forces re-approval."
-    )
     header = LICENSE.read_text(encoding="utf-8")[:400]
     in_file = re.search(r"^Version\s+(\d+\.\d+)", header, re.M)
-    assert in_file, f"{LICENSE.name} no longer states its version in its header"
-    assert suffix.group(1) == in_file.group(1), (
-        f"the identifier claims license version {suffix.group(1)}; "
-        f"{LICENSE.name} says {in_file.group(1)}"
-    )
+    if in_file:
+        assert suffix, (
+            f"{expression!r} carries no version suffix but {LICENSE.name} "
+            f"says Version {in_file.group(1)}"
+        )
+        assert suffix.group(1) == in_file.group(1), (
+            f"the identifier claims license version {suffix.group(1)}; "
+            f"{LICENSE.name} says {in_file.group(1)}"
+        )
+    else:
+        assert not suffix, (
+            f"{expression!r} carries version suffix {suffix.group(1)} but "
+            f"{LICENSE.name} has no Version line"
+        )
 
 
 def test_no_license_classifier_survives_beside_the_expression() -> None:


### PR DESCRIPTION
Taking @marcelruhf's improvement back from the sibling repos, as promised on jdocmunch-mcp#122.

`test_the_version_suffix_tracks_the_license_file` (mine, #518) asserted that the identifier carries a `-X.Y` suffix **unconditionally**. That is only correct while this repo's LICENSE happens to state a version. He ported the ratchet into jdocmunch-mcp and jdatamunch-mcp, whose LICENSE files carry no `Version` line, and wrote the general form instead: a version line and a suffix **imply each other, in both directions**.

The half only his version catches is the one nobody would think to test — an identifier claiming a licence version the text does not state. Proven by temporarily editing LICENSE:

- `Version 1.1` → `Version 1.2`, identifier unchanged: **fails** (the case mine also caught)
- `Version` line removed, identifier still `-1.1`: **fails** (the case mine missed)

LICENSE restored byte-for-byte after both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)