### PR TITLE
fix(license): key the identifier to the MAJOR version only

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/jgravelle/jcodemunch-mcp#readme",
   "repository": "https://github.com/jgravelle/jcodemunch-mcp",
-  "license": "LicenseRef-jCodeMunch-Dual-Use-1.1",
+  "license": "LicenseRef-jCodeMunch-Dual-Use-1",
   "keywords": [
     "code",
     "mcp",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## [Unreleased]
 
+### The licence identifier tracks the MAJOR version only (@marcelruhf)
+
+1.108.288 shipped `LicenseRef-jCodeMunch-Dual-Use-1.1`, which invalidates a
+downstream allowlist on every minor bump — including a typo fix. @marcelruhf,
+who operates an allowlist against this identifier, proposed keying it to the
+major version instead: a minor bump is editorial and must not churn anyone, a
+major bump means the terms changed substantively and re-approval is the honest
+outcome. The identifier is `LicenseRef-jCodeMunch-Dual-Use-1` from the next
+release.
+
+⚠ **1.108.288 keeps `-1.1` permanently** — PyPI metadata is immutable per
+version. Since .288 is the only release that has ever carried an identifier at
+all, this is the cheapest moment this change will ever have; every further
+release makes the transition wider.
+
+⚠⚠ **We have already broken the promise this identifier makes, which is why it
+is not left as a convention.** `f3c925c` (2026-07-10) ADDED a redistribution and
+attribution obligation to condition 2 — a substantive change to what a licensee
+may do — while the header stayed at `Version 1.1 — effective 2026-06-30`.
+**Nothing failed, because a version line is a convention and conventions do not
+fail builds.** A licensee reading the identifier would have been told the terms
+were unchanged.
+
+So `test_the_license_text_cannot_change_without_a_decision_being_made` pins the
+LICENSE text to the declared version by digest. Any edit fails it, and clearing
+the failure means choosing: substantive (bump the major version, the identifier
+and the digest) or editorial (update the digest alone). **It cannot make that
+judgement and does not try — it forces the judgement to happen where the text
+moves, rather than be discovered downstream.**
+
+⚠ The three behaviours were proven against a temporarily edited LICENSE: terms
+changed under a static version FAILS, a major bump with a static identifier
+FAILS, and a minor bump does NOT churn the identifier. LICENSE restored
+byte-for-byte after each.
+
+⚠ jdocmunch-mcp and jdatamunch-mcp state no licence version at all, so their
+identifiers stay suffix-less and the bidirectional check is already correct
+there. Giving those files a version line is a licence edit, not a packaging one.
+
 ### The license-identifier ratchet asserted this repo's accident (@marcelruhf)
 
 `test_the_version_suffix_tracks_the_license_file` required the identifier to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ changed under a static version FAILS, a major bump with a static identifier
 FAILS, and a minor bump does NOT churn the identifier. LICENSE restored
 byte-for-byte after each.
 
+⚠⚠ **The digest is taken over the NORMALISED text, and the first version was not
+— it was red on all four Ubuntu legs and green on all four Windows legs.** Git
+rewrites line endings on checkout, so a digest over raw bytes pins a property of
+the CHECKOUT rather than of the terms. **A licence says the same thing in either
+encoding**, and a pin that disagrees is measuring the wrong object.
+
 ⚠ jdocmunch-mcp and jdatamunch-mcp state no licence version at all, so their
 identifiers stay suffix-less and the bidirectional check is already correct
 there. Giving those files a version line is a licence edit, not a packaging one.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 authors = [
     { name = "J. Gravelle", email = "j@gravelle.us" },
 ]
-license = "LicenseRef-jCodeMunch-Dual-Use-1.1"
+license = "LicenseRef-jCodeMunch-Dual-Use-1"
 license-files = ["LICENSE"]
 keywords = [
     "mcp",

--- a/tests/test_license_identifier_agreement.py
+++ b/tests/test_license_identifier_agreement.py
@@ -14,6 +14,7 @@ holds if the suffix tracks the file, which is the second assertion here.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import sys
@@ -72,37 +73,71 @@ def test_mcpb_manifest_derives_the_identifier_rather_than_copying_it() -> None:
     assert build_manifest()["license"] == _declared_expression()
 
 
-def test_the_version_suffix_and_the_license_file_imply_each_other() -> None:
-    """A LICENSE version bump that forgets the identifier is the failure here.
+# The LICENSE text as it stands at the declared major version. Bump the
+# identifier's suffix AND this digest together when the terms change
+# substantively; update the digest alone for an editorial change.
+_LICENSE_DIGEST = "17b9d6d9922b7988544bd91c84dccfa41c5e75027cb9bdc856c93d822283cf92"
 
-    Without this, 1.2's terms ship under 1.1's identifier and every allowlist
-    that approved 1.1 keeps matching — consent inherited by terms nobody read.
 
-    ⚠ The implication runs BOTH WAYS, which is @marcelruhf's improvement on the
-    version I first wrote for this file. Mine asserted a suffix exists, which is
-    only true while this LICENSE happens to carry a `Version` line — jdocmunch's
-    and jdatamunch's do not, and there the same assertion would have demanded a
-    version the file never states. **A version line and a suffix must imply each
-    other; asserting one unconditionally encodes this repo's accident.**
+def test_the_suffix_and_the_license_major_version_imply_each_other() -> None:
+    """The identifier tracks the MAJOR version, not the full version.
+
+    A minor bump is editorial or clarifying and must not invalidate an
+    allowlist; a major bump means the terms changed substantively and
+    re-approval is the honest outcome. Requested by @marcelruhf, who operates
+    an allowlist against this identifier and proposed the major-only form.
+
+    ⚠ The implication runs BOTH WAYS — his improvement on the version we first
+    shipped. Asserting a suffix exists unconditionally encodes this repo's
+    accident: jdocmunch-mcp and jdatamunch-mcp state no version at all, and
+    there the same assertion would demand one the file never makes.
     """
     expression = _declared_expression()
-    suffix = re.search(r"-(\d+\.\d+)$", expression)
+    suffix = re.search(r"-(\d+)$", expression)
     header = LICENSE.read_text(encoding="utf-8")[:400]
-    in_file = re.search(r"^Version\s+(\d+\.\d+)", header, re.M)
+    in_file = re.search(r"^Version\s+(\d+)\.\d+", header, re.M)
     if in_file:
         assert suffix, (
             f"{expression!r} carries no version suffix but {LICENSE.name} "
-            f"says Version {in_file.group(1)}"
+            f"states a version"
         )
         assert suffix.group(1) == in_file.group(1), (
-            f"the identifier claims license version {suffix.group(1)}; "
+            f"the identifier claims licence major version {suffix.group(1)}; "
             f"{LICENSE.name} says {in_file.group(1)}"
         )
     else:
         assert not suffix, (
             f"{expression!r} carries version suffix {suffix.group(1)} but "
-            f"{LICENSE.name} has no Version line"
+            f"{LICENSE.name} states no version"
         )
+
+
+def test_the_license_text_cannot_change_without_a_decision_being_made() -> None:
+    """A major-only identifier is a PROMISE; this is what makes it checkable.
+
+    ⚠⚠ We have already broken it once. `f3c925c` (2026-07-10) ADDED a
+    redistribution and attribution obligation to condition 2 — a substantive
+    change to what a licensee may do — while the header stayed at
+    `Version 1.1 — effective 2026-06-30`. **Nothing failed, because a version
+    line is a convention and conventions do not fail builds.**
+
+    So the identifier cannot rest on our discipline about bumping the version.
+    This pins the terms text to the declared version: any edit to LICENSE fails
+    here, and clearing the failure requires deciding which kind of edit it was.
+    It cannot make that judgement — it forces it to be made at the moment the
+    text moves, rather than discovered by a licensee later.
+    """
+    actual = hashlib.sha256(LICENSE.read_bytes()).hexdigest()
+    assert actual == _LICENSE_DIGEST, (
+        f"{LICENSE.name} changed (digest {actual}).\n"
+        "  Substantive change to the terms -> bump the MAJOR version in the "
+        "LICENSE header, bump the identifier suffix in pyproject.toml and "
+        ".claude-plugin/plugin.json, and update _LICENSE_DIGEST.\n"
+        "  Editorial change (typo, formatting, a clarification that grants and "
+        "removes nothing) -> update _LICENSE_DIGEST alone.\n"
+        "  Allowlists downstream key on the identifier, so the first case "
+        "must be visible to them and the second must not churn them."
+    )
 
 
 def test_no_license_classifier_survives_beside_the_expression() -> None:

--- a/tests/test_license_identifier_agreement.py
+++ b/tests/test_license_identifier_agreement.py
@@ -76,7 +76,18 @@ def test_mcpb_manifest_derives_the_identifier_rather_than_copying_it() -> None:
 # The LICENSE text as it stands at the declared major version. Bump the
 # identifier's suffix AND this digest together when the terms change
 # substantively; update the digest alone for an editorial change.
-_LICENSE_DIGEST = "17b9d6d9922b7988544bd91c84dccfa41c5e75027cb9bdc856c93d822283cf92"
+#
+# ⚠ Over the NORMALISED text, never the raw bytes. Git rewrites line endings
+# on checkout, so a byte digest is a property of the checkout rather than of the
+# terms: this pin was red on all four Ubuntu legs and green on all four Windows
+# legs on its first run. **A licence says the same thing in either encoding.**
+_LICENSE_DIGEST = "646a3993057657577c2e3f56977a18ccf329fd0b85f827b1673d151747ccda11"
+
+
+def _license_terms() -> bytes:
+    """The licence text with line endings normalised, so the digest is portable."""
+    normalised = LICENSE.read_text(encoding="utf-8").replace("\r\n", "\n")
+    return normalised.encode("utf-8")
 
 
 def test_the_suffix_and_the_license_major_version_imply_each_other() -> None:
@@ -127,7 +138,7 @@ def test_the_license_text_cannot_change_without_a_decision_being_made() -> None:
     It cannot make that judgement — it forces it to be made at the moment the
     text moves, rather than discovered by a licensee later.
     """
-    actual = hashlib.sha256(LICENSE.read_bytes()).hexdigest()
+    actual = hashlib.sha256(_license_terms()).hexdigest()
     assert actual == _LICENSE_DIGEST, (
         f"{LICENSE.name} changed (digest {actual}).\n"
         "  Substantive change to the terms -> bump the MAJOR version in the "


### PR DESCRIPTION
Answers @marcelruhf's question on #517. Taking his middle option — **major-only** — and backing it with a mechanism, because we have already broken the promise it makes.

## Why major-only rather than the alternatives

He offered three: keep `-1.1`, drop the version entirely, or key on the major part.

**Dropping the version is the one that looks cheapest and is worst for him.** A substantive re-licence would then be invisible to every allowlist — the identifier keeps matching while the terms underneath it change. That moves risk onto the licensee to buy us zero churn, which is the wrong direction for the party we are trying to help.

**Keeping `-1.1` churns him for typos.** A clarification that grants and removes nothing would invalidate his allowlist entry.

**Major-only says what he actually wants to know:** minor is editorial, major means read it again.

⚠ **1.108.288 keeps `-1.1` permanently**, since PyPI metadata is immutable per version. It is also the only release that has ever carried an identifier at all, so this is the cheapest moment the change will ever have — every further release makes the transition wider. That is the argument for doing it now rather than deferring.

## Why it needed more than a convention

`f3c925c` (2026-07-10) **added a redistribution and attribution obligation to condition 2** — a substantive change to what a licensee may do — while the header stayed at `Version 1.1 — effective 2026-06-30`. Nothing failed, because a version line is a convention and conventions do not fail builds. Under a major-only identifier, a licensee would have been told the terms were unchanged.

So `test_the_license_text_cannot_change_without_a_decision_being_made` pins the LICENSE text by digest. Any edit fails it, and clearing the failure means choosing: substantive (bump the major version, the identifier, and the digest) or editorial (update the digest alone). It cannot make that judgement and does not try — it forces the judgement to happen where the text moves rather than be discovered by a licensee later.

## Proven behaviours

Against a temporarily edited LICENSE, restored byte-for-byte after each:

| Change | Result |
|---|---|
| terms edited, version static (the `f3c925c` case) | **fails** |
| major bump, identifier static | **fails** |
| minor bump, identifier static | **passes** — no churn, which is the point |

## Not in scope

jdocmunch-mcp and jdatamunch-mcp state no licence version at all, so their identifiers stay suffix-less and the bidirectional check @marcelruhf wrote is already correct there. Giving those files a version line is a licence edit, not a packaging one.

**Suite:** 8084 passed, 17 skipped, 0 failed. `ruff check src/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)