### PR TITLE
chore(license): take the aside out of the operative clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+### The aside came out of the LICENSE files
+
+`He's kinda full of himself.` sat inside condition 2 of all three LICENSE files,
+in the middle of the derivation-and-attribution obligation. It stays in the
+README, where it reads as the author's voice; a licence is the document a
+customer's counsel reads before allowlisting, and a joke inside an operative
+clause makes a reader stop and work out whether it is operative.
+
+⚠ **This is the first exercise of the digest pin shipped an hour earlier, and it
+routed correctly.** The edit grants and removes nothing, so it is EDITORIAL:
+`_LICENSE_DIGEST` was updated and the version, the identifier and the suffix were
+left alone. **A downstream allowlist on `LicenseRef-jCodeMunch-Dual-Use-1` is not
+churned by this**, which is the whole reason the identifier is major-only.
+
+⚠ Removed from jdocmunch-mcp and jdatamunch-mcp too, where the same line sat in
+the same clause.
+
 ### The licence identifier tracks the MAJOR version only (@marcelruhf)
 
 1.108.288 shipped `LicenseRef-jCodeMunch-Dual-Use-1.1`, which invalidates a

--- a/LICENSE
+++ b/LICENSE
@@ -50,7 +50,6 @@ CONDITIONS (all uses)
    redistributed version. Any modifications made to the software must
    clearly indicate that they are derived from the original work, and
    the name of the original author (J. Gravelle) must remain intact.
-   He's kinda full of himself.
 
 3. The software may not be used, directly or indirectly, in any
    product, service, or workflow that generates revenue, is offered

--- a/tests/test_license_identifier_agreement.py
+++ b/tests/test_license_identifier_agreement.py
@@ -81,7 +81,7 @@ def test_mcpb_manifest_derives_the_identifier_rather_than_copying_it() -> None:
 # on checkout, so a byte digest is a property of the checkout rather than of the
 # terms: this pin was red on all four Ubuntu legs and green on all four Windows
 # legs on its first run. **A licence says the same thing in either encoding.**
-_LICENSE_DIGEST = "646a3993057657577c2e3f56977a18ccf329fd0b85f827b1673d151747ccda11"
+_LICENSE_DIGEST = "66ed60bbc2a646e4bf7cde22a636b1a7ddeef514bb95b3b88af1e944457d6f38"
 
 
 def _license_terms() -> bytes:


### PR DESCRIPTION
`He's kinda full of himself.` sat inside **condition 2** of the LICENSE, in the middle of the derivation-and-attribution obligation:

```
   clearly indicate that they are derived from the original work, and
   the name of the original author (J. Gravelle) must remain intact.
   He's kinda full of himself.
```

It stays in the README, where it reads as the author's voice. A licence is the document a customer's counsel reads before allowlisting, and a joke inside an operative clause makes a reader stop and work out whether it is operative.

Removed from jdocmunch-mcp and jdatamunch-mcp as well, where the same line sits in the same clause.

## The digest pin's first real exercise, and it routed correctly

#521 shipped an hour ago. This edit **grants and removes nothing**, so it is editorial: `_LICENSE_DIGEST` updated, and the LICENSE version, the identifier and its suffix left alone.

A downstream allowlist on `LicenseRef-jCodeMunch-Dual-Use-1` is **not churned by this**, which is exactly why @marcelruhf asked for a major-only identifier. Had the same mechanism keyed on the full version, this tone edit would have invalidated his entry.

**Suite:** 8084 passed, 17 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)