### PR TITLE
bench(route): identifier-shape does not discriminate — measured, refuted

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -644,12 +644,52 @@ the emitted distribution, not a citation of 69.5%.**
 counter-evidence becomes a number to clear and then forget. Under (a) it stays a
 standing disclosure that has to be argued past every time.
 
-⚠ **The next piece of work is named and its data already exists.** v1.108.253
-identified the missing rank-1 discriminator — most likely "does the task name an
-identifier-shaped token" — and declined to guess it without fresh data. The
-corpus holds **157 unused rows** (197 minus the 40 sampled). The author's
-standing offer on #422: *"willing, but do not wait on me... if you or anyone
-else wants to run it, take it."*
+⚠⚠ **THE NAMED NEXT PIECE OF WORK WAS TESTED AND REFUTED, 2026-08-20. DO NOT
+BUILD IT.** v1.108.253 identified the missing rank-1 discriminator — "most
+likely 'does the task name an identifier-shaped token'" — and declined to guess
+without fresh data. It was measured instead of built:
+`benchmarks/route_recall/measure_shape_separation.py`, artifact
+`shape_separation_results.json`, over the same corpus digest the emitted-task run
+used.
+
+| sample | rule | majority floor | lift | coverage |
+| --- | ---: | ---: | ---: | ---: |
+| 164 raw prompts | 48.8% | 50.0% | **-1.2 pts** | 15% |
+| 35 emitted tasks | 60.0% | 51.4% | +8.6 pts | 14% |
+
+⚠ **The positive row is n=5.** Identifier-shape fires on five emitted tasks and
+gets four right. Under the null that is **p = 0.17** — a one-in-six coincidence,
+and one case flipping moves it twenty points. **The larger sample is the one to
+read, and there the rule is WORSE THAN A CONSTANT ANSWER.**
+
+⚠⚠ **COVERAGE IS THE FINDING, AND IT KILLS THE IDEA EVEN AT PERFECT PURITY.**
+The predicate fires on ~15% of family cases either way, so **the 85% residue —
+at 51-57% purity, which is the coin flip we started with — is untouched by any
+version of this rule.** A discriminator that cannot reach the majority case is
+not a discriminator for this problem. ⚠ Per-pattern breakdown is in the artifact
+and nothing survives: `snake_case` 3/6, `PascalCase` 7/13, `camelCase` 1/3.
+**Seven patterns were tested on one sample, so expect one to look good by
+chance; none is a finding.**
+
+⚠ **The predicate is declared in the script ABOVE the point labels are read**,
+and that ordering is the only thing separating this from a search for a pattern
+that fits. Anyone re-testing a discriminator hypothesis here does the same or the
+result means nothing.
+
+⚠ **What this does NOT refute.** The signal may be in the VERB rather than the
+token — "where is X defined" against "everywhere X appears". That is a different
+hypothesis and gets the same cheap pre-test before anyone writes a rule.
+⚠⚠ **The likelier reading is that .253 was right on the merits: "find X" is
+genuinely undecidable without more signal.** `route` returns 2-3 candidates on 38
+of 40 cases BY DESIGN, and `strict@3` is 80% against a 70% floor. **`@1` is the
+metric that penalises a router for being honest about ambiguity** — a perfectly
+calibrated one that says "it is one of these two" scores zero on it. Decide
+whether `@1` is the objective before optimising it.
+
+⚠ **157 corpus rows remain unused** (197 minus the 40 sampled) and the author's
+standing offer on #422 holds: *"willing, but do not wait on me... if you or
+anyone else wants to run it, take it."* **That data is still there for the next
+hypothesis; it has now answered this one.**
 
 ⚠ **Progress is measured from 45.8, never from 42.4.** The 3.4-point move
 between them was v1.108.218's corpus correction, not routing work. A reader who

--- a/benchmarks/route_recall/measure_shape_separation.py
+++ b/benchmarks/route_recall/measure_shape_separation.py
@@ -1,0 +1,167 @@
+"""Does identifier-shape predict search_symbols vs search_text? Measured: no.
+
+v1.108.253 fixed `route`'s @3 collapse on emitted task strings and named the
+remaining gap without guessing at it: a rank-1 discriminator, "most likely
+'does the task name an identifier-shaped token'". This script tests that
+hypothesis before anyone builds a rule on it.
+
+⚠⚠ THE PREDICATE IS DECLARED BEFORE ANY LABEL IS READ. That ordering is the
+only thing separating a test from a search for a pattern that fits.
+
+Result (2026-08-20, see shape_separation_results.json): the rule scores BELOW
+a constant answer on the larger sample, and its coverage is ~15% either way,
+so the residue it cannot reach IS the problem. Do not build it.
+
+Usage:
+    python measure_shape_separation.py [--corpus path/to/route_candidates_v0.1.csv]
+
+Without --corpus the file is fetched from the published dataset and its sha256
+is verified against the digest this measurement was taken over.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import re
+from collections import Counter
+from pathlib import Path
+
+CORPUS_URL = (
+    "https://raw.githubusercontent.com/rknighton/jcm-route-benchmark-corpus"
+    "/main/data/route_candidates_v0.1.csv"
+)
+# The digest emitted_task_cases.json recorded, so both measurements are over
+# one corpus rather than two spellings of a moving one.
+CORPUS_SHA256 = "25d09f6ae9e8e668d1a3b9a30755cf8dbd7d063ce08868529cc152fdfe84b86e"
+
+HERE = Path(__file__).parent
+SEARCH_FAMILY = {"search_text", "search_symbols"}
+
+# ── The predicate. Declared before labels. ────────────────────────────────
+PATTERNS = {
+    "snake_case": re.compile(r"\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b"),
+    "camelCase": re.compile(r"\b[a-z]+[A-Z][A-Za-z0-9]*\b"),
+    "PascalCase": re.compile(r"\b[A-Z][a-z0-9]+[A-Z][A-Za-z0-9]*\b"),
+    "CONSTANT_CASE": re.compile(r"\b[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+\b"),
+    "call_form": re.compile(r"\b\w+\(\s*\)"),
+    "dotted_path": re.compile(r"\b[A-Za-z_]\w*\.[A-Za-z_]\w*\b"),
+    "backticked": re.compile(r"`[^`\n]+`"),
+}
+
+
+def shape_hits(text: str) -> list[str]:
+    return sorted(name for name, pat in PATTERNS.items() if pat.search(text or ""))
+
+
+def is_identifier_shaped(text: str) -> bool:
+    return bool(shape_hits(text))
+
+
+# ── Measurement ───────────────────────────────────────────────────────────
+
+def _binom_ge(k: int, n: int, p: float) -> float:
+    """P(at least k of n) under the null. Small buckets need this stated."""
+    return sum(math.comb(n, i) * p**i * (1 - p) ** (n - i) for i in range(k, n + 1))
+
+
+def _score(pairs: list[tuple[bool, str]]) -> dict:
+    """pairs of (shaped, gold). The rule under test: shaped -> symbols."""
+    tab = Counter(pairs)
+    n = len(pairs)
+    correct = tab[(True, "search_symbols")] + tab[(False, "search_text")]
+    symbols = sum(tab[(s, "search_symbols")] for s in (True, False))
+    majority = max(symbols, n - symbols)
+    fires = sum(tab[(True, g)] for g in SEARCH_FAMILY)
+    return {
+        "n": n,
+        "table": {
+            "shaped": {g: tab[(True, g)] for g in sorted(SEARCH_FAMILY)},
+            "unshaped": {g: tab[(False, g)] for g in sorted(SEARCH_FAMILY)},
+        },
+        "rule_accuracy_pct": round(correct / n * 100, 1),
+        "majority_floor_pct": round(majority / n * 100, 1),
+        "lift_over_floor_pts": round((correct - majority) / n * 100, 1),
+        "coverage_pct": round(fires / n * 100, 1),
+        "residue_purity_pct": round(
+            max(tab[(False, g)] for g in SEARCH_FAMILY) / max(n - fires, 1) * 100, 1
+        ),
+    }
+
+
+def _load_corpus(path: str | None) -> list[dict]:
+    if path:
+        raw = Path(path).read_bytes()
+    else:
+        import urllib.request
+
+        with urllib.request.urlopen(CORPUS_URL) as resp:  # noqa: S310 (pinned host)
+            raw = resp.read()
+    digest = hashlib.sha256(raw).hexdigest()
+    if digest != CORPUS_SHA256:
+        raise SystemExit(
+            f"corpus digest {digest} != {CORPUS_SHA256}. The dataset moved; this "
+            "measurement's numbers are not comparable to it until re-run."
+        )
+    return list(csv.DictReader(raw.decode("utf-8").splitlines()))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus", default=None)
+    ap.add_argument("--write", action="store_true", help="update the results artifact")
+    args = ap.parse_args()
+
+    cases = json.loads(
+        (HERE / "emitted_task_cases.json").read_text(encoding="utf-8")
+    )["cases"]
+    emitted = [c for c in cases if c["gold_primary"] in SEARCH_FAMILY]
+    emitted_result = _score(
+        [(is_identifier_shaped(c["emitted_task"]), c["gold_primary"]) for c in emitted]
+    )
+    base = sum(1 for c in emitted if c["gold_primary"] == "search_symbols") / len(emitted)
+    shaped_right = emitted_result["table"]["shaped"]["search_symbols"]
+    shaped_n = sum(emitted_result["table"]["shaped"].values())
+    emitted_result["null_p_of_shaped_bucket"] = round(
+        _binom_ge(shaped_right, shaped_n, base), 3
+    )
+
+    rows = _load_corpus(args.corpus)
+    prompts = [r for r in rows if r["gold_primary_action"] in SEARCH_FAMILY]
+    prompt_result = _score(
+        [(is_identifier_shaped(r["prompt_text"]), r["gold_primary_action"]) for r in prompts]
+    )
+
+    per_pattern = {}
+    for name in PATTERNS:
+        hit = [r for r in prompts if name in shape_hits(r["prompt_text"])]
+        if hit:
+            sy = sum(1 for r in hit if r["gold_primary_action"] == "search_symbols")
+            per_pattern[name] = {"fires": len(hit), "search_symbols": sy}
+        else:
+            per_pattern[name] = {"fires": 0}
+
+    out = {
+        "hypothesis": "identifier-shape predicts search_symbols over search_text",
+        "verdict": "REFUTED",
+        "corpus": {"source": CORPUS_URL, "sha256": CORPUS_SHA256},
+        "emitted_tasks": emitted_result,
+        "raw_prompts": prompt_result,
+        "per_pattern_exploratory": per_pattern,
+        "per_pattern_note": (
+            "Seven patterns tested on one sample. Expect one to look good by chance; "
+            "none is a finding on its own."
+        ),
+    }
+    print(json.dumps(out, indent=1))
+    if args.write:
+        (HERE / "shape_separation_results.json").write_text(
+            json.dumps(out, indent=1) + "\n", encoding="utf-8"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/route_recall/shape_separation_results.json
+++ b/benchmarks/route_recall/shape_separation_results.json
@@ -1,0 +1,75 @@
+{
+ "hypothesis": "identifier-shape predicts search_symbols over search_text",
+ "verdict": "REFUTED",
+ "corpus": {
+  "source": "https://raw.githubusercontent.com/rknighton/jcm-route-benchmark-corpus/main/data/route_candidates_v0.1.csv",
+  "sha256": "25d09f6ae9e8e668d1a3b9a30755cf8dbd7d063ce08868529cc152fdfe84b86e"
+ },
+ "emitted_tasks": {
+  "n": 35,
+  "table": {
+   "shaped": {
+    "search_symbols": 4,
+    "search_text": 1
+   },
+   "unshaped": {
+    "search_symbols": 13,
+    "search_text": 17
+   }
+  },
+  "rule_accuracy_pct": 60.0,
+  "majority_floor_pct": 51.4,
+  "lift_over_floor_pts": 8.6,
+  "coverage_pct": 14.3,
+  "residue_purity_pct": 56.7,
+  "null_p_of_shaped_bucket": 0.17
+ },
+ "raw_prompts": {
+  "n": 164,
+  "table": {
+   "shaped": {
+    "search_symbols": 11,
+    "search_text": 13
+   },
+   "unshaped": {
+    "search_symbols": 71,
+    "search_text": 69
+   }
+  },
+  "rule_accuracy_pct": 48.8,
+  "majority_floor_pct": 50.0,
+  "lift_over_floor_pts": -1.2,
+  "coverage_pct": 14.6,
+  "residue_purity_pct": 50.7
+ },
+ "per_pattern_exploratory": {
+  "snake_case": {
+   "fires": 6,
+   "search_symbols": 3
+  },
+  "camelCase": {
+   "fires": 3,
+   "search_symbols": 1
+  },
+  "PascalCase": {
+   "fires": 13,
+   "search_symbols": 7
+  },
+  "CONSTANT_CASE": {
+   "fires": 1,
+   "search_symbols": 0
+  },
+  "call_form": {
+   "fires": 1,
+   "search_symbols": 1
+  },
+  "dotted_path": {
+   "fires": 3,
+   "search_symbols": 1
+  },
+  "backticked": {
+   "fires": 0
+  }
+ },
+ "per_pattern_note": "Seven patterns tested on one sample. Expect one to look good by chance; none is a finding on its own."
+}


### PR DESCRIPTION
v1.108.253 named the missing rank-1 discriminator — *"most likely 'does the task name an identifier-shaped token'"* — and declined to guess without fresh data. This tests it instead of building it.

## Verdict: refuted

| sample | rule | majority floor | lift | coverage |
| --- | ---: | ---: | ---: | ---: |
| 164 raw prompts | 48.8% | 50.0% | **−1.2 pts** | 15% |
| 35 emitted tasks | 60.0% | 51.4% | +8.6 pts | 14% |

**The positive row is n=5.** Shape fires on five emitted tasks and gets four right — **p = 0.17** under the null. One case flipping moves it twenty points. The larger sample is the one to read, and there the rule is worse than a constant answer.

**Coverage is the finding, and it kills the idea at perfect purity.** The predicate fires on ~15% of family cases either way, so the **85% residue — at 51–57% purity, the coin flip we started with — is untouched by any version of this rule.** A discriminator that cannot reach the majority case isn't one for this problem.

Per-pattern: `snake_case` 3/6, `PascalCase` 7/13, `camelCase` 1/3. Seven patterns tested on one sample, so expect one to look good by chance; none is a finding, and the artifact says so.

## Method

**The predicate is declared in the script above the point labels are read.** That ordering is the only thing separating this from a search for a pattern that fits, and anyone re-testing a discriminator hypothesis here has to do the same.

Corpus digest verified against the one `emitted_task_cases.json` recorded, so both measurements are over one dataset rather than two spellings of a moving one. The script refuses to run on a mismatch.

## What this does not refute

The signal may be in the **verb** rather than the token — "where is X defined" vs "everywhere X appears". Different hypothesis, same cheap pre-test before anyone writes a rule.

The likelier reading is that .253 was right on the merits: "find X" is genuinely undecidable without more signal. `route` returns 2–3 candidates on 38 of 40 cases **by design**, and `strict@3` is 80% against a 70% floor. **`@1` is the metric that penalises a router for being honest about ambiguity** — a perfectly calibrated one saying "it's one of these two" scores zero on it. Worth deciding whether `@1` is the objective before optimising it.

## Scope

Benchmark script + JSON artifact + ROADMAP. **No CHANGELOG entry** — nothing user-facing, so this does not trip the 1.108.289 content-update trigger. Suite 8084 passed / 17 skipped / 0 failed; `[Unreleased]` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)