### PR TITLE
docs: the mcp_toolset defer path, and the vendor's catalog-size number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## [Unreleased]
 
+### Docs - deferring our schemas via Anthropic tool search, and a catalog-size number from the vendor
+
+README gains a section on keeping jCodeMunch's tool schemas out of the context
+prefix using [tool search](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool).
+⚠ For an MCP server you do **not** set `defer_loading` per tool — it goes once
+on the `mcp_toolset` entry's `default_config`, with per-tool `configs`
+overriding it. The snippet keeps `resolve_repo` / `search_symbols` /
+`get_ranked_context` resident, which is Anthropic's own 3–5-resident-tools
+advice. ⚠ Both halves of the connector are required and the beta header is
+named, because the `tools`-only form is a validation error; and the connector
+is URL-based, so this is for `sse` / `streamable-http`, not default stdio.
+⚠ Deferred definitions are excluded from the prefix and appended as
+`tool_reference` blocks, so **prompt caching is preserved** — worth stating,
+since a dynamic tool list normally invalidates it.
+
+ROADMAP records a number beside the catalog moratorium:
+
+> "Claude's ability to pick the right tool degrades once you exceed **30–50
+> available tools**."
+
+⚠⚠ **We serve 91 on `full` and that is 2–3x past it** — the first EXTERNAL
+evidence for the freeze, and it is on an axis the exit conditions do not
+measure. Every prior argument has been about whether `route` is good enough;
+this says the catalog is already past where the *model's* selection degrades,
+independent of `route`. ⚠⚠ **It moves conditions 1–3 in neither direction and
+must not be cited as progress**: the "over 85 percent" headline is a TOKEN
+figure over a five-server setup, their accuracy claim carries no number, and
+our wall is `route` at 52.2% against a 51.4% majority baseline. ⚠ Their 85% and
+our 95.9% have the same epistemic status — one configuration each, neither a
+benchmark. ⚠ The 91 applies to carried-forward installs; `init` writes
+`counter` (3 tools) on a first-ever install.
+
 ### Fixed - `_build`, the third spelling of a build tree
 
 `build` and `.build` were both excluded from indexing. `_build` was not — and

--- a/README.md
+++ b/README.md
@@ -183,6 +183,43 @@ It helps most on targeted edits (one function, one method, one class), which is 
 
 <a id="background-behavior-fully-disclosed"></a>
 
+## Deferring the tool schemas (Anthropic tool search)
+
+If you reach jCodeMunch through the [MCP connector](https://platform.claude.com/docs/en/agents-and-tools/mcp-connector) on a model that supports [tool search](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool), you can keep our schemas out of your context prefix entirely and let Claude load only the two or three tools a request needs. **You do not set `defer_loading` per tool** — set it once for the whole server:
+
+```json
+{
+  "mcp_servers": [
+    { "type": "url", "url": "https://your-host/mcp", "name": "jcodemunch" }
+  ],
+  "tools": [
+    { "type": "tool_search_tool_bm25_20251119", "name": "tool_search_tool_bm25" },
+    {
+      "type": "mcp_toolset",
+      "mcp_server_name": "jcodemunch",
+      "default_config": { "defer_loading": true },
+      "configs": {
+        "resolve_repo":       { "defer_loading": false },
+        "search_symbols":     { "defer_loading": false },
+        "get_ranked_context": { "defer_loading": false }
+      }
+    }
+  ]
+}
+```
+
+Send it with the beta header `mcp-client-2025-11-20`. **Both halves are required** — `mcp_servers` alone is a validation error, and so is `mcp_toolset` without the matching `mcp_server_name`.
+
+⚠ **The MCP connector takes a URL, so this applies to jCodeMunch served over `sse` or `streamable-http`** (`jcodemunch-mcp serve --transport streamable-http`), not to the default local stdio setup. On stdio, whether schemas are deferred is up to your client, and `tool_surface: "counter"` below is the lever you control.
+
+The `configs` block above follows Anthropic's own advice — keep your 3–5 most-used tools resident so common requests skip the search round trip — and per-tool `configs` overrides `default_config`.
+
+Deferred definitions are excluded from the system-prompt prefix and appended inline as `tool_reference` blocks when Claude discovers them, **so prompt caching is preserved** — this is not the cache-invalidating kind of dynamic tool list. At least one tool in the request must stay non-deferred, or the API returns a 400.
+
+⚠ **This is a different mechanism from our own `tool_surface: "counter"`**, and you do not need both. Tool search is host-side and works across every MCP server you have connected; the Counter is server-side, works on any host including ones with no tool-search support, and is what `init` configures on a first-ever install. Pick whichever your host supports — see [CONFIGURATION.md](CONFIGURATION.md#the-counter--collapse-to-a-3-tool-front-door-tool_surface) for the Counter and `jcodemunch-mcp surface` for what your install actually advertises.
+
+---
+
 ## Security, privacy, and background behavior
 
 Local-first by design: indexes live at `~/.code-index/`, and the base package's only default network behavior is an anonymous savings counter (random ID plus aggregate token counts, no code, no paths, no PII; opt out with `share_savings: false`). Everything the server does beyond answering a tool call (file watching, the opt-in login service, license validation, model downloads, org reporting) is opt-in or opt-out, visible, and reversible, and every item is enumerated in **[SECURITY.md](SECURITY.md#background-behavior-fully-disclosed)** alongside the path-traversal, symlink, and secret-redaction controls.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -575,6 +575,45 @@ functionally absent while still costing a schema, a 1.x compatibility promise,
 an output contract and a test matrix. #397 is the sharp end: generated
 `CLAUDE.md` named 25 tools against a server exposing 6.
 
+⚠⚠ **THE MODEL VENDOR NOW PUTS A NUMBER ON THE CATALOG-SIZE COST, AND WE ARE
+2-3x PAST IT** (recorded 2026-08-24 from Anthropic's [tool search
+docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool)):
+
+> "Claude's ability to pick the right tool degrades once you exceed **30-50
+> available tools**."
+
+`jcodemunch-mcp surface` on `full` reports **91 visible of 94**; the canonical
+`benchmarks/schema_baseline.json` puts that payload at **22,741 tokens**
+(`full_full`) against **939** for `counter`. Their "when to use tool search"
+list — 10+ tools, definitions over 10k tokens, a library that grows — describes
+this server exactly.
+
+⚠⚠ **THIS IS EVIDENCE FOR THE FREEZE, NOT AGAINST IT, AND IT IS THE FIRST
+EXTERNAL NUMBER WE HAVE.** Every argument to exit has so far been about whether
+`route` is good enough. This says the catalog is already past the size at which
+the MODEL's own selection degrades, independent of `route`. **A 92nd action
+makes the number worse on an axis the exit conditions do not measure at all.**
+
+⚠⚠ **AND IT DOES NOT TOUCH THE EXIT CONDITIONS — do not cite it as progress.**
+The headline "over 85 percent" reduction is a TOKEN figure over a five-server
+MCP setup; their accuracy claim ("selection accuracy stays high") carries **no
+number**. Our wall is that `route` scores **52.2% vs a 51.4% majority baseline**
+on agent wording, i.e. chance. **Nothing in that document measures routing
+accuracy, so nothing in it moves conditions 1-3 in either direction.** Anyone
+quoting the 85% at this block is answering an accuracy question with a token
+number — the same category error as quoting 71.2% at the emitted distribution.
+
+⚠ **Their 85% and our 95.9% have the SAME epistemic status**: each characterises
+one configuration, neither is a benchmark. Do not present theirs as validating
+ours, and do not let ours be read as competing with theirs.
+
+⚠ **The surface default is split and the distinction matters when quoting 91.**
+`init` writes `tool_surface: "counter"` on a genuinely first-ever install (3
+tools). The config template and the env fallback both resolve to `full`, so an
+upgraded install, or one with no config, serves all 91. **The 30-50 finding
+therefore applies to the carried-forward population, not to new installs** —
+which is an argument about the default, tracked separately from this freeze.
+
 **Exit conditions, named before the work** (same discipline as Arc 4's
 thresholds — neither side picks the bar after seeing results):
 


### PR DESCRIPTION
Two documentation changes from reading [Anthropic's tool search docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool).

## README — deferring our schemas

For an MCP server you do **not** set `defer_loading` per tool. It goes once on the `mcp_toolset` entry's `default_config`, with per-tool `configs` overriding it — the snippet keeps `resolve_repo` / `search_symbols` / `get_ranked_context` resident, which is Anthropic's own 3–5-resident-tools advice.

Two things the first draft got wrong and this fixes:

- **Both halves of the connector are required.** `mcp_servers` alone is a validation error, and so is `mcp_toolset` without it. The beta header is named. A snippet that does not work as pasted costs the reader a debugging cycle.
- **The connector is URL-based**, so this is for `sse` / `streamable-http`, not the default local stdio setup — on stdio the client decides and `tool_surface` is the lever the user controls. The section says so rather than letting a stdio user try it.

Also stated because it is easy to miss: deferred definitions are excluded from the system-prompt prefix and appended as `tool_reference` blocks, **so prompt caching is preserved**. A dynamic tool list normally invalidates it.

## ROADMAP — a number beside the moratorium

> "Claude's ability to pick the right tool degrades once you exceed **30–50 available tools**."

`jcodemunch-mcp surface` on `full` reports **91 visible of 94**; `benchmarks/schema_baseline.json` puts that at **22,741 tokens** against **939** for `counter`.

⚠⚠ **This is the first external evidence for the freeze, and it is on an axis the exit conditions do not measure.** Every argument to exit has been about whether `route` is good enough. This says the catalog is already past the size at which the *model's* selection degrades, independent of `route` — so a 92nd action makes the number worse in a way conditions 1–3 cannot see.

⚠⚠ **It moves conditions 1–3 in neither direction and must not be cited as progress.** The "over 85 percent" headline is a **token** figure over a five-server MCP setup; their accuracy claim carries no number; our wall is `route` at **52.2% vs a 51.4% majority baseline** on agent wording. Quoting the 85% at this block answers an accuracy question with a token number.

⚠ Their 85% and our 95.9% have the **same epistemic status** — one configuration each, neither a benchmark. Neither validates the other.

⚠ The 91 applies to **carried-forward** installs. `init` writes `tool_surface: "counter"` (3 tools) on a genuinely first-ever install, while the config template and env fallback resolve to `full`. That is an argument about the default, tracked separately from this freeze.

## Verification

Docs only. `tests/test_catalog_moratorium.py` + `test_route_recall_artifacts_are_fresh.py` pass (17). Full suite **8248 passed / 17 skipped**, 8265 total — unchanged, as a docs change should be. README JSON snippet parses; the CONFIGURATION.md anchor resolves.