### PR TITLE
fix(hooks): a strict deny requires a target the hook can resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 ## [Unreleased]
 
+### Fixed - a strict deny now requires a target the hook can resolve (#541)
+
+Two blindnesses in the same guard, found in ordinary use of the
+`Read|Grep|Glob|Bash` matcher rather than by looking for them. Both only bite
+`JCODEMUNCH_ENFORCE=strict`, where the cost is blocked work; advisory (the
+default) got one extra nudge.
+
+**1. Shell expansions.** `_bash_targets_outside_roots` reads path tokens out of
+the raw command string, so it cannot see `$B`, `${B}`, `$HOME`, `$(...)` or
+backticks. Overlap is then judged on `cwd`, which is the indexed repo, so it
+denied. ⚠⚠ **The reported pair: `grep ~/x.md` allowed, `grep $HOME/x.md`
+denied — same destination, opposite verdicts.**
+
+⚠ Not a regex gap to close: the hook cannot know what `$B` holds and guessing
+is worse than not looking. **A deny now requires a resolvable target**, which
+is the caution already applied everywhere else in that function (`find` is
+never deniable, a pipeline is never denied, `../` returns silent). It
+downgrades to a nudge rather than to silence — a wrong nudge is a sentence of
+text, a wrong deny is blocked work.
+
+⚠⚠ **The detector is deliberately not a bare `\$`.** A trailing `$` is a regex
+end-anchor and `grep -n "foo$" src/` is idiomatic; suppressing on any `$` would
+stop denying one of the commonest in-repo searches and quietly weaken the
+enforcement a strict user opted into. Requiring a name char, `{` or `(` after
+the `$` separates an expansion from an anchor.
+
+**2. Windows absolute paths — surfaced BY the test for the first half.**
+`_BASH_PATH_TOKEN_RE` recognised only POSIX-style roots, so `/c/Users/j/x.md`
+(git-bash) was seen and **`C:/Users/j/x.md` was not**. ⚠⚠ **A strict deny fired
+on a search targeting a path outside every indexed root, on the platform most
+of this project's users are on, and the verdict depended on how the user
+spelled the drive.** Unlike a `$VAR` this is genuinely resolvable, so it gets a
+real fix rather than a downgrade: the token regex now matches `C:/…`, `C:\…`
+and a leading quote. A quoted path containing a space still captures only its
+first segment, which resolves to "not inside any root" and therefore errs
+toward allowing.
+
+⚠ `tests/test_strict_deny_requires_resolvable_target.py` asserts outcomes both
+ways — the outside cases must not deny, and the in-repo cases (including regex
+end-anchors and a drive-letter path inside the repo) must still deny, which is
+what stops either fix from becoming a strict-mode regression. Verified by
+reintroducing each defect separately: each fails only its own half.
+
+⚠ Hermetic by construction. The first draft resolved the real index and
+reported **11 skipped** under conftest's `CODE_INDEX_PATH` isolation — a file
+announcing success while checking nothing, which is the v1.108.293 defect class
+in a new costume. It now owns its roots via `monkeypatch`.
+
+The matcher that surfaced this is @marcelruhf's from
+[#535](https://github.com/jgravelle/jcodemunch-mcp/pull/535); the guard it
+slipped past already handled four other shapes correctly.
+
 ### Docs - deferring our schemas via Anthropic tool search, and a catalog-size number from the vendor
 
 README gains a section on keeping jCodeMunch's tool schemas out of the context

--- a/src/jcodemunch_mcp/cli/hooks/steering.py
+++ b/src/jcodemunch_mcp/cli/hooks/steering.py
@@ -178,7 +178,42 @@ _BASH_SEARCH_RE = re.compile(
 )
 
 # Absolute or ~-anchored path tokens inside a command line.
-_BASH_PATH_TOKEN_RE = re.compile(r"(?:^|[\s=])((?:/|~/)[^\s;|&)>\"']+)")
+# Absolute or ~-anchored path tokens inside a command line.
+#
+# ⚠⚠ The drive-letter alternative is load-bearing on Windows and was missing
+# (#541, found by the test for the shell-expansion half). `/c/Users/j/x.md`
+# (git-bash) was seen and `C:/Users/j/x.md` was not, so a strict deny fired on
+# a search targeting a path outside every indexed root — on the platform most
+# of this project's users are on.
+#
+# ⚠ Unlike a `$VAR`, a drive-letter path IS resolvable, so this is a real fix
+# rather than a downgrade: the guard now sees the target and answers correctly.
+#
+# ⚠ A leading quote is allowed so `grep "C:/x.md"` is seen. A quoted path
+# containing a space still captures only its first segment, which resolves to
+# "not inside any root" and therefore errs toward ALLOWING — the safe direction.
+_BASH_PATH_TOKEN_RE = re.compile(
+    r"(?:^|[\s=])[\"']?((?:/|~/|[A-Za-z]:[\\/])[^\s;|&)>\"']+)"
+)
+
+# A shell expansion the hook cannot resolve: $VAR, ${VAR}, $(cmd), `cmd`.
+#
+# ⚠⚠ Deliberately NOT a bare `\$`. A trailing `$` is a regex end-anchor and
+# `grep -n "foo$" src/` is idiomatic — treating that as unresolvable would
+# stop denying one of the commonest in-repo searches, weakening the very
+# enforcement a strict-mode user opted into. Requiring a name char, `{` or `(`
+# after the `$` separates an expansion from an anchor.
+_SHELL_EXPANSION_RE = re.compile(r"\$[A-Za-z_{(]|`")
+
+
+def _bash_path_is_unresolvable(command: str) -> bool:
+    """True when the command's target depends on a shell expansion.
+
+    ``_bash_targets_outside_roots`` reads path tokens out of the raw command
+    string, so it is blind to anything the shell has not expanded yet: the
+    hook cannot know what ``$B`` holds, and guessing is worse than not looking.
+    """
+    return _SHELL_EXPANSION_RE.search(command) is not None
 
 
 def _bash_targets_outside_roots(command: str, roots: "list[str]") -> bool:
@@ -215,6 +250,22 @@ def _handle_bash(tool_input: dict, cwd: str, mode: str) -> int:
     deny = mode == "strict" and _BASH_SEARCH_COMMANDS[cmd_word]
     if deny and re.search(r"[|&;]", command):
         deny = False  # Pipeline/compound: the non-search half is real work.
+    if deny and _bash_path_is_unresolvable(command):
+        # ⚠⚠ A DENY REQUIRES A RESOLVABLE TARGET (#541). The overlap test below
+        # judges `cwd` only, so a search whose target sits outside every indexed
+        # root is caught by `_bash_targets_outside_roots` — but only when the
+        # path is written literally. `grep ~/x.md` is allowed and
+        # `grep $HOME/x.md` was denied: same destination, opposite verdicts.
+        #
+        # ⚠ This is not a regex gap to close. `_handle_bash` deliberately does
+        # not parse shell, and the caution already exists everywhere else here:
+        # `find` is never deniable, a pipeline is never denied, `../` returns
+        # silent rather than resolving where it lands. This was the one shape
+        # the same rule was not applied to.
+        #
+        # Downgrade to a nudge rather than going silent: a wrong nudge is a
+        # sentence of text, a wrong deny is blocked work.
+        deny = False
     if not deny and not _search_nudge_enabled():
         return 0  # Guaranteed silent — skip the store load below.
     roots = _indexed_source_roots()

--- a/tests/test_strict_deny_requires_resolvable_target.py
+++ b/tests/test_strict_deny_requires_resolvable_target.py
@@ -1,0 +1,156 @@
+"""A strict deny requires a target the hook can actually resolve (#541).
+
+`_handle_bash` judges indexed-root overlap on `cwd` alone, and relies on
+`_bash_targets_outside_roots` to stay quiet when the command names a path jcm
+cannot serve. That guard reads path tokens out of the RAW command string, so it
+is blind to anything the shell has not expanded yet.
+
+⚠⚠ **The reported pair: `grep ~/x.md` was allowed and `grep $HOME/x.md` was
+denied. Same destination, opposite verdicts.** Advisory mode made that a
+harmless extra nudge; strict mode made it blocked work.
+
+⚠ **This is not a regex gap to close.** `_handle_bash` deliberately does not
+parse shell — the hook cannot know what `$B` holds and guessing is worse than
+not looking. The caution already exists everywhere else in that function:
+`find` is never deniable (`find … -delete` opens with the same word), a
+pipeline is never denied (the non-search half is real work), and `../` returns
+silent rather than resolving where it lands. The unexpanded-expansion case is
+the same shape, and was the one place the rule was not applied.
+
+⚠⚠ **The fix must not weaken strict mode, which is the whole reason someone
+turned it on.** A trailing `$` is a regex end-anchor, and `grep -n "foo$" src/`
+is idiomatic — suppressing the deny on any `$` would stop denying one of the
+commonest in-repo searches. The anchor cases below are as load-bearing as the
+expansion cases; a blunt `\\$` passes half this file and fails the other half.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from jcodemunch_mcp.cli.hooks import steering
+
+
+# A root the TEST owns. Nothing here touches the developer's real index --
+# conftest isolates CODE_INDEX_PATH, so a fixture that needed a real indexed
+# repo would skip locally AND in CI, and 11 skips is a file that reports
+# success while checking nothing (the v1.108.293 defect class).
+@pytest.fixture
+def indexed(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    (root / "src").mkdir(parents=True)
+    norm = steering._norm_path(str(root))
+    monkeypatch.setattr(steering, "_indexed_source_roots", lambda: [norm])
+    return str(root)
+
+
+def _verdict(capsys, command: str, cwd: str, *, mode: str = "strict") -> str:
+    """Classify what the Bash branch emits for one command."""
+    capsys.readouterr()
+    steering._handle_bash({"command": command}, cwd, mode)
+    out = capsys.readouterr().out.strip()
+    if not out:
+        return "allow"
+    block = json.loads(out).get("hookSpecificOutput", {})
+    return "deny" if block.get("permissionDecision") == "deny" else "nudge"
+
+
+# Every one of these targets a path OUTSIDE every indexed root, written so the
+# hook cannot see it. None may be denied.
+UNRESOLVABLE = [
+    pytest.param('grep -n p "$B/x.md"', id="dollar-var"),
+    pytest.param('grep -n p "${B}/x.md"', id="braced-var"),
+    pytest.param("grep -n p $HOME/x.md", id="dollar-home"),
+    pytest.param("grep -n p $(dirname $X)/f.md", id="command-substitution"),
+    pytest.param("grep -n p `pwd`/f.md", id="backticks"),
+]
+
+# In-repo searches the hook CAN resolve. Strict mode must still deny these --
+# they are the reason someone enabled it.
+STILL_DENIED = [
+    pytest.param("grep -rn pattern src/", id="plain-in-repo"),
+    pytest.param('grep -n "foo$" src/', id="regex-end-anchor"),
+    pytest.param('grep -n "^def .*$" src/', id="anchored-pattern"),
+]
+
+
+@pytest.mark.parametrize("command", UNRESOLVABLE)
+def test_unresolvable_target_is_never_denied(capsys, command, indexed):
+    assert _verdict(capsys, command, indexed) != "deny", (
+        f"strict mode denied {command!r}, whose target depends on a shell "
+        "expansion the hook cannot resolve. The same path written literally "
+        "is allowed, so this blocks real work while claiming the search "
+        "targets an indexed repo."
+    )
+
+
+@pytest.mark.parametrize("command", STILL_DENIED)
+def test_resolvable_in_repo_search_is_still_denied(capsys, command, indexed):
+    """⚠ The half that stops the fix from becoming a strict-mode regression."""
+    assert _verdict(capsys, command, indexed) == "deny", (
+        f"strict mode stopped denying {command!r}. A trailing `$` is a regex "
+        "end-anchor, not a shell expansion -- treating it as unresolvable "
+        "silently disables enforcement the user opted into."
+    )
+
+
+def test_a_downgraded_deny_still_steers(capsys, indexed):
+    """Downgrade to a nudge, not to silence.
+
+    A wrong nudge is a sentence of text; a wrong deny is blocked work. Going
+    silent would trade one failure for a quieter one.
+    """
+    assert _verdict(capsys, 'grep -n p "$B/x.md"', indexed) == "nudge"
+
+
+def test_advisory_mode_is_unchanged(capsys, indexed):
+    """The default tier never denied, and must not start caring about this."""
+    assert _verdict(capsys, 'grep -n p "$B/x.md"', indexed, mode="advisory") == "nudge"
+    assert _verdict(capsys, "grep -rn pattern src/", indexed, mode="advisory") == "nudge"
+
+
+def test_literal_outside_paths_still_pass_silently(capsys, indexed, tmp_path):
+    """The guard that already worked keeps working -- not re-implemented."""
+    outside = (tmp_path / "elsewhere" / "x.md").as_posix()
+    assert _verdict(capsys, f"grep -n p {outside}", indexed) == "allow"
+    assert _verdict(capsys, "grep -n p ../x.md", indexed) == "allow"
+
+
+# --- the second finding, surfaced BY the test above ---------------------------
+#
+# ⚠⚠ A native Windows absolute path was invisible to `_BASH_PATH_TOKEN_RE`,
+# which only recognised POSIX-style roots. `/c/Users/j/x.md` (git-bash) was
+# seen; `C:/Users/j/x.md` was not, so strict mode denied a search whose target
+# sits outside every indexed root -- on the platform most users are on.
+#
+# ⚠ Unlike a `$VAR` this is genuinely resolvable, so the remedy is a real fix
+# (see the target) rather than the downgrade the expansion half gets. These
+# cases assert the OUTCOME both ways: outside allows, inside still denies.
+
+WINDOWS_OUTSIDE = [
+    pytest.param("C:/Users/j/x.md", id="drive-forward-slash"),
+    pytest.param(r"C:\Users\j\x.md", id="drive-backslash"),
+    pytest.param('"C:/Program Files/x.md"', id="quoted-with-space"),
+    pytest.param("D:/other/repo/src", id="other-drive"),
+]
+
+
+@pytest.mark.parametrize("target", WINDOWS_OUTSIDE)
+def test_windows_absolute_path_outside_roots_is_not_denied(capsys, target, indexed):
+    assert _verdict(capsys, f"grep -n pattern {target}", indexed) != "deny", (
+        f"strict mode denied a search for {target!r}, which is outside every "
+        "indexed root. The git-bash spelling of the same path was already "
+        "allowed, so the verdict depended on how the user spelled the drive."
+    )
+
+
+def test_windows_absolute_path_inside_the_repo_is_still_denied(capsys, indexed):
+    """⚠ The other half: widening the token regex must not stop it denying.
+
+    Without this, deleting the drive-letter alternative and returning "outside"
+    for everything would pass every case above.
+    """
+    inside = indexed.replace("\\", "/") + "/src"
+    assert _verdict(capsys, f"grep -rn pattern {inside}", indexed) == "deny"


### PR DESCRIPTION
Closes #541. **Two** blindnesses in the same guard — the second was surfaced by the test written for the first.

## 1. Shell expansions (the reported defect)

`_bash_targets_outside_roots` reads path tokens out of the raw command string, so it is blind to `$B`, `${B}`, `$HOME`, `$(...)` and backticks. Overlap is then judged on `cwd`, which is the indexed repo, so it denied.

⚠ **Not a regex gap to close.** The hook cannot know what `$B` holds, and guessing is worse than not looking. **A deny now requires a resolvable target** — the caution that already exists everywhere else in that function (`find` never deniable, pipelines never denied, `../` returns silent). It downgrades to a **nudge, not silence**: a wrong nudge is a sentence of text, a wrong deny is blocked work.

⚠⚠ **The detector is deliberately not a bare `\$`.** A trailing `$` is a regex end-anchor and `grep -n "foo$" src/` is idiomatic — suppressing on any `$` would stop denying one of the commonest in-repo searches and quietly weaken the enforcement a strict user opted into.

## 2. Windows absolute paths (found by the test)

`_BASH_PATH_TOKEN_RE` recognised only POSIX-style roots:

```
grep -n p /c/Users/j/x.md    seen      (git-bash)
grep -n p C:/Users/j/x.md    BLIND  -> denied
grep -n p C:\Users\j\x.md    BLIND  -> denied
```

⚠⚠ **A strict deny fired on a search whose target is outside every indexed root, on the platform most of this project's users are on — and the verdict depended on how the user spelled the drive.**

Unlike a `$VAR` this is genuinely resolvable, so it gets a **real fix rather than a downgrade**. A quoted path containing a space still captures only its first segment, which resolves to "not inside any root" and therefore errs toward allowing.

## Verification

Outcomes asserted **both ways** — the outside cases must not deny, and the in-repo cases must still deny (including regex end-anchors and a drive-letter path *inside* the repo). That second half is what stops either fix from becoming a strict-mode regression.

Non-vacuity, each defect reintroduced separately:

- revert the expansion downgrade → 6 fail, all in the expansion half
- revert the drive-letter alternative → 5 fail, all in the Windows half

Neither reversion touches the other half, so the two guards are independent.

⚠ **The first draft of the test file was wrong and it is worth recording why.** It resolved the developer's real index, which conftest isolates via `CODE_INDEX_PATH` — so it reported **11 skipped** locally and would have in CI too. A file announcing success while checking nothing is the v1.108.293 defect class in a new costume. It now owns its roots via `monkeypatch` and runs everywhere.

Local **8264 passed / 17 skipped / 0 failed**; 8281 total against 8265 — these sixteen tests and nothing else. `ruff check src/` clean.

The matcher that surfaced all of this is @marcelruhf's from #535; the guard it slipped past already handled four other shapes correctly.