### PR TITLE
docs: correct an argument from absence, made the same day it shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## [Unreleased]
 
+### Docs - correcting an argument from absence, made the same day it shipped
+
+1.108.295 recorded the vendor's 30–50 tool degradation threshold beside the
+catalog moratorium, guarded with the claim that **"their accuracy claim carries
+no number."** That was **wrong**. It was true of the tool search docs page and
+false of the [Advanced tool
+use](https://www.anthropic.com/engineering/advanced-tool-use) post that page
+links, which reports tool-selection accuracy **49% → 74% on Opus 4** and
+**79.5% → 88.1% on Opus 4.5** with tool search enabled, on "MCP evaluations".
+
+⚠⚠ **The lesson is the shape of the error, not the number: never argue from an
+absence of evidence you did not go looking for.** One page said "stays high"
+and I read that as nothing published, without following the link it sat next to.
+
+⚠⚠ **The verdict on the moratorium is UNCHANGED and its reason is now
+stronger.** It is not that they published no number — it is that **their number
+measures a different quantity**. Theirs is the MODEL's selection accuracy with
+a retrieval layer available versus all tools loaded, which prices the Counter's
+premise and prices it favourably. Ours is `route`'s own rank-1 accuracy on
+agent-emitted wording, measured directly, sitting at chance (52.2% against a
+51.4% majority baseline). A vendor result showing retrieval helps in general
+cannot stand in for our own measurement showing that *our* router does not, and
+their corpus is unpublished, so it is not an instrument we can run.
+
+⚠ Read it as raising the value of the Counter, not as clearing `route`. Those
+are separate claims and only the second is what the exit conditions gate.
+
+⚠ The 1.108.295 CHANGELOG entry is struck through in place rather than
+rewritten, so the history shows both what shipped and that it was corrected.
+
 ## [1.108.295] - 2026-08-24 - What the guard could not see
 
 ### Fixed - `_build`, the third spelling of a build tree
@@ -154,7 +184,9 @@ measure. Every prior argument has been about whether `route` is good enough;
 this says the catalog is already past where the *model's* selection degrades,
 independent of `route`. ⚠⚠ **It moves conditions 1–3 in neither direction and
 must not be cited as progress**: the "over 85 percent" headline is a TOKEN
-figure over a five-server setup, their accuracy claim carries no number, and
+figure over a five-server setup, ~~their accuracy claim carries no number~~
+[**corrected 2026-08-24 — see the Unreleased entry; it does, in the linked
+Advanced tool use post: 49% → 74% on Opus 4, 79.5% → 88.1% on Opus 4.5**], and
 our wall is `route` at 52.2% against a 51.4% majority baseline. ⚠ Their 85% and
 our 95.9% have the same epistemic status — one configuration each, neither a
 benchmark. ⚠ The 91 applies to carried-forward installs; `init` writes

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -596,12 +596,31 @@ makes the number worse on an axis the exit conditions do not measure at all.**
 
 ⚠⚠ **AND IT DOES NOT TOUCH THE EXIT CONDITIONS — do not cite it as progress.**
 The headline "over 85 percent" reduction is a TOKEN figure over a five-server
-MCP setup; their accuracy claim ("selection accuracy stays high") carries **no
-number**. Our wall is that `route` scores **52.2% vs a 51.4% majority baseline**
-on agent wording, i.e. chance. **Nothing in that document measures routing
-accuracy, so nothing in it moves conditions 1-3 in either direction.** Anyone
-quoting the 85% at this block is answering an accuracy question with a token
-number — the same category error as quoting 71.2% at the emitted distribution.
+MCP setup. Our wall is that `route` scores **52.2% vs a 51.4% majority
+baseline** on agent wording, i.e. chance. Anyone quoting the 85% at this block
+is answering an accuracy question with a token number — the same category
+error as quoting 71.2% at the emitted distribution.
+
+⚠⚠ **CORRECTION, 2026-08-24, SAME DAY AS THE ENTRY ABOVE: this block first said
+their accuracy claim "carries no number". THAT WAS WRONG** — true of the tool
+search DOCS page, false of the [Advanced tool
+use](https://www.anthropic.com/engineering/advanced-tool-use) post it links,
+which reports tool-selection accuracy **49% -> 74% on Opus 4** and **79.5% ->
+88.1% on Opus 4.5** with tool search enabled, on "MCP evaluations". **Never
+argue from an absence of evidence you did not go looking for.**
+
+⚠⚠ **The verdict is unchanged and the REASON is now better.** It is not that
+they published no number; it is that **their number measures a different
+quantity**. Theirs is the MODEL's selection accuracy with a retrieval layer
+available versus all tools loaded — i.e. it prices the Counter's premise, and
+prices it favourably. Ours is `route`'s OWN rank-1 accuracy on agent-emitted
+wording, measured directly, and it sits at chance. **A vendor number showing
+that retrieval helps in general cannot substitute for our own measurement
+showing that OUR router does not.** Their corpus is unpublished, so it is not
+an instrument we can run either.
+
+⚠ **Read it as raising the value of the Counter, not as clearing `route`.**
+Those are separate claims and only the second is what conditions 1-3 gate.
 
 ⚠ **Their 85% and our 95.9% have the SAME epistemic status**: each characterises
 one configuration, neither is a benchmark. Do not present theirs as validating


### PR DESCRIPTION
I got this wrong in 1.108.295, which shipped a few hours ago.

## The error

The ROADMAP block recording the vendor's 30–50 tool threshold was guarded with **"their accuracy claim carries no number."**

True of the [tool search docs page](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool), which says only "selection accuracy stays high". **False of the [Advanced tool use](https://www.anthropic.com/engineering/advanced-tool-use) post that page links from**, which reports tool-selection accuracy:

| Model | Without tool search | With |
|---|---:|---:|
| Opus 4 | 49% | **74%** |
| Opus 4.5 | 79.5% | **88.1%** |

on "MCP evaluations".

⚠⚠ **The lesson is the shape of the error: never argue from an absence of evidence you did not go looking for.** One page said "stays high" and I read that as nothing published, without following the link sitting next to it.

## What does not change, and why the reason is better

The moratorium verdict is unchanged. But the argument I wrote was weak and is now replaced with the real one:

**It is not that they published no number. It is that their number measures a different quantity.** Theirs is the *model's* selection accuracy with a retrieval layer available versus all tools loaded — which prices the Counter's premise, and prices it favourably. Ours is `route`'s own rank-1 accuracy on agent-emitted wording, measured directly, at **52.2% against a 51.4% majority baseline**.

A vendor result showing retrieval helps in general cannot stand in for our own measurement showing that *our* router does not. Their corpus is unpublished, so it is not an instrument we can run either.

⚠ Read it as **raising the value of the Counter, not as clearing `route`**. Two separate claims; only the second is what conditions 1–3 gate.

## History

The 1.108.295 CHANGELOG entry is **struck through in place** rather than rewritten, so the record shows both what shipped and that it was corrected.

⚠ The published GitHub release notes for v1.108.295 still carry the original wording. Correcting a published artifact is a separate call — flagged, not taken.