### PR TITLE
fix: tolerate stripped blast-radius cache metadata

### DIFF
--- a/src/jcodemunch_mcp/tools/get_blast_radius.py
+++ b/src/jcodemunch_mcp/tools/get_blast_radius.py
@@ -375,7 +375,7 @@ def get_blast_radius(
     cached = result_cache_get("get_blast_radius", repo_key, specific_key)
     if cached is not None:
         result = dict(cached)
-        result["_meta"] = {**cached["_meta"],
+        result["_meta"] = {**cached.get("_meta", {}),
                            "timing_ms": round((time.perf_counter() - start) * 1000, 1),
                            "cache_hit": True}
         return _attach_scip_to_blast(result, store, owner, name)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -603,6 +603,54 @@ async def test_meta_fields_empty_list_removes_meta_envelope():
 
 
 @pytest.mark.asyncio
+async def test_meta_fields_empty_list_preserves_blast_radius_cache(
+    tmp_path, monkeypatch,
+):
+    """Stripping response metadata must not corrupt the cached tool result."""
+    from jcodemunch_mcp import config as config_module
+    from jcodemunch_mcp.tools.index_folder import index_folder
+
+    (tmp_path / "owner.py").write_text(
+        "def target_symbol():\n    return 1\n"
+    )
+    (tmp_path / "consumer.py").write_text(
+        "from owner import target_symbol\n\n"
+        "def consume():\n    return target_symbol()\n"
+    )
+    store_path = str(tmp_path / "idx")
+    repo = index_folder(
+        path=str(tmp_path), use_ai_summaries=False,
+        storage_path=store_path, incremental=False, identity_mode="local",
+    )["repo"]
+
+    orig_config = config_module._GLOBAL_CONFIG.copy()
+    config_module._GLOBAL_CONFIG.clear()
+    monkeypatch.setenv("CODE_INDEX_PATH", store_path)
+
+    try:
+        config_module._GLOBAL_CONFIG["meta_fields"] = []
+        arguments = {
+            "repo": repo,
+            "symbol": "target_symbol",
+        }
+
+        first = await call_tool("get_blast_radius", arguments)
+        assert isinstance(first, list), first
+        first_payload = json.loads(first[0].text)
+        assert "error" not in first_payload, first_payload
+        assert "_meta" not in first_payload
+
+        second = await call_tool("get_blast_radius", arguments)
+        assert isinstance(second, list), second
+        second_payload = json.loads(second[0].text)
+        assert "error" not in second_payload, second_payload
+        assert "_meta" not in second_payload
+    finally:
+        config_module._GLOBAL_CONFIG.clear()
+        config_module._GLOBAL_CONFIG.update(orig_config)
+
+
+@pytest.mark.asyncio
 async def test_sql_removed_auto_disables_search_columns(monkeypatch):
     """search_columns should be auto-disabled when SQL not in languages."""
     from jcodemunch_mcp import config as config_module

--- a/tests/test_v1_108_56.py
+++ b/tests/test_v1_108_56.py
@@ -186,6 +186,45 @@ class TestSearchSymbolsCacheMeta:
         assert "timing_ms" in second["_meta"]
 
 
+class TestBlastRadiusCacheMeta:
+    def _seed(self, tmp_path: Path):
+        (tmp_path / "owner.py").write_text(
+            "def target_symbol():\n    return 1\n"
+        )
+        (tmp_path / "consumer.py").write_text(
+            "from owner import target_symbol\n\n"
+            "def consume():\n    return target_symbol()\n"
+        )
+        store_path = str(tmp_path / "idx")
+        res = index_folder(
+            path=str(tmp_path), use_ai_summaries=False,
+            storage_path=store_path, incremental=False, identity_mode="local",
+        )
+        return res["repo"], store_path
+
+    def test_cache_hit_without_meta_synthesizes_envelope(self, tmp_path):
+        from jcodemunch_mcp.tools import get_blast_radius as blast
+
+        repo, store_path = self._seed(tmp_path)
+        kwargs = dict(
+            repo=repo,
+            symbol="target_symbol",
+            storage_path=store_path,
+        )
+        first = blast.get_blast_radius(**kwargs)
+        assert "error" not in first, first
+
+        # The dispatcher strips metadata from the returned dictionary in place.
+        # That dictionary is also the cached value, so the next call must tolerate
+        # an entry that no longer contains _meta.
+        first.pop("_meta", None)
+
+        second = blast.get_blast_radius(**kwargs)
+        assert "error" not in second, second
+        assert second["_meta"]["cache_hit"] is True
+        assert "timing_ms" in second["_meta"]
+
+
 class TestDispatcherKeyError:
     def test_internal_keyerror_is_not_reported_as_missing_argument(self, tmp_path, monkeypatch):
         from jcodemunch_mcp.server import call_tool


### PR DESCRIPTION
## Summary

- tolerate cached `get_blast_radius` results whose `_meta` envelope was stripped by the dispatcher
- add a direct cache-hit regression and a repeated dispatcher-call regression
- preserve the existing tool signature and response contract

## Root cause

`server.call_tool` can strip `_meta` from the same dictionary retained by the result cache when `meta_fields=[]`. The next identical `get_blast_radius` cache hit indexed `cached["_meta"]` and raised `KeyError: '_meta'`.

## Local validation

Exact head: `6ce53a04239f132ed2efcdfad717d5feb1ec5ec1`

- `PYTHONPATH=src py -3 -m pytest tests/test_v1_108_56.py tests/test_server.py tests/test_result_cache.py -q`: 103 passed
- `PYTHONPATH=src py -3 -m pytest tests -q`: 9,133 passed, 14 skipped, 3 failed
- the same three failures reproduce on untouched upstream `main` at `9fb1568c46e81d5c053c53c7589567674fc1290d`: one configured `JCODEMUNCH_PERF_TELEMETRY` warning assertion and two Windows symlink privilege failures
- `py -3 -m ruff check --ignore F401 src/jcodemunch_mcp/tools/get_blast_radius.py tests/test_v1_108_56.py tests/test_server.py`: passed
- `git diff --check`: passed
- cache-envelope microbenchmark, 10,000,000 loops best of 7: direct lookup 37.9 ns; tolerant lookup 45.8 ns; delta 7.9 ns per cache hit

Hosted CI was not queried. The local evidence above is the complete validation record for this submission.

## Risk

JCodeMunch post-edit analysis rated the change medium risk at 0.4203 because `get_blast_radius` is a large, highly connected MCP tool. The patch itself changes one cache-envelope lookup and preserves the signature.

