### PR TITLE
feat(scripts): surface_diff.py --descriptions diffs tool descriptions (FINDINGS W-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Added - `scripts/surface_diff.py --descriptions`: a reworded tool description is a surface change the script can now see
+
+The stage-5 surface gate compared tool NAMES between the base ref and the
+working tree and nothing else (`docs/workflows/FINDINGS.md` W-1), so the one
+class of surface change that moves a byte-pinned prefix and the
+`core_compact` ceiling -- a description edit -- passed it as `no surface
+change`. `--descriptions` diffs each tool's description from the same
+`_build_tools_list()` call that already lists the names (one subprocess per
+tree, no second worktree), prints `description changed: <name>` per tool,
+and appends a `## done: tool descriptions` block under `--summary`. It is
+LISTED, never a failure: the exit code still belongs to the name rule alone,
+so `dod_checklist.py` and `surface_guard.py`, which parse the old stdout,
+read it unchanged. `tests/test_surface_diff.py` exercises `verdict()` and
+the description diff on synthetic inputs with a red arm for each and no
+subprocess. No `src/` change.
+
 ## [1.108.317] - 2026-09-04 - CI runs the harness on every change; publishing is a dispatched workflow
 
 ### Changed - CI runs the harness on every change; publishing is a dispatched workflow

--- a/scripts/surface_diff.py
+++ b/scripts/surface_diff.py
@@ -1,12 +1,19 @@
 """Tool-surface diff between a base ref and the working tree (DESIGN stage 5, Practice 1).
 
-`python scripts/surface_diff.py --base-ref origin/main [--changed-files FILE] [--summary FILE]`
+`python scripts/surface_diff.py --base-ref origin/main [--descriptions] [--summary FILE]`
 
 Lists the `full` surface (every visible tool name) on both sides by calling
 `_build_tools_list` from each tree -- never a hand-typed count. A non-empty
 diff (added, removed or renamed tools) requires `README.md`, `CLAUDE.md` and
 `CHANGELOG.md` among the changed files, and the CHANGELOG diff must name each
 added or removed tool. Exit 1 otherwise. Nothing here restates a number.
+
+`--descriptions` also diffs each tool's DESCRIPTION between the two trees
+(docs/workflows/FINDINGS.md W-1): one `description changed: <name>` line per
+tool whose description differs, and under `--summary` a
+`## done: tool descriptions` block. A description change is a surface change
+(STANDARD criterion 4) and is always LISTED; it never moves the exit code,
+which belongs to the name rule alone.
 """
 
 from __future__ import annotations
@@ -21,14 +28,19 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 REQUIRED_DOCS = ("README.md", "CLAUDE.md", "CHANGELOG.md")
+# One subprocess per tree returns BOTH halves: the sorted names and the
+# name -> description map. Two snippets would mean two worktrees of the base
+# ref for one question.
 SNIPPET = (
     "import json,sys;"
     "from jcodemunch_mcp import server;"
-    "print(json.dumps(sorted(t.name for t in server._build_tools_list(profile_override='full', surface_override='full'))))"
+    "ts=server._build_tools_list(profile_override='full', surface_override='full');"
+    "print(json.dumps({'names': sorted(t.name for t in ts), "
+    "'descriptions': {t.name: t.description for t in ts}}))"
 )
 
 
-def _names(src_root: Path) -> list[str]:
+def _surface(src_root: Path) -> dict:
     env = dict(
         os.environ, PYTHONPATH=str(src_root / "src"), JCODEMUNCH_TOOL_SURFACE="full"
     )
@@ -45,11 +57,11 @@ def _names(src_root: Path) -> list[str]:
         raise SystemExit(
             f"could not list the tool surface in {src_root}:\n{p.stderr[-1500:]}"
         )
-    line = [ln for ln in p.stdout.splitlines() if ln.startswith("[")][-1]
+    line = [ln for ln in p.stdout.splitlines() if ln.startswith("{")][-1]
     return json.loads(line)
 
 
-def base_names(base_ref: str) -> list[str]:
+def base_surface(base_ref: str) -> dict:
     wt = Path(tempfile.mkdtemp(prefix="surface-base-"))
     subprocess.run(
         ["git", "worktree", "add", "--detach", "-q", str(wt), base_ref],
@@ -57,7 +69,7 @@ def base_names(base_ref: str) -> list[str]:
         check=True,
     )
     try:
-        return _names(wt)
+        return _surface(wt)
     finally:
         subprocess.run(["git", "worktree", "remove", "--force", str(wt)], cwd=REPO)
 
@@ -116,30 +128,84 @@ def verdict(
     return ok, lines
 
 
-def main(argv=None) -> int:
+def description_diff(base_desc: dict[str, str], head_desc: dict[str, str]) -> list[str]:
+    """One `description changed: <name>` line per tool on BOTH sides whose text differs.
+
+    A tool on one side only is a name change and belongs to `verdict()`; a
+    single space moved counts, because the published surface is byte-pinned.
+    """
+    return [
+        f"description changed: {name}"
+        for name in sorted(set(base_desc) & set(head_desc))
+        if base_desc[name] != head_desc[name]
+    ]
+
+
+def report(
+    *,
+    base: list[str],
+    head: list[str],
+    changed: list[str],
+    cl_diff: str,
+    base_desc: dict[str, str],
+    head_desc: dict[str, str],
+    descriptions: bool,
+) -> tuple[int, list[str], str]:
+    """(exit code, stdout lines, summary text). The exit code is the name verdict's alone."""
+    ok, lines = verdict(base, head, changed, cl_diff)
+    summary = (
+        f"## done: tool surface documented: {'PASS' if ok else 'FAIL'}\n\n"
+        + "\n".join(f"- {ln}" for ln in lines)
+        + "\n"
+    )
+    if descriptions:
+        desc_lines = description_diff(base_desc, head_desc)
+        lines = lines + desc_lines
+        count = len(desc_lines) if desc_lines else "none"
+        body = (
+            "\n".join(f"- {ln}" for ln in desc_lines)
+            if desc_lines
+            else "- no description changes"
+        )
+        summary += f"\n## done: tool descriptions: {count} changed\n\n{body}\n"
+    return (0 if ok else 1), lines, summary
+
+
+def build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser()
     ap.add_argument("--base-ref", default="origin/main")
     ap.add_argument("--summary")
-    a = ap.parse_args(argv)
-    base = base_names(a.base_ref)
-    head = _names(REPO)
-    ok, lines = verdict(
-        base, head, changed_files(a.base_ref), changelog_diff(a.base_ref)
+    ap.add_argument(
+        "--descriptions",
+        action="store_true",
+        help="also diff each tool's description (listed, never a failure; FINDINGS W-1)",
+    )
+    return ap
+
+
+def main(argv=None) -> int:
+    a = build_parser().parse_args(argv)
+    base = base_surface(a.base_ref)
+    head = _surface(REPO)
+    rc, lines, summary = report(
+        base=base["names"],
+        head=head["names"],
+        changed=changed_files(a.base_ref),
+        cl_diff=changelog_diff(a.base_ref),
+        base_desc=base["descriptions"],
+        head_desc=head["descriptions"],
+        descriptions=a.descriptions,
     )
     for ln in lines:
         print(ln)
     if a.summary:
         with open(a.summary, "a", encoding="utf-8") as fh:
-            fh.write(
-                f"## done: tool surface documented: {'PASS' if ok else 'FAIL'}\n\n"
-                + "\n".join(f"- {ln}" for ln in lines)
-                + "\n"
-            )
-    if not ok:
+            fh.write(summary)
+    if rc:
         print(
             "::error title=tool surface::the tool surface changed without the documentation Practice 1 requires"
         )
-    return 0 if ok else 1
+    return rc
 
 
 if __name__ == "__main__":

--- a/tests/test_surface_diff.py
+++ b/tests/test_surface_diff.py
@@ -1,0 +1,187 @@
+"""`scripts/surface_diff.py`: the name verdict and the description diff on synthetic inputs.
+
+The script's public halves are pure functions over lists and dicts:
+`verdict()` (names, changed files, CHANGELOG diff -> ok + lines) and, since
+`--descriptions` (docs/workflows/FINDINGS.md W-1), `description_diff()` and
+`report()`. Nothing here spawns a subprocess, adds a git worktree or imports
+the server; every input is built in the test.
+
+Each behaviour has a red arm: the assertion that the verdict FAILS, that a
+changed description IS listed, that a name change still exits 1 -- because a
+pass-only test of a diff tool cannot tell a working diff from an empty one
+(Standing lesson 08-27, a set cannot count).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "scripts" / "surface_diff.py"
+
+
+@pytest.fixture(scope="module")
+def sd():
+    spec = importlib.util.spec_from_file_location("surface_diff_under_test", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ALL_DOCS = ["README.md", "CLAUDE.md", "CHANGELOG.md", "src/jcodemunch_mcp/server.py"]
+
+
+def _cl_diff(*names: str) -> str:
+    body = "\n".join(f"+- new tool `{n}` does a thing" for n in names)
+    return "--- a/CHANGELOG.md\n+++ b/CHANGELOG.md\n" + body + "\n"
+
+
+# --------------------------------------------------------------------------- verdict
+
+
+def test_verdict_no_change_passes_and_says_so(sd):
+    ok, lines = sd.verdict(["a", "b"], ["b", "a"], [], "")
+    assert ok is True
+    assert any("no surface change" in ln for ln in lines)
+
+
+def test_verdict_added_tool_with_docs_and_changelog_passes(sd):
+    ok, lines = sd.verdict(["a"], ["a", "new_tool"], ALL_DOCS, _cl_diff("new_tool"))
+    assert ok is True
+    assert not any(ln.startswith("FAIL") for ln in lines)
+    assert any(ln.startswith("PASS") for ln in lines)
+
+
+def test_verdict_added_tool_without_readme_fails(sd):
+    # red arm: the documentation rule refuses
+    changed = [d for d in ALL_DOCS if d != "README.md"]
+    ok, lines = sd.verdict(["a"], ["a", "new_tool"], changed, _cl_diff("new_tool"))
+    assert ok is False
+    assert any("README.md" in ln and ln.startswith("FAIL") for ln in lines)
+
+
+def test_verdict_removed_tool_not_named_in_changelog_fails(sd):
+    # red arm: every doc changed, but the CHANGELOG's added lines never name the tool
+    ok, lines = sd.verdict(
+        ["a", "old_tool"], ["a"], ALL_DOCS, _cl_diff("something_else")
+    )
+    assert ok is False
+    assert any("`old_tool`" in ln and ln.startswith("FAIL") for ln in lines)
+
+
+def test_verdict_reads_only_added_changelog_lines(sd):
+    # a name that appears on a REMOVED line is not documentation of the addition
+    diff = (
+        "--- a/CHANGELOG.md\n+++ b/CHANGELOG.md\n-- new_tool was here\n+- unrelated\n"
+    )
+    ok, _ = sd.verdict(["a"], ["a", "new_tool"], ALL_DOCS, diff)
+    assert ok is False
+
+
+# ------------------------------------------------------------------ description diff
+
+
+def test_description_diff_identical_is_empty(sd):
+    base = {"a": "does a", "b": "does b"}
+    assert sd.description_diff(base, dict(base)) == []
+
+
+def test_description_diff_lists_each_changed_tool_sorted(sd):
+    # red arm: a reworded description IS reported, one line per tool, sorted
+    base = {"zeta": "old z", "alpha": "old a", "mid": "same"}
+    head = {"zeta": "new z", "alpha": "new a", "mid": "same"}
+    assert sd.description_diff(base, head) == [
+        "description changed: alpha",
+        "description changed: zeta",
+    ]
+
+
+def test_description_diff_ignores_one_sided_tools(sd):
+    # a tool on one side only is a NAME change; verdict() owns it
+    base = {"a": "does a", "gone": "x"}
+    head = {"a": "does a", "added": "y"}
+    assert sd.description_diff(base, head) == []
+
+
+def test_description_diff_whitespace_change_counts(sd):
+    # a byte-pinned surface (test_counter_surface_stability) moves on a space
+    assert sd.description_diff({"a": "does a"}, {"a": "does  a"}) == [
+        "description changed: a"
+    ]
+
+
+# ------------------------------------------------------------------------- report
+
+
+def test_report_description_only_change_exits_zero_and_is_listed(sd):
+    rc, lines, summary = sd.report(
+        base=["a", "b"],
+        head=["a", "b"],
+        changed=[],
+        cl_diff="",
+        base_desc={"a": "old", "b": "same"},
+        head_desc={"a": "new", "b": "same"},
+        descriptions=True,
+    )
+    assert rc == 0
+    assert "description changed: a" in lines
+    assert "description changed: b" not in lines
+    assert "## done: tool descriptions" in summary
+    assert "a" in summary.split("## done: tool descriptions", 1)[1]
+
+
+def test_report_without_flag_prints_no_description_lines(sd):
+    # the existing output is byte-for-byte unchanged when the flag is absent
+    rc, lines, summary = sd.report(
+        base=["a"],
+        head=["a"],
+        changed=[],
+        cl_diff="",
+        base_desc={"a": "old"},
+        head_desc={"a": "new"},
+        descriptions=False,
+    )
+    assert rc == 0
+    assert not any(ln.startswith("description changed") for ln in lines)
+    assert "tool descriptions" not in summary
+    assert summary.startswith("## done: tool surface documented: PASS")
+
+
+def test_report_name_change_still_fails_with_flag(sd):
+    # red arm: the flag never softens the name rule
+    rc, lines, summary = sd.report(
+        base=["a"],
+        head=["a", "new_tool"],
+        changed=[],
+        cl_diff="",
+        base_desc={"a": "x"},
+        head_desc={"a": "x", "new_tool": "y"},
+        descriptions=True,
+    )
+    assert rc == 1
+    assert any(ln.startswith("FAIL") for ln in lines)
+    assert "## done: tool surface documented: FAIL" in summary
+    assert "## done: tool descriptions: none" in summary
+
+
+def test_report_unchanged_descriptions_says_none(sd):
+    rc, lines, summary = sd.report(
+        base=["a"],
+        head=["a"],
+        changed=[],
+        cl_diff="",
+        base_desc={"a": "x"},
+        head_desc={"a": "x"},
+        descriptions=True,
+    )
+    assert rc == 0
+    assert "## done: tool descriptions: none" in summary
+
+
+def test_main_exposes_descriptions_flag(sd):
+    parser = sd.build_parser()
+    assert parser.parse_args(["--descriptions"]).descriptions is True
+    assert parser.parse_args([]).descriptions is False


### PR DESCRIPTION
## What was missing

`scripts/surface_diff.py`, the stage-5 surface gate, compared tool NAMES between the base ref and the working tree and nothing else (`docs/workflows/FINDINGS.md` W-1). A reworded description passed it as `no surface change`, and the description dump that `/feature` step 7 does by hand was the only place the difference showed.

## Why

The script called `_build_tools_list()` on both trees and kept only `t.name`. The description was already in the object it was reading; it dropped it. A description is a surface change under STANDARD.md criterion 4 (the published `counter` surface is byte-pinned; `core_compact` has a hard ceiling), so the gate could not see the class of change those two Floors exist for. Not a regression of a Standing lesson; a gap the FINDINGS row already named.

## What is now possible

`python scripts/surface_diff.py --base-ref origin/main --descriptions` prints `description changed: <name>` for every tool present on both sides whose description differs (a tool on one side only stays a NAME change and `verdict()` owns it; a single moved space counts). Under `--summary` it appends a `## done: tool descriptions: <n> changed` block, `none` when empty. The exit code is the name rule's alone: a description-only change exits 0 and is listed. Without the flag the stdout, summary and exit code are byte-for-byte what they were, so `dod_checklist.py` and `surface_guard.py`, which parse `no surface change` from its stdout, read it unchanged. One subprocess per tree returns names and descriptions together; no second worktree. `tests/test_surface_diff.py` imports the script by path, spawns no subprocess, and covers `verdict()` (pass, missing doc, CHANGELOG not naming the tool, removed-line ignored), `description_diff()` (identical, changed-and-sorted, one-sided, whitespace) and `report()` (description-only exits 0 and is listed; no flag prints nothing new; a name change still exits 1 with the flag), each with a red arm. The file is in the full tier; it is NOT added to `harness/tiers.json` `fast`, because that touches `harness/`, which this PR leaves alone.

Scope: `scripts/`, `tests/` and a CHANGELOG `[Unreleased]` entry. No `src/`, harness or CI change. The `no-changelog` label is not applied: the label names a `src/` change carrying no line, and this PR carries a line. The W-1 status row and the two hooks that would call the flag (`dod_checklist.py`, `surface_guard.py`) live on the `workflows/build` branch, which `origin/main` gitignores (`.gitignore:83 docs/*`, `:58 .claude/`), so flipping W-1 to FIXED and pointing the hooks at `--descriptions` is that branch's follow-up.

## Evidence

### Harness bench on `e928081` (base = committed artifacts)

| threshold | crit | floor | base | PR | delta | verdict |
|---|---|---|---|---|---|---|
| `index.cold_self_seconds` | 3 | <= 5.2 | 2.516 | 2.516 | +0 | PASS |
| `index.one_file_reindex_ms` | 3 | <= 284 | 140.4 | 140.4 | +0 | PASS |
| `latency.search_symbols_warm_p95_ms` | 5 | <= 23 | 10.2 | 10.2 | +0 | PASS |
| `latency.search_text_warm_p95_ms` | 5 | <= 271 | 119 | 119 | +0 | PASS |
| `latency.get_symbol_source_warm_p95_ms` | 5 | <= 27 | 13.6 | 13.6 | +0 | PASS |
| `latency.get_file_outline_warm_p95_ms` | 5 | <= 28 | 11.3 | 11.3 | +0 | PASS |

_Floors from `harness/thresholds.json`; base from `harness/results/latest.json` and `benchmarks/jcm_reference.json` on the base ref. `latency.*` verdicts are informational until F-19 closes with three CI runs._

(No `bench.md`: the bench tier is required only when `benchmarks/`, `harness/` or `server.py` change, and none does. The table is base == PR by construction.)

## done: tool surface documented: PASS

- surface: base 91 tools, head 91 tools; added none, removed none
- no surface change; documentation rule not triggered

## surface descriptions (origin/main vs HEAD, _build_tools_list dumps)

no description changes

- tools compared: 91 (head 91, base 91)

Review (second pass, on `e928081`): **APPROVE** — No Floor failed (`fast.md`, `full.md`, `bench_table.md` all PASS; `full-tier.json` stamps `e928081`); no assert removed, no skip added, no test deleted, no threshold or retirement entry touched. First pass returned REQUEST CHANGES (CHANGELOG record of the W-1 closure on `main`; two dead wrappers; unformatted test file; a copied token figure in SPEC.md), all four resolved in this commit.

## Definition of Done

| DoD | item | verdict | evidence |
|---|---|---|---|
| 1 | A test that fails on the pre-change tree and passes on the post-change tree, run on the no | met | evidence/red.txt fails=True; evidence/green.txt passes=True |
| 2 | `ruff check src/` clean and the touched test files green locally BEFORE the full suite (Pr | met | fast tier pass=True; full tier pass=True (skip ceilings are verdict rows inside) |
| 3 | A `CHANGELOG.md` `[Unreleased]` entry that states what was wrong, why, and what the fix ma | n.a. | no change under src/ |
| 4 | If a tool was added or its description changed: README tool reference, `CLAUDE.md` Key Fil | n.a. | surface unchanged (names via scripts/surface_diff.py; descriptions via evidence/surface_descriptions.md) |
| 5 | If a benchmark artifact moved: every mirror re-synced in the same PR (`results.md`, `METHO | n.a. | benchmarks/ untouched |
| 6 | If a config key, env var or CLI subcommand was added: a row in `CONFIGURATION.md` or `CLI- | n.a. | config.py and cli/ untouched |
| 7 | If a new background, persistent or network behaviour was added: a README disclosure in "Ba | n.a. | no thread/socket/http/scheduled addition in the diff |
| 8 | If a number is published in a response (a rate, a share, a confidence): a `*_basis` field  | n.a. | no new rate/share/confidence key in the diff |
| 9 | For a contributor PR: trial-merged onto `main` and run locally before the merge; `license/ | n.a. | our own PR |
| 10 | `python -m harness fast` passes; for a change under `benchmarks/`, `harness/` or `server.p | met | fast pass=True; bench pass=not required |
| 11 | If a test was retired: a `harness/retired.json` entry with the lesson and the replacement  | n.a. | no test file deleted |
| 12 | If a threshold moved: tightened with the old value appended to `history`, or loosened with | n.a. | harness/thresholds.json untouched |

Checklist: 12/12 met or n.a.; unmet: none. Generated by .claude/hooks/dod_checklist.py against origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNakUxLnKHWVsWTQNPpPQ9
