### PR TITLE
competitive: Phase 5, the instructions (CLAUDE.md section, RUNBOOK section 10, ENFORCEMENT-PLAN)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,9 @@ row, a summary and a draft are written by scripts (`findings.py`,
 review finding. ⚠⚠ **A competitor's README figure is never a measurement
 and competitor code runs only in the sandbox**; a release title is the
 only competitor text quoted, as `data`. ⚠ Losses are recorded unsoftened
-(CF-20, CF-51: our own P2 is 0 on every corpus, the adapter's fault). The
+(CF-20; CF-51: our P2 is 0 on every corpus, a harness mapping defect and
+a real loss at once, since a user reaching for the same tool gets the
+same answer). The
 three scheduled jobs are OFF until a human sets `COMPETITIVE_POST_ENABLED`
 and creates the four labels (CF-57); nothing here touches marketing.
 Open findings: `docs/competitive/FINDINGS.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,25 @@ touches POLICY 4.4's never-touch list (this file included); every drafted
 reply waits for a human `approved: true`. Open findings (the human setup
 steps IN-3/4/6/8; IN-15): `docs/inbound/FINDINGS.md`.
 
+## Competitive: the tier that measures us against the field (2026-09-06)
+
+**`docs/competitive/DESIGN.md` is the loop; `FIELD.md` is who is in the
+set and why; `VERIFICATION.md` is whether the tier can be trusted;
+`docs/cicd/RUNBOOK.md` section 10 is what a human does.** `benchmarks/
+competitive/run.py` runs the nulls, jcodemunch and eight adapters over a
+pinned corpus set in the D2 container, three runs, the corpus and task
+checks refusing before scoring; `/competitive-compare [tool] [ref]` is the
+interactive form. ⚠⚠ **Every number comes from a result file**: a FINDINGS
+row, a summary and a draft are written by scripts (`findings.py`,
+`trend.py`, `compare_ref.py --findings-row`), and a typed number is a
+review finding. ⚠⚠ **A competitor's README figure is never a measurement
+and competitor code runs only in the sandbox**; a release title is the
+only competitor text quoted, as `data`. ⚠ Losses are recorded unsoftened
+(CF-20, CF-51: our own P2 is 0 on every corpus, the adapter's fault). The
+three scheduled jobs are OFF until a human sets `COMPETITIVE_POST_ENABLED`
+and creates the four labels (CF-57); nothing here touches marketing.
+Open findings: `docs/competitive/FINDINGS.md`.
+
 ## CI/CD: the harness's judgment on every change (2026-09-04)
 
 **`docs/cicd/DESIGN.md` is the pipeline; `docs/cicd/RUNBOOK.md` is what a

--- a/docs/cicd/RUNBOOK.md
+++ b/docs/cicd/RUNBOOK.md
@@ -281,25 +281,34 @@ The first dispatched run is the measurement FINDINGS CF-53 is waiting for
 (the full set did not fit the 240-minute budget on a workstation) and the
 three-run Linux baseline CF-8 and CF-14 need before `latency_call_ms` and
 `index_cold_seconds` are read at all. Read its summary from the
-`competitive-result-<run id>` artifact or `competitive/latest.md` on
-`inbound-ledger`; the header says which runner it ran on.
+`competitive-result-<run id>` artifact or `competitive/results/latest.md`
+on `inbound-ledger`; which runner it ran on is in the result JSON's
+header (`runner.os`, `runner.python`, `runner.ci`), beside `latest.md` in
+the same directory, not in the summary.
 
 **Approve a draft.** Drafts are files under `competitive/drafts/` on
 `inbound-ledger`, one per fingerprint (`competitive-id:` line), with
 `approved: false` in the head. Edit the file on that branch and set
 `approved: true` in a commit of your own; the next post run (daily 07:00
 UTC) opens the issue, applies the label, and writes `posted: #<n>` back.
-An App-authored approval never posts. A `standard-proposal` draft's first
-line says the standard is edited only by a human; approving it opens the
-issue, nothing more.
+The post script checks only that the line reads `approved: true`; the
+guarantee that no headless job approves rests on the App never writing
+that line (`findings.py` and `ledger_merge.py` write `approved: false`
+and keep an existing head), so a human commit is the only thing that can
+flip it. A `standard-proposal` draft's body opens with the sentence that
+the standard is edited only by a human; approving it opens the issue,
+nothing more.
 
 **Read a finding.** A gap draft names the axis, corpus, category, both
 medians and spreads, the band, the competitor's pinned release and image
 digest, the run file, and one hypothesis from the fixed list. Two rows
 travel with caveats the draft must carry: a token row where the tool
 returns hits and the body is read elsewhere (CF-24), and a token row where
-the harness chose the pattern (CF-29). A `tool_not_called` hypothesis is
-the adapter's fault before it is the tool's; ours was first (CF-51).
+the harness chose the pattern (CF-29). A `tool_not_called` hypothesis
+names the adapter before the tool; check the adapter's call plan first.
+Ours was the first case (CF-51), and that one is both: a harness mapping
+defect and a real loss, because a user who reaches for the same tool for
+that question gets the same answer.
 
 **Weekly feed.** Sundays 04:00 UTC (`competitive-feed.yml`) reads each set
 member's latest release through registries on a read-only token, drafts a
@@ -307,7 +316,10 @@ member's latest release through registries on a read-only token, drafts a
 one re-run when a release names a measured axis. It reads the ledger first
 so one release is re-run once.
 
-**Something looks wrong.** Flip `INBOUND_ENABLED` off (all three jobs stop
-within one step); read the run's audit record (`competitive-audit-<run
-id>` artifact). A container that outlived its run is named
+**Something looks wrong.** Flip `INBOUND_ENABLED` off: each job re-reads
+it before its next write, so a running job finishes its current step
+and writes nothing after (the run job's container step is up to 240
+minutes long and holds no write; the flip stops the ledger push after
+it). Read the run's audit record: the `competitive-audit-<run id>`
+artifact, or `competitive-audit-<run id>-gate` when the gate refused. A container that outlived its run is named
 `jcm-compete-<hex>`; `docker ps` shows it and `docker kill` ends it.

--- a/docs/cicd/RUNBOOK.md
+++ b/docs/cicd/RUNBOOK.md
@@ -241,3 +241,73 @@ Write, Maintain and Admin repository roles, mode `always`). ⚠ Leaving
 `main` inside it makes every human merge need `--admin` and stops
 auto-merge (FINDINGS IN-19); `main` is protected by branch protection
 already. `docs/inbound/VERIFICATION.md` row 1.10 tracks it.
+
+## 10. The competitive loop (the tier that measures us against the field)
+
+`docs/competitive/DESIGN.md` is the loop; `POLICY.md` section 4.4 and
+section 7 (the inbound contract) govern its three jobs. This section is the
+human's part. Nothing in it can run before the steps below.
+
+**Turn it on.** The loop inherits `INBOUND_ENABLED` (section 9) for all
+three jobs, and the post job also needs a second variable. Only the exact
+string `true` is on; absent is off.
+
+```
+gh variable set COMPETITIVE_POST_ENABLED --body true
+gh variable set COMPETITIVE_POST_ENABLED --body false
+```
+
+**Create the labels (once).** The post job applies exactly one of these
+plus `needs-human`; they do not exist and only a human creates them
+(POLICY 4.4 lists labels as never-touch; the post job is the one exception,
+for these four).
+
+```
+gh label create competitive-gap --description "a competitor ahead on a comparable axis, meaningful, from a recorded run"
+gh label create competitive-watch --description "we lead and the gap narrowed on two consecutive runs"
+gh label create competitive-idea --description "a set member's release names a capability (title quoted as data)"
+gh label create standard-proposal --description "a competitor past a STANDARD Target on two runs; a human edits the standard or declines"
+```
+
+**Run it.** Monthly on the first Sunday 03:00 UTC (`competitive-run.yml`),
+or by hand with a reason and an optional tool:
+
+```
+gh workflow run competitive-run.yml -f reason="first run on a runner (CF-53)"
+gh workflow run competitive-run.yml -f reason="serena release" -f tool=serena
+```
+
+The first dispatched run is the measurement FINDINGS CF-53 is waiting for
+(the full set did not fit the 240-minute budget on a workstation) and the
+three-run Linux baseline CF-8 and CF-14 need before `latency_call_ms` and
+`index_cold_seconds` are read at all. Read its summary from the
+`competitive-result-<run id>` artifact or `competitive/latest.md` on
+`inbound-ledger`; the header says which runner it ran on.
+
+**Approve a draft.** Drafts are files under `competitive/drafts/` on
+`inbound-ledger`, one per fingerprint (`competitive-id:` line), with
+`approved: false` in the head. Edit the file on that branch and set
+`approved: true` in a commit of your own; the next post run (daily 07:00
+UTC) opens the issue, applies the label, and writes `posted: #<n>` back.
+An App-authored approval never posts. A `standard-proposal` draft's first
+line says the standard is edited only by a human; approving it opens the
+issue, nothing more.
+
+**Read a finding.** A gap draft names the axis, corpus, category, both
+medians and spreads, the band, the competitor's pinned release and image
+digest, the run file, and one hypothesis from the fixed list. Two rows
+travel with caveats the draft must carry: a token row where the tool
+returns hits and the body is read elsewhere (CF-24), and a token row where
+the harness chose the pattern (CF-29). A `tool_not_called` hypothesis is
+the adapter's fault before it is the tool's; ours was first (CF-51).
+
+**Weekly feed.** Sundays 04:00 UTC (`competitive-feed.yml`) reads each set
+member's latest release through registries on a read-only token, drafts a
+`competitive-idea` when a title carries a capability word, and dispatches
+one re-run when a release names a measured axis. It reads the ledger first
+so one release is re-run once.
+
+**Something looks wrong.** Flip `INBOUND_ENABLED` off (all three jobs stop
+within one step); read the run's audit record (`competitive-audit-<run
+id>` artifact). A container that outlived its run is named
+`jcm-compete-<hex>`; `docker ps` shows it and `docker kill` ends it.

--- a/docs/standard/ENFORCEMENT-PLAN.md
+++ b/docs/standard/ENFORCEMENT-PLAN.md
@@ -1,5 +1,7 @@
 # ENFORCEMENT PLAN — moving each criterion to MEASURED and gated
 
+**Status 2026-09-06 (competitive layer, `docs/competitive/`):** the tier that measures us against the field, the head-to-head benchmarking the out-of-scope list below parked on a VM. `benchmarks/competitive/run.py` runs the nulls, jcodemunch and eight adapters over a pinned corpus set in the D2 container, three runs, with the corpus and task checks refusing before scoring; `findings.py` drafts issues the human approves on the ledger; three scheduled jobs in the inbound shape, OFF until RUNBOOK section 10's variables and labels exist. No item below moves by it: the tier adds no Floor, edits no threshold, and its `standard-proposal` draft can only ask a human to change a Target (DESIGN section 8). What it adds is the instrument criteria 1(b), 2, 3(c), 4 and 5 lacked for a comparison against a product: one recorded run, `results/2026-09-06-0e3a1706.json`, with our own losses in it (FINDINGS CF-20, CF-51). Verification: `docs/competitive/VERIFICATION.md`; open: `docs/competitive/FINDINGS.md`.
+
 **Status 2026-09-04 (workflows layer, `docs/workflows/`):** the process side is a set of Claude Code commands, hooks and a reviewer subagent that invoke items 1-4, 7, 8, 10, 17 at the right moments (`/feature`, `/fix-issue`, `/release`, `/benchmark-compare`, `/review`, `/triage-issue`; `docs/workflows/DESIGN.md`). No item below changes state by it; item 13 (coverage as an artifact) and W-1/W-2/W-3 in `docs/workflows/FINDINGS.md` are what the workflows still lack from the harness.
 
 **Status 2026-09-04 (inbound layer, `docs/inbound/`):** nine headless workflow files put items 1-4, 7 and 17 in front of inbound issues and PRs as well as our own changes: triage labels and drafts, dependency PRs are graded by the gate's Floor lines and a full-corpus bench, an agent-authored fix is opened as a draft only when a no-model gate accepts its commits, and marked ready only when the PR gate, the self-check (the failing test proven red on `main`) and the reviewer's APPROVE are all green. No item below moves by it; the layer adds no gate and loosens none (POLICY 4.4 makes `harness/thresholds.json`, `retired.json`, the standard and `ARCHAEOLOGY.md` untouchable to every headless job). Open: `docs/inbound/FINDINGS.md`.
@@ -64,7 +66,8 @@ that makes two ranked axes measurable at all.
 
 ## Explicitly out of scope
 
-- Competitor head-to-head benchmarking: gated on a VM by `ROADMAP.md:308` and
-  not reopened here.
+- Competitor head-to-head benchmarking: gated on a VM by `ROADMAP.md:308` when
+  this was written; built 2026-09-05/06 as the competitive layer (status
+  paragraph above), in a container rather than a VM (DESIGN D2).
 - SWE-bench: parked by decision (`benchmarks/swebench/PROTOCOL.md`), 120 GB.
 - Raising `CLAUDE.md`'s 140,000 budget: the gate says its buffer is the last one.


### PR DESCRIPTION
Phase 5 of the competitive layer: the instructions. Stacked on `competitive/phase4-verify` (Phase 4); merge in order, or retarget after. Docs only.

## What changed

- `CLAUDE.md`: a "Competitive" section beside the Inbound and CI/CD ones, in their shape: where the loop, the set, the verification and the human's part live; that every number is script-written from a result file and a typed number is a review finding; that a competitor's README figure is never a measurement and competitor code runs only in the sandbox; that losses are recorded unsoftened, naming our own open P2 defect; that the three jobs are OFF until a human acts; that nothing touches marketing. Measured against the file's budget by the harness's own check (the fast tier's `claude_md.max_chars` row).
- `docs/cicd/RUNBOOK.md` section 10, the human's part of the loop: the second variable and its exact-string rule; the four labels to create, with descriptions; running the monthly job by hand with a reason and an optional tool, and why the first dispatched run is the measurement two findings wait for; approving a draft on the ledger branch; reading a gap draft, including the two caveats that must travel with a token row and that a `tool_not_called` hypothesis is the adapter's fault first; the weekly feed; what to do when something looks wrong.
- `docs/standard/ENFORCEMENT-PLAN.md`: a dated status paragraph for the layer in the shape of the workflows and inbound ones (no item moves by it; no Floor added, no threshold edited; a `standard-proposal` can only ask a human to change a Target), and the out-of-scope line that parked head-to-head benchmarking on a VM now says it was built, in a container.
- `docs/inbound/POLICY.md` needed no edit: 4.4's label exception for the post job was amended in #618 and the prompts re-rendered there.

## Result

Docs only. The instructions point at things that exist: the variable name the post job reads, the four label names `post.py` accepts, the workflow file names and their inputs, the ledger paths, the artifact names, the container name prefix.

## Review

Independent reviewer subagent, two rounds. Round 1 REQUEST CHANGES, five items, all taken at fad2fcdf: the RUNBOOK named a ledger path the workflow does not write and sent the reader to the summary for the runner name, which only the result JSON carries; the fast-tier stamp predated the tree (the commit hook skips the tier on docs-only commits, so the tier was run on HEAD by hand, and the gap is recorded as a workflows finding to follow); the kill-switch sentence overstated what a flip stops mid-run; and the wording on our own open P2 defect attributed it to the adapter alone where FINDINGS records a real loss as well. Three notes fixed alongside (the approval guarantee's mechanism named, the gate-refused audit artifact's suffix, a draft's first body line). Round 2 APPROVE: "every name in the instructions resolves to the spelling in the workflows, post.py, findings.py, feed.py, ledger_merge.py, run.py and sandbox.py". Verdicts verbatim in `.claude/state/evidence/review.md`.

## Evidence

- fast tier run on HEAD by hand (`uv run python -m harness fast --summary`, since the commit hook skips the tier for docs-only commits): PASS, `claude_md.max_chars` PASS in it (`.claude/state/evidence/fast.md`); full tier PASS on the code roots this tree shares with the stack (docs-only change on top); checklist 12/12 met or n.a. against `competitive/phase4-verify`; green.txt names the five guard files over CLAUDE.md and the inbound prompts (43 passed); red.txt n.a. (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNakUxLnKHWVsWTQNPpPQ9
