### PR TITLE
docs: CLAUDE.md records CF-63 shipped (#658)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,10 @@ only competitor text quoted, as `data`. ⚠ Losses are recorded unsoftened
 adapter asked the import-graph tool for a usage question, a harness
 mapping defect and a real loss at once, since a user reaching for the
 same tool gets the same answer; the adapter asks `check_references`
-since 2026-09-06 and the next recorded run carries it, the product-doc
-half is CF-63). The
+since 2026-09-06 and the next recorded run carries it; the product half,
+CF-63, shipped 2026-09-10 (#658): seven steering surfaces route the usage
+question to `check_references`, and `tests/test_usage_question_routes_to_usage_tool.py`
+scans `src/` so an eighth inherits the rule). The
 three scheduled jobs are OFF until a human sets `COMPETITIVE_POST_ENABLED`
 and creates the four labels (CF-57); nothing here touches marketing.
 Open findings: `docs/competitive/FINDINGS.md`.


### PR DESCRIPTION
## What changed

Docs only. The CLAUDE.md competitive block said the product half of CF-51 was still open as CF-63; #658 shipped it on 2026-09-10, and the sentence now says so and names the test that keeps an eighth steering surface honest. No code, no threshold, no artifact.

## Definition of Done

| DoD | item | verdict | evidence |
|---|---|---|---|
| 1 | A test that fails on the pre-change tree and passes on the post-change tree, run on the no | met | evidence/red.txt fails=True; evidence/green.txt passes=True |
| 2 | `ruff check src/` clean and the touched test files green locally BEFORE the full suite (Pr | met | fast tier pass=True; full tier pass=True (skip ceilings are verdict rows inside) |
| 3 | For a change under `src/`: a `CHANGELOG.md` entry under `[Unreleased]` (or in a new versio | n.a. | no change under src/ |
| 4 | If a tool was added or its description changed: README tool reference, `CLAUDE.md` Key Fil | n.a. | surface unchanged (names and descriptions via scripts/surface_diff.py) |
| 5 | If a benchmark artifact moved: every mirror re-synced in the same PR (`results.md`, `METHO | n.a. | benchmarks/ untouched |
| 6 | If a config key, env var or CLI subcommand was added: a row in `CONFIGURATION.md` or `CLI- | n.a. | config.py and cli/ untouched |
| 7 | If a new background, persistent or network behaviour was added: a README disclosure in "Ba | n.a. | no thread/socket/http/scheduled addition in the diff |
| 8 | If a number is published in a response (a rate, a share, a confidence): a `*_basis` field  | n.a. | no new rate/share/confidence key in the diff |
| 9 | For a contributor PR: trial-merged onto `main` and run locally before the merge; `license/ | n.a. | our own PR |
| 10 | `python -m harness fast` passes; for a change under `benchmarks/`, `harness/` or `server.p | met | fast pass=True; bench pass=not required |
| 11 | If a test was retired: a `harness/retired.json` entry with the lesson and the replacement  | n.a. | no test file deleted |
| 12 | If a threshold moved: tightened with the old value appended to `history`, or loosened with | n.a. | harness/thresholds.json untouched |

Checklist: 12/12 met or n.a.; unmet: none. Generated by .claude/hooks/dod_checklist.py against origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9edtvog56izAyb3y4ua7k
